### PR TITLE
Update hostname on updating host specs

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -110,3 +110,19 @@ func TestPrepare(t *testing.T) {
 		t.Error("Host name mismatch", host)
 	}
 }
+
+func TestCollectHostSpecs(t *testing.T) {
+	hostname, meta, _ /*interfaces*/, err := collectHostSpecs()
+
+	if err != nil {
+		t.Errorf("collectHostSpecs should not fail: %s", err)
+	}
+
+	if hostname == "" {
+		t.Error("hostname should not be empty")
+	}
+
+	if _, ok := meta["cpu"]; !ok {
+		t.Error("meta.cpu should exist")
+	}
+}


### PR DESCRIPTION
Curretly mackerel-agent uses the host's name that is obtained at its startup time,
so it cannot follow the hostname changes.

This PR adds hostname to `collectHostSpecs`'s return values so that the agent can
update the hostname every time it updates the host specs.
