### PR TITLE
Run once and output results to stdout

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -90,20 +90,9 @@ func (agent *Agent) CollectGraphDefsOfPlugins() []mackerel.CreateGraphDefsPayloa
 	return payloads
 }
 
-
 // InitPluginGenerators XXX
 func (agent *Agent) InitPluginGenerators(api *mackerel.API) {
-	payloads := []mackerel.CreateGraphDefsPayload{}
-
-	for _, g := range agent.PluginGenerators {
-		p, err := g.PrepareGraphDefs()
-		if err != nil {
-			logger.Debugf("Failed to fetch meta information from plugin %s (non critical); seems that this plugin does not have meta information: %s", g, err)
-		}
-		if p != nil {
-			payloads = append(payloads, p...)
-		}
-	}
+	payloads := agent.CollectGraphDefsOfPlugins()
 
 	if len(payloads) > 0 {
 		err := api.CreateGraphDefs(payloads)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -20,6 +20,7 @@ type MetricsResult struct {
 	Values  metrics.Values
 }
 
+// CollectMetrics collects metrics with generators.
 func (agent *Agent) CollectMetrics(collectedTime time.Time) *MetricsResult {
 	generators := agent.MetricsGenerators
 	for _, g := range agent.PluginGenerators {
@@ -72,7 +73,7 @@ func (agent *Agent) Watch() chan *MetricsResult {
 	return metricsResult
 }
 
-// InitPluginGenerators XXX
+// CollectGraphDefsOfPlugins collects GraphDefs of Plugins
 func (agent *Agent) CollectGraphDefsOfPlugins() []mackerel.CreateGraphDefsPayload {
 	payloads := []mackerel.CreateGraphDefsPayload{}
 

--- a/command/command.go
+++ b/command/command.go
@@ -53,6 +53,17 @@ func saveHostID(root string, id string) error {
 	return nil
 }
 
+// buildHostSpec build data structure for Host specs
+func buildHostSpec(name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string) map[string]interface{} {
+
+	return map[string]interface{}{
+		"name":          name,
+		"meta":          meta,
+		"interfaces":    interfaces,
+		"roleFullnames": roleFullnames,
+	}
+}
+
 // prepareHost collects specs of the host and sends them to Mackerel server.
 // A unique host-id is returned by the server if one is not specified.
 func prepareHost(root string, api *mackerel.API, roleFullnames []string) (*mackerel.Host, error) {
@@ -82,7 +93,7 @@ func prepareHost(root string, api *mackerel.API, roleFullnames []string) (*macke
 		if err != nil {
 			return nil, fmt.Errorf("Failed to find this host on mackerel (You may want to delete file \"%s\" to register this host to an another organization): %s", idFilePath(root), err.Error())
 		}
-		err := api.UpdateHost(hostID, hostname, meta, interfaces, roleFullnames)
+		err := api.UpdateHost(hostID, buildHostSpec(hostname, meta, interfaces, roleFullnames))
 		if err != nil {
 			return nil, fmt.Errorf("Failed to update this host: %s", err.Error())
 		}
@@ -322,7 +333,7 @@ func UpdateHostSpecs(conf *config.Config, api *mackerel.API, host *mackerel.Host
 		return
 	}
 
-	err = api.UpdateHost(host.ID, hostname, meta, interfaces, conf.Roles)
+	err = api.UpdateHost(host.ID, buildHostSpec(hostname, meta, interfaces, conf.Roles))
 	if err != nil {
 		logger.Errorf("Error while updating host specs: %s", err)
 	} else {
@@ -361,17 +372,12 @@ func RunOnce(conf *config.Config) {
 	logger.Infof("Collecting metrics may take one minutes.")
 	metrics := ag.CollectMetrics(time.Now())
 	payload := map[string]interface{}{
-		"host": map[string]interface{}{
-			"name":          hostname,
-			"meta":          meta,
-			"interfaces":    interfaces,
-			"roleFullnames": conf.Roles,
-		},
+		"host":    buildHostSpec(hostname, meta, interfaces, conf.Roles),
 		"metrics": metrics,
 	}
 	json, err := json.Marshal(payload)
 	if err != nil {
-		logger.Warningf("Error while marshaling graphdefs: graphdefs = %s.", graphdefs)
+		logger.Warningf("Error while marshaling graphdefs: err = %s, graphdefs = %s.", err.Error(), graphdefs)
 	} else {
 		fmt.Println(string(json))
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -346,6 +346,7 @@ func Prepare(conf *config.Config) (*mackerel.API, *mackerel.Host, error) {
 	return api, host, nil
 }
 
+// RunOnce collects specs and metrics, then output them to stdout.
 func RunOnce(conf *config.Config) {
 	hostname, meta, interfaces, err := collectHostSpecs()
 	if err != nil {

--- a/command/command.go
+++ b/command/command.go
@@ -353,17 +353,28 @@ func RunOnce(conf *config.Config) {
 		logger.Errorf("While collecting host specs: %s", err)
 		return
 	}
-	logger.Infof("%s, %s, %s", hostname, meta, interfaces)
-	logger.Infof("agent")
 	ag := &agent.Agent{
 		MetricsGenerators: metricsGenerators(conf),
 		PluginGenerators:  pluginGenerators(conf),
 	}
 	graphdefs := ag.CollectGraphDefsOfPlugins()
-	logger.Infof("%s", graphdefs)
-	logger.Infof("Collecting metrics may takes one minutes.")
+	logger.Infof("Collecting metrics may take one minutes.")
 	metrics := ag.CollectMetrics(time.Now())
-	logger.Infof("%s", metrics)
+	payload := map[string]interface{}{
+		"host": map[string]interface{}{
+			"name":          hostname,
+			"meta":          meta,
+			"interfaces":    interfaces,
+			"roleFullnames": conf.Roles,
+		},
+		"metrics": metrics,
+	}
+	json, err := json.Marshal(payload)
+	if err != nil {
+		logger.Warningf("Error while marshaling graphdefs: graphdefs = %s.", graphdefs)
+	} else {
+		fmt.Println(string(json))
+	}
 }
 
 // Run starts the main metric collecting logic and this function will never return.

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -17,6 +17,41 @@ import (
 	"github.com/mackerelio/mackerel-agent/metrics"
 )
 
+func TestBuildHostSpec(t *testing.T) {
+	var interfaces []map[string]interface{}
+	interfaces = append(interfaces, map[string]interface{}{
+		"name":       "eth0",
+		"ipAddress":  "10.0.4.7",
+		"macAddress": "01:23:45:67:89:ab",
+		"encap":      "Ethernet",
+	})
+	meta := map[string]interface{}{
+		"memo": "hello",
+	}
+	roleFullnames := []string{"My-Service:app-default"}
+
+	hostSpec := buildHostSpec("Host123", meta, interfaces, roleFullnames)
+
+	if hostSpec["name"] != "Host123" {
+		t.Error("name should 'Host123' but:", hostSpec["name"])
+	}
+
+	_, ok := hostSpec["interfaces"].([]map[string]interface{})
+	if !ok {
+		t.Error("the type of interfaces should be '[]map[string]interface{}'")
+	}
+
+	_, ok = hostSpec["meta"].(map[string]interface{})
+	if !ok {
+		t.Error("the type of meta should be 'map[string]interface{}'")
+	}
+
+	_, ok = hostSpec["roleFullnames"].([]string)
+	if !ok {
+		t.Error("the type of meta should be '[]string'")
+	}
+}
+
 func TestDelayByHost(t *testing.T) {
 	delay1 := time.Duration(delayByHost(&mackerel.Host{
 		ID:     "246PUVUngPo",

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,6 @@ type Config struct {
 	Conffile        string
 	Roles           []string
 	Verbose         bool
-  OutputOnce      bool
 	Connection      ConnectionConfig
 	Plugin          map[string]PluginConfigs
 	DeprecatedSensu map[string]PluginConfigs `toml:"sensu"` // DEPRECATED this is for backward compatibility

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Conffile        string
 	Roles           []string
 	Verbose         bool
+  OutputOnce      bool
 	Connection      ConnectionConfig
 	Plugin          map[string]PluginConfigs
 	DeprecatedSensu map[string]PluginConfigs `toml:"sensu"` // DEPRECATED this is for backward compatibility

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -166,15 +166,10 @@ func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces 
 }
 
 // UpdateHost updates the host information on Mackerel.
-func (api *API) UpdateHost(hostID string, name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string) error {
+func (api *API) UpdateHost(hostID string, hostSpec map[string]interface{}) error {
 	url := api.urlFor("/api/v0/hosts/" + hostID)
 
-	requestJSON, err := json.Marshal(map[string]interface{}{
-		"name":          name,
-		"meta":          meta,
-		"interfaces":    interfaces,
-		"roleFullnames": roleFullnames,
-	})
+	requestJSON, err := json.Marshal(hostSpec)
 	if err != nil {
 		return err
 	}

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -284,9 +284,16 @@ func TestUpdateHost(t *testing.T) {
 		"encap":      "Ethernet",
 	})
 
-	err := api.UpdateHost("ABCD123", "dummy", map[string]interface{}{
-		"memo": "hello",
-	}, interfaces, []string{"My-Service:app-default"})
+	hostSpec := map[string]interface{}{
+		"name": "dummy",
+		"meta": map[string]interface{}{
+			"memo": "hello",
+		},
+		"interfaces":    interfaces,
+		"roleFullnames": []string{"My-Service:app-default"},
+	}
+
+	err := api.UpdateHost("ABCD123", hostSpec)
 
 	if err != nil {
 		t.Error("should not raise error: ", err)

--- a/main.go
+++ b/main.go
@@ -59,6 +59,11 @@ func main() {
 
 	logger.Infof("Starting mackerel-agent version:%s, rev:%s", version.VERSION, version.GITCOMMIT)
 
+	if conf.OutputOnce {
+		command.RunOnce(conf)
+		exit(0, conf)
+	}
+
 	if conf.Apikey == "" {
 		logger.Criticalf("Apikey must be specified in the command-line flag or in the config file")
 		exit(1, conf)
@@ -82,6 +87,7 @@ func resolveConfig() (*config.Config, bool) {
 		pidfile      = flag.String("pidfile", config.DefaultConfig.Pidfile, "File containing PID")
 		root         = flag.String("root", config.DefaultConfig.Root, "Directory containing variable state information")
 		apikey       = flag.String("apikey", "", "API key from mackerel.io web site")
+		outputOnce   = flag.Bool("once", false, "Show spec and metrics to stdout once")
 		printVersion = flag.Bool("version", false, "Prints version and exit")
 	)
 
@@ -106,6 +112,7 @@ func resolveConfig() (*config.Config, bool) {
 		exitWithoutPidfileCleaning(1)
 	}
 
+
 	// overwrite config from file by config from args
 	flag.Visit(func(f *flag.Flag) {
 		switch f.Name {
@@ -121,6 +128,8 @@ func resolveConfig() (*config.Config, bool) {
 			conf.Verbose = verbose
 		case "role":
 			conf.Roles = roleFullnames
+		case "once":
+			conf.OutputOnce = *outputOnce
 		}
 	})
 

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	if conf.OutputOnce {
 		command.RunOnce(conf)
-		exit(0, conf)
+		exitWithoutPidfileCleaning(0)
 	}
 
 	if conf.Apikey == "" {
@@ -111,7 +111,6 @@ func resolveConfig() (*config.Config, bool) {
 		logger.Criticalf("Failed to load the config file: %s", confErr)
 		exitWithoutPidfileCleaning(1)
 	}
-
 
 	// overwrite config from file by config from args
 	flag.Visit(func(f *flag.Flag) {

--- a/main.go
+++ b/main.go
@@ -42,8 +42,8 @@ func (r *roleFullnamesFlag) Set(input string) error {
 }
 
 type otherOptions struct {
-	PrintVersion bool
-	RunOnce      bool
+	printVersion bool
+	runOnce      bool
 }
 
 var logger = logging.GetLogger("main")
@@ -51,7 +51,7 @@ var logger = logging.GetLogger("main")
 func main() {
 	conf, otherOptions := resolveConfig()
 
-	if otherOptions.PrintVersion {
+	if otherOptions.printVersion {
 		fmt.Printf("mackerel-agent version %s (rev %s)\n", version.VERSION, version.GITCOMMIT)
 		exitWithoutPidfileCleaning(0)
 	}
@@ -64,7 +64,7 @@ func main() {
 
 	logger.Infof("Starting mackerel-agent version:%s, rev:%s", version.VERSION, version.GITCOMMIT)
 
-	if otherOptions.RunOnce {
+	if otherOptions.runOnce {
 		command.RunOnce(conf)
 		exitWithoutPidfileCleaning(0)
 	}
@@ -109,12 +109,12 @@ func resolveConfig() (*config.Config, *otherOptions) {
 	flag.Parse()
 
 	if *printVersion {
-		otherOptions.PrintVersion = true
+		otherOptions.printVersion = true
 		return conf, otherOptions
 	}
 
 	if *runOnce {
-		otherOptions.RunOnce = true
+		otherOptions.runOnce = true
 		return conf, otherOptions
 	}
 

--- a/main.go
+++ b/main.go
@@ -110,12 +110,12 @@ func resolveConfig() (*config.Config, *otherOptions) {
 
 	if *printVersion {
 		otherOptions.PrintVersion = true
-		return nil, otherOptions
+		return conf, otherOptions
 	}
 
 	if *runOnce {
 		otherOptions.RunOnce = true
-		return nil, otherOptions
+		return conf, otherOptions
 	}
 
 	conf, confErr := config.LoadConfig(*conffile)

--- a/main_test.go
+++ b/main_test.go
@@ -58,7 +58,7 @@ func TestParseFlagsPrintVersion(t *testing.T) {
 		t.Error("with -version args, variables of config should have default values")
 	}
 
-	if otherOptions.PrintVersion == false {
+	if otherOptions.printVersion == false {
 		t.Error("with -version args, printVersion should be true")
 	}
 }
@@ -73,7 +73,7 @@ func TestParseFlagsRunOnce(t *testing.T) {
 		t.Error("with -version args, variables of config should have default values")
 	}
 
-	if otherOptions.RunOnce == false {
+	if otherOptions.runOnce == false {
 		t.Error("with -once args, RunOnce should be true")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -54,8 +54,8 @@ func TestParseFlagsPrintVersion(t *testing.T) {
 
 	config, otherOptions := resolveConfig()
 
-	if config != nil {
-		t.Error("with -version args, config should be null")
+	if config.Verbose != false {
+		t.Error("with -version args, variables of config should have default values")
 	}
 
 	if otherOptions.PrintVersion == false {
@@ -69,8 +69,8 @@ func TestParseFlagsRunOnce(t *testing.T) {
 
 	config, otherOptions := resolveConfig()
 
-	if config != nil {
-		t.Error("with -once args, config should be null")
+	if config.Verbose != false {
+		t.Error("with -version args, variables of config should have default values")
 	}
 
 	if otherOptions.RunOnce == false {

--- a/main_test.go
+++ b/main_test.go
@@ -52,13 +52,28 @@ func TestParseFlagsPrintVersion(t *testing.T) {
 	os.Args = []string{"mackerel-agent", "-version"}
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.PanicOnError)
 
-	config, printVersion := resolveConfig()
+	config, otherOptions := resolveConfig()
 
 	if config != nil {
 		t.Error("with -version args, config should be null")
 	}
 
-	if printVersion == false {
+	if otherOptions.PrintVersion == false {
 		t.Error("with -version args, printVersion should be true")
+	}
+}
+
+func TestParseFlagsRunOnce(t *testing.T) {
+	os.Args = []string{"mackerel-agent", "-once"}
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.PanicOnError)
+
+	config, otherOptions := resolveConfig()
+
+	if config != nil {
+		t.Error("with -once args, config should be null")
+	}
+
+	if otherOptions.RunOnce == false {
+		t.Error("with -once args, RunOnce should be true")
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -20,5 +20,5 @@ type Generator interface {
 // PluginGenerator XXX
 type PluginGenerator interface {
 	Generate() (Values, error)
-	PrepareGraphDefs(api *mackerel.API) ([]mackerel.CreateGraphDefsPayload, error)
+	PrepareGraphDefs() ([]mackerel.CreateGraphDefsPayload, error)
 }

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -58,7 +58,7 @@ func (g *pluginGenerator) Generate() (Values, error) {
 	return results, nil
 }
 
-func (g *pluginGenerator) PrepareGraphDefs(api *mackerel.API) ([]mackerel.CreateGraphDefsPayload, error) {
+func (g *pluginGenerator) PrepareGraphDefs() ([]mackerel.CreateGraphDefsPayload, error) {
 	err := g.loadPluginMeta()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add `-once` option that mackerel-agent runs once and outputs results to stdout.
This option is useful for developing and debugging mackerel-agent itself and plugins.

Example of output is as follows.
```json
# build/mackerel-agent -once -conf=mackerel-agent.conf | jq .
2015/03/08 12:46:46 INFO main Starting mackerel-agent version:0.14.3, rev:85bd358
2015/03/08 12:46:46 INFO command Collecting metrics may take one minutes.
{
  "host": {
    "interfaces": null,
    "meta": {
      "agent-name": "mackerel-agent/0.14.3 (Revision 85bd358)",
      "agent-revision": "85bd358",
      "agent-version": "0.14.3",
      "cpu": [
        {
          "model_name": "Intel(R) Core(TM) i7-3667U CPU @ 2.00GHz\n"
        }
      ],
      ...
}
```
