### PR TITLE
Filter invalid float values

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -271,6 +272,11 @@ func enqueueLoop(c *context, postQueue chan *postValue, quit chan struct{}) {
 			created := float64(result.Created.Unix())
 			creatingValues := [](*mackerel.CreatingMetricsValue){}
 			for name, value := range (map[string]float64)(result.Values) {
+				if math.IsNaN(value) || math.IsInf(value, 0) {
+					logger.Warningf("Invalid value: hostID = %s, name = %s, value = %f\n is not sent.", c.host.ID, name, value)
+					continue
+				}
+
 				creatingValues = append(
 					creatingValues,
 					&mackerel.CreatingMetricsValue{


### PR DESCRIPTION
See https://github.com/mackerelio/go-mackerel-plugin/pull/3

```
2015/01/05 16:33:16 ERROR command Failed to post metrics value (will retry): json: unsupported value: +Inf
```
```
2015/01/06 13:35:31 ERROR command Failed to post metrics value (will retry): json: unsupported value: NaN
```

I thing go-mackerel-plugin's condition is also needed to detect invalid plugin.
