### PR TITLE
Add travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+  - 1.2
+  - tip
+
+script: make test


### PR DESCRIPTION
Add .travis.yml to support travis-ci build.

Currently tests under tavis-ci are failing. Need more works.
