### PR TITLE
Add Copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ The agent collects information about a host which the agent run.
 make test
 ```
 
+License
+----------
+
+Copyright 2014 Hatena Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.


### PR DESCRIPTION
Need to write copyright to apply the Apache v2 license to mackerel-agent.
