### PR TITLE
Prevent exiting without pidfile cleaning

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -90,8 +90,7 @@ func prepareHost(root string, api *mackerel.API, roleFullnames []string) (*macke
 
 	err = SaveHostId(root, result.Id)
 	if err != nil {
-		logger.Criticalf("Failed to save host ID: %s", err.Error())
-		os.Exit(1)
+		return nil, fmt.Errorf("Failed to save host ID: %s", err.Error())
 	}
 
 	return result, nil
@@ -206,20 +205,18 @@ func UpdateHostSpecs(conf config.Config, api *mackerel.API, host *mackerel.Host)
 
 // Prepare sets up API and registers the host data to the Mackerel server.
 // Use returned values to call Run().
-func Prepare(conf config.Config) (*mackerel.API, *mackerel.Host) {
+func Prepare(conf config.Config) (*mackerel.API, *mackerel.Host, error) {
 	api, err := mackerel.NewApi(conf.Apibase, conf.Apikey, conf.Verbose)
 	if err != nil {
-		logger.Criticalf("Failed to prepare an api: %s", err.Error())
-		os.Exit(1)
+		return nil, nil, fmt.Errorf("Failed to prepare an api: %s", err.Error())
 	}
 
 	host, err := prepareHost(conf.Root, api, conf.Roles)
 	if err != nil {
-		logger.Criticalf("Failed to run this agent: %s", err.Error())
-		os.Exit(1)
+		return nil, nil, fmt.Errorf("Failed to preapre host: %s", err.Error())
 	}
 
-	return api, host
+	return api, host, nil
 }
 
 // Run starts the main metric collecting logic and this function will never return.

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -96,7 +96,7 @@ func TestPrepare(t *testing.T) {
 		}
 	}
 
-	api, host := Prepare(conf)
+	api, host, _ := Prepare(conf)
 
 	if api.BaseUrl.String() != ts.URL {
 		t.Errorf("Apibase mismatch: %s != %s", api.BaseUrl, ts.URL)


### PR DESCRIPTION
Mackerel-agent sometime exit without cleaning pidfile. This pull-request fix the problem by replacing the os.Exit statement to the exit function with pidfile cleaning.
