### PR TITLE
Stop sending device-mapper metrics

### DIFF
--- a/metrics/linux/filesystem.go
+++ b/metrics/linux/filesystem.go
@@ -30,6 +30,9 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
+		if regexp.MustCompile(`^/dev/mapper/`).FindStringSubmatch(name) != nil {
+			continue;
+		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {
 			device := regexp.MustCompile(`[^A-Za-z0-9_-]`).ReplaceAllString(matches[1], "_")
 			for key, value := range values {


### PR DESCRIPTION
- Filesystem usage metrics on device-mapper virtual devices are not useful.
- Docker creates many device-mapper device nodes.