### PR TITLE
suppress logging

### DIFF
--- a/spec/linux/cloud.go
+++ b/spec/linux/cloud.go
@@ -68,7 +68,7 @@ func (g *CloudGenerator) Generate() (interface{}, error) {
 	for _, key := range metadataKeys {
 		resp, err := client.Get(g.baseURL.String() + "/" + key)
 		if err != nil {
-			cloudLogger.Infof("This host may not be running on EC2. Error while reading '%s'", key)
+			cloudLogger.Debugf("This host may not be running on EC2. Error while reading '%s'", key)
 			return nil, nil
 		}
 		defer resp.Body.Close()


### PR DESCRIPTION
Following log appears every hours. It's too noisy, so suppress it.

```
2015/04/04 16:14:32 INFO spec.cloud This host may not be running on EC2. Error while reading 'instance-id'
```