### PR TITLE
Fix 'panic: runtime error: index out of range'.

### DIFF
--- a/metrics/freebsd/memory.go
+++ b/metrics/freebsd/memory.go
@@ -39,38 +39,32 @@ func (g *MemoryGenerator) Generate() (metrics.Values, error) {
 		}
 
 		if fields[0] == "Mem:" {
-
-			if v, err := getValue(fields[1]); err == nil {
-				ret["memory.active"] = v
-			} else {
-				errRet = err
-			}
-			if v, err := getValue(fields[3]); err == nil {
-				ret["memory.inactive"] = v
-			} else {
-				errRet = err
-			}
-			/*
-			         if v, err := getValue(fields[5]); err == nil {
-			           ret["memory.wired"] = v
-			         } else {
-			   	errRet = err
-			         }
-			*/
-			if v, err := getValue(fields[7]); err == nil {
-				ret["memory.cached"] = v
-			} else {
-				errRet = err
-			}
-			if v, err := getValue(fields[9]); err == nil {
-				ret["memory.buffers"] = v
-			} else {
-				errRet = err
-			}
-			if v, err := getValue(fields[11]); err == nil {
-				ret["memory.free"] = v
-			} else {
-				errRet = err
+			for i := 1; i < len(fields); i += 2 {
+				v, err := getValue(fields[i])
+				if err == nil {
+					k := fields[i + 1]
+					if strings.HasSuffix(k, ",") {
+						k = k[0 : len(k) - 1]
+					}
+					switch k {
+					case "Active":
+						ret["memory.active"] = v
+					case "Inact":
+						ret["memory.inactive"] = v
+					/*
+					case "Wired":
+						ret["memory.wired"] = v
+					*/
+					case "Cache":
+						ret["memory.cached"] = v
+					case "Buf":
+						ret["memory.buffers"] = v
+					case "Free":
+						ret["memory.free"] = v
+					}
+				} else {
+					errRet = err;
+				}
 			}
 		}
 		if fields[0] == "Swap:" {


### PR DESCRIPTION
mackerel-agent will sometimes stop because panic on FreeBSD machine:

```
2015/05/01 23:04:08 INFO main Starting mackerel-agent version:0.15.0-alpha, rev:97d2407, apibase:https://mackerel.io
2015/05/01 23:04:08 INFO command Start: apibase = https://mackerel.io, hostName = www7114ue.sakura.ne.jp, hostID = 2jyUhDw7FXw
panic: runtime error: index out of range

goroutine 197312 [running]:
github.com/mackerelio/mackerel-agent/metrics/freebsd.(*MemoryGenerator).Generate(0x910c20, 0xc208016f50, 0x0, 0x0)
	/home/don/go/src/github.com/mackerelio/mackerel-agent/metrics/freebsd/memory.go:70 +0xac2
github.com/mackerelio/mackerel-agent/agent.func·005(0x800945898, 0x910c20)
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/generator.go:37 +0x67
created by github.com/mackerelio/mackerel-agent/agent.func·006
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/generator.go:43 +0x16c

goroutine 1 [select]:
github.com/mackerelio/mackerel-agent/command.loop(0xc208338960, 0xc20827d920, 0x0)
	/home/don/go/src/github.com/mackerelio/mackerel-agent/command/command.go:166 +0xf64
github.com/mackerelio/mackerel-agent/command.Run(0xc20806c160, 0xc20800aa60, 0xc20827f6c0, 0xc20827d920, 0x800939a80)
	/home/don/go/src/github.com/mackerelio/mackerel-agent/command/command.go:402 +0x582
main.start(0xc20806c160, 0x0, 0x0)
	/home/don/go/src/github.com/mackerelio/mackerel-agent/main.go:232 +0x59e
main.main()
	/home/don/go/src/github.com/mackerelio/mackerel-agent/main.go:79 +0x52a

goroutine 5 [syscall, 10319 minutes]:
os/signal.loop()
	/home/don/src/go/src/os/signal/signal_unix.go:21 +0x1f
created by os/signal.init·1
	/home/don/src/go/src/os/signal/signal_unix.go:27 +0x35

goroutine 20 [chan receive, 10317 minutes]:
main.func·003()
	/home/don/go/src/github.com/mackerelio/mackerel-agent/main.go:206 +0x96
created by main.start
	/home/don/go/src/github.com/mackerelio/mackerel-agent/main.go:230 +0x564

goroutine 23 [chan receive]:
github.com/mackerelio/mackerel-agent/agent.func·001()
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/agent.go:46 +0x100
created by github.com/mackerelio/mackerel-agent/agent.(*Agent).Watch
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/agent.go:55 +0x126

goroutine 17 [syscall, 10319 minutes, locked to thread]:
runtime.goexit()
	/home/don/src/go/src/runtime/asm_amd64.s:2232 +0x1

goroutine 21 [select, 57 minutes]:
github.com/mackerelio/mackerel-agent/command.updateHostSpecsLoop(0xc208338960, 0xc20827daa0)
	/home/don/go/src/github.com/mackerelio/mackerel-agent/command/command.go:267 +0x102
created by github.com/mackerelio/mackerel-agent/command.loop
	/home/don/go/src/github.com/mackerelio/mackerel-agent/command/command.go:149 +0xdf

goroutine 22 [select]:
github.com/mackerelio/mackerel-agent/command.enqueueLoop(0xc208338960, 0xc20827db60, 0xc20827daa0)
	/home/don/go/src/github.com/mackerelio/mackerel-agent/command/command.go:279 +0x77a
created by github.com/mackerelio/mackerel-agent/command.loop
	/home/don/go/src/github.com/mackerelio/mackerel-agent/command/command.go:152 +0x17f

goroutine 24 [chan receive]:
github.com/mackerelio/mackerel-agent/agent.func·003()
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/agent.go:63 +0xdf
created by github.com/mackerelio/mackerel-agent/agent.(*Agent).Watch
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/agent.go:71 +0x1c4

goroutine 197306 [chan receive]:
github.com/mackerelio/mackerel-agent/agent.(*Agent).CollectMetrics(0xc2082f09f0, 0xeccdef190, 0x3986aab3, 0x9082a0, 0xc20827d080)
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/agent.go:30 +0x24c
github.com/mackerelio/mackerel-agent/agent.func·002()
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/agent.go:67 +0x4b
created by github.com/mackerelio/mackerel-agent/agent.func·003
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/agent.go:69 +0x250

goroutine 197310 [syscall]:
syscall.Syscall6(0x7, 0x9e09, 0xc20809fb1c, 0x0, 0xc2082f65a0, 0x0, 0x0, 0xc208052d20, 0x405b51, 0xc208052d40)
	/home/don/src/go/src/syscall/asm_freebsd_amd64.s:49 +0x5
syscall.wait4(0x9e09, 0xc20809fb1c, 0x0, 0xc2082f65a0, 0x90, 0x0, 0x0)
	/home/don/src/go/src/syscall/zsyscall_freebsd_amd64.go:32 +0x79
syscall.Wait4(0x9e09, 0xc20809fb64, 0x0, 0xc2082f65a0, 0x0, 0x0, 0x0)
	/home/don/src/go/src/syscall/syscall_bsd.go:162 +0x60
os.(*Process).wait(0xc2083296a0, 0x0, 0x0, 0x0)
	/home/don/src/go/src/os/exec_unix.go:22 +0x103
os.(*Process).Wait(0xc2083296a0, 0xc2083209b0, 0x0, 0x0)
	/home/don/src/go/src/os/doc.go:45 +0x3a
os/exec.(*Cmd).Wait(0xc2082bfb80, 0x0, 0x0)
	/home/don/src/go/src/os/exec/exec.go:364 +0x23c
os/exec.(*Cmd).Run(0xc2082bfb80, 0x0, 0x0)
	/home/don/src/go/src/os/exec/exec.go:246 +0x71
os/exec.(*Cmd).Output(0xc2082bfb80, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/don/src/go/src/os/exec/exec.go:392 +0x1d3
github.com/mackerelio/mackerel-agent/metrics/freebsd.(*CPUUsageGenerator).Generate(0x910c20, 0x515a17, 0x0, 0x0)
	/home/don/go/src/github.com/mackerelio/mackerel-agent/metrics/freebsd/cpuusage.go:35 +0xc1
github.com/mackerelio/mackerel-agent/agent.func·005(0x800945848, 0x910c20)
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/generator.go:37 +0x67
created by github.com/mackerelio/mackerel-agent/agent.func·006
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/generator.go:43 +0x16c

goroutine 197316 [syscall]:
syscall.Syscall(0x3, 0xc, 0xc20821d230, 0x5d0, 0x30, 0x200, 0x0)
	/home/don/src/go/src/syscall/asm_freebsd_amd64.s:26 +0x5
syscall.read(0xc, 0xc20821d230, 0x5d0, 0x5d0, 0x0, 0x0, 0x0)
	/home/don/src/go/src/syscall/zsyscall_freebsd_amd64.go:890 +0x6e
syscall.Read(0xc, 0xc20821d230, 0x5d0, 0x5d0, 0xc20801d5a0, 0x0, 0x0)
	/home/don/src/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc2080384f0, 0xc20821d230, 0x5d0, 0x5d0, 0xc20821d200, 0x0, 0x0)
	/home/don/src/go/src/os/file_unix.go:191 +0x86
os.(*File).Read(0xc2080384f0, 0xc20821d230, 0x5d0, 0x5d0, 0x30, 0x0, 0x0)
	/home/don/src/go/src/os/file.go:95 +0x91
bytes.(*Buffer).ReadFrom(0xc208011030, 0x80093e088, 0xc2080384f0, 0x30, 0x0, 0x0)
	/home/don/src/go/src/bytes/buffer.go:169 +0x25a
io.Copy(0x80093e2e0, 0xc208011030, 0x80093e088, 0xc2080384f0, 0x0, 0x0, 0x0)
	/home/don/src/go/src/io/io.go:358 +0x13d
os/exec.func·003(0x0, 0x0)
	/home/don/src/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc208329180)
	/home/don/src/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
	/home/don/src/go/src/os/exec/exec.go:329 +0xb6d

goroutine 197308 [semacquire]:
sync.(*WaitGroup).Wait(0xc208328e80)
	/home/don/src/go/src/sync/waitgroup.go:132 +0x169
github.com/mackerelio/mackerel-agent/agent.func·006()
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/generator.go:45 +0x19b
created by github.com/mackerelio/mackerel-agent/agent.generateValues
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/generator.go:47 +0x265

goroutine 197307 [select]:
github.com/mackerelio/mackerel-agent/agent.func·004()
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/generator.go:20 +0x154
created by github.com/mackerelio/mackerel-agent/agent.generateValues
	/home/don/go/src/github.com/mackerelio/mackerel-agent/agent/generator.go:28 +0x1c7
```

In my guess, the cause of this error is that the number of memory stats from top command is variable.

Memory stats will be display only when the value is non-zero.

https://svnweb.freebsd.org/base/release/10.1.0/contrib/top/display.c?view=markup#l1159

In addition, the other stats also has the possibility the occurs same error because uses the same function (summary_format()). But this patch includes for memory stats only.

Thanks,
