### PR TITLE
Release version 0.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.14.3-1.noarch.rpm
-  - packaging/mackerel-agent_0.14.3-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.15.0-1.noarch.rpm
+  - packaging/mackerel-agent_0.15.0-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.15.0 (2015-04-02)
+
+* Only skip device mapper created by docker
+* Run once and output results to stdout with -once option
+* introduce Songmu/timeout for interrupting long time plugin execution
+* add config.apibase
+* output GOOS GOARCH runtime.Version() when -version option is specified
+
+## 0.14.3 (2015-03-23)
+
+- [enhancement] add collector for ec2 metadata
+
+## 0.14.1 (2015-01-20)
+
+* [fix] skip device mapper metrics
+* [fix] filter invalid float values
+* [enhancement] testing
+* [enhancement] collect more metrics about darwin and freebsd
+
 ## 0.14.0 (2014-12-25)
 
 * [improve] wait for termination until postQueue is empty up to 30 seconds.

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ var logger = logging.GetLogger("main")
 func main() {
 	conf, otherOptions := resolveConfig()
 
-	if otherOptions.printVersion {
+	if otherOptions != nil && otherOptions.printVersion {
 		fmt.Printf("mackerel-agent version %s (rev %s) [%s %s %s] \n",
 			version.VERSION, version.GITCOMMIT, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		exitWithoutPidfileCleaning(0)
@@ -66,7 +66,7 @@ func main() {
 
 	logger.Infof("Starting mackerel-agent version:%s, rev:%s, apibase:%s", version.VERSION, version.GITCOMMIT, conf.Apibase)
 
-	if otherOptions.runOnce {
+	if otherOptions != nil && otherOptions.runOnce {
 		command.RunOnce(conf)
 		exitWithoutPidfileCleaning(0)
 	}

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.15.0-1) stable; urgency=low
+
+  * building packages (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/56>
+  * Only skip device mapper created by docker (Resolve #70) (by mechairoi)
+    <https://github.com/mackerelio/mackerel-agent/pull/71>
+  * Run once and output results to stdout (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent/pull/72>
+  * introduce Songmu/timeout for interrupting long time plugin execution (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/73>
+  * add config.apibase (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/74>
+  * output GOOS GOARCH runtime.Version() when -version option is specified (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/75>
+
+ -- Songmu <y.songmu@gmail.com>  Thu, 02 Apr 2015 18:09:28 +0900
+
 mackerel-agent (0.14.3-1) precise; urgency=low
 
   * [enhancement] add collector for ec2 metadata (stanaka)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.14.3
+Version:   0.15.0
 Release:   1
 License:   Commercial
 Summary:   macekrel.io agent

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -78,7 +78,6 @@ fi
 - introduce Songmu/timeout for interrupting long time plugin execution (by Songmu)
 - add config.apibase (by Songmu)
 - output GOOS GOARCH runtime.Version() when -version option is specified (by Songmu)
-
 * Mon Mar 23 2015 Songmu <songmu@hatena.ne.jp> 0.14.3-1
 - [enhancement] add collector for ec2 metadata (stanaka)
 * Tue Jan 20 2015 Songmu <songmu@hatena.ne.jp> 0.14.1-1

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -71,6 +71,14 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Thu Apr 02 2015 <y.songmu@gmail.com> - 0.15.0-1
+- building packages (by Songmu)
+- Only skip device mapper created by docker (Resolve #70) (by mechairoi)
+- Run once and output results to stdout (by stanaka)
+- introduce Songmu/timeout for interrupting long time plugin execution (by Songmu)
+- add config.apibase (by Songmu)
+- output GOOS GOARCH runtime.Version() when -version option is specified (by Songmu)
+
 * Mon Mar 23 2015 Songmu <songmu@hatena.ne.jp> 0.14.3-1
 - [enhancement] add collector for ec2 metadata (stanaka)
 * Tue Jan 20 2015 Songmu <songmu@hatena.ne.jp> 0.14.1-1

--- a/tool/releng
+++ b/tool/releng
@@ -250,6 +250,17 @@ sub update_changelog {
         $content =~ s/%changelog/%changelog\n$update/;
         $content;
     };
+
+    replace 'CHANGELOG.md' => sub {
+        my $content = shift;
+
+        my $update = "\n\n## %s (%s)\n\n", $next_version, $now->strftime('%Y-%m-%d');
+        for my $rel (@releases) {
+            $update .= sprintf "* %s #%d (%s)\n", $rel->{title}, $rel->{num}, $rel->{user};
+        }
+        $content =~ s/\A# Changelog/# Changelog$update/;
+        $content;
+    };
 }
 
 sub build_pull_request_body {


### PR DESCRIPTION
- building packages #56
- Only skip device mapper created by docker (Resolve #70) #71
- Run once and output results to stdout #72
- introduce Songmu/timeout for interrupting long time plugin execution #73
- add config.apibase #74
- output GOOS GOARCH runtime.Version() when -version option is specified #75