### PR TITLE
separete out metrics/darwin/swap.go from memory.go

### DIFF
--- a/command/command_darwin.go
+++ b/command/command_darwin.go
@@ -26,6 +26,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 		&metricsDarwin.Loadavg5Generator{},
 		&metricsDarwin.CPUUsageGenerator{},
 		&metricsDarwin.MemoryGenerator{},
+		&metricsDarwin.SwapGenerator{},
 		&metricsDarwin.FilesystemGenerator{},
 		&metricsDarwin.InterfaceGenerator{Interval: 60},
 	}

--- a/metrics/darwin/memory.go
+++ b/metrics/darwin/memory.go
@@ -51,14 +51,8 @@ Swapins:                                      0.
 Swapouts:                                     0.
 */
 
-/* sysctl vm.swapusage sample
-% sysctl vm.swapusage
-vm.swapusage: total = 1024.00M  used = 2.50M  free = 1021.50M  (encrypted)
-*/
-
 var memoryLogger = logging.GetLogger("metrics.memory")
 var statReg = regexp.MustCompile(`^(.+):\s+([0-9]+)\.$`)
-var swapReg = regexp.MustCompile(`([0-9]+(?:\.[0-9]+))?M[^0-9]*([0-9]+(?:\.[0-9]+)?)M[^0-9]*([0-9]+(?:\.[0-9]+)?)M`)
 
 // Generate generate metrics values
 func (g *MemoryGenerator) Generate() (metrics.Values, error) {
@@ -98,18 +92,5 @@ func (g *MemoryGenerator) Generate() (metrics.Values, error) {
 		"memory.inactive": float64(inactive),
 	}
 
-	outBytes, err = exec.Command("sysctl", "vm.swapusage").Output()
-	if err != nil {
-		memoryLogger.Errorf("Failed (skip swap metrics): %s", err)
-	} else {
-		if matches := swapReg.FindStringSubmatch(string(outBytes)); matches != nil {
-			t, _ := strconv.ParseFloat(matches[1], 64)
-			// swap_used are calculated at server, so don't send it
-			// u, _ := strconv.ParseFloat(matches[2], 64)
-			f, _ := strconv.ParseFloat(matches[3], 64)
-			ret["memory.swap_total"] = t * 1024 * 1024
-			ret["memory.swap_free"] = f * 1024 * 1024
-		}
-	}
 	return metrics.Values(ret), nil
 }

--- a/metrics/darwin/memory.go
+++ b/metrics/darwin/memory.go
@@ -15,9 +15,9 @@ import (
 /*
 MemoryGenerator collect memory usage
 
-`memory.{metric}`: using memory size retrieved from `vm_stat` and `sysctl vm.swapusage`
+`memory.{metric}`: using memory size retrieved from `vm_stat`
 
-metric = "total", "free", "used", "cached", "active", "inactive", "swap_total", "swap_used", "swap_free"
+metric = "total", "free", "used", "cached", "active", "inactive"
 
 graph: stacks `memory.{metric}`
 */

--- a/metrics/darwin/swap.go
+++ b/metrics/darwin/swap.go
@@ -1,0 +1,58 @@
+// +build darwin
+
+package darwin
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+
+	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/mackerel-agent/metrics"
+)
+
+/*
+SwapGenerator collect swap usage
+
+`memory.{metric}`: using swap size retrieved from `sysctl vm.swapusage`
+
+metric = "swap_total", "swap_free"
+
+graph: stacks `memory.{metric}`
+*/
+type SwapGenerator struct {
+}
+
+/* sysctl vm.swapusage sample
+% sysctl vm.swapusage
+vm.swapusage: total = 1024.00M  used = 2.50M  free = 1021.50M  (encrypted)
+*/
+
+var swapLogger = logging.GetLogger("metrics.memory.swap")
+var swapReg = regexp.MustCompile(`([0-9]+(?:\.[0-9]+)?)M[^0-9]*([0-9]+(?:\.[0-9]+)?)M[^0-9]*([0-9]+(?:\.[0-9]+)?)M`)
+
+// Generate generate swap values
+func (g *SwapGenerator) Generate() (metrics.Values, error) {
+	outBytes, err := exec.Command("sysctl", "vm.swapusage").Output()
+	if err != nil {
+		swapLogger.Errorf("Failed (skip these metrics): %s", err)
+		return nil, err
+	}
+
+	out := string(outBytes)
+	matches := swapReg.FindStringSubmatch(out)
+	if matches == nil || len(matches) != 4 {
+		return nil, fmt.Errorf("faild to parse vm.swapusage result: [%q]", out)
+	}
+	t, _ := strconv.ParseFloat(matches[1], 64)
+	// swap_used are calculated at server, so don't send it
+	// u, _ := strconv.ParseFloat(matches[2], 64)
+	f, _ := strconv.ParseFloat(matches[3], 64)
+
+	const mb = 1024.0 * 1024.0
+	return metrics.Values(map[string]float64{
+		"memory.swap_total": t * mb,
+		"memory.swap_free":  f * mb,
+	}), nil
+}

--- a/metrics/darwin/swap.go
+++ b/metrics/darwin/swap.go
@@ -19,7 +19,7 @@ SwapGenerator collect swap usage
 
 metric = "swap_total", "swap_free"
 
-graph: stacks `memory.{metric}`
+graph: `memory.{metric}`
 */
 type SwapGenerator struct {
 }

--- a/metrics/darwin/swap_test.go
+++ b/metrics/darwin/swap_test.go
@@ -4,20 +4,16 @@ package darwin
 
 import "testing"
 
-func TestMemoryGenerator(t *testing.T) {
-	g := &MemoryGenerator{}
+func TestSwapGenerator(t *testing.T) {
+	g := &SwapGenerator{}
 	values, err := g.Generate()
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
 
 	for _, name := range []string{
-		"total",
-		"free",
-		"cached",
-		"active",
-		"inactive",
-		"used",
+		"swap_total",
+		"swap_free",
 	} {
 		if v, ok := values["memory."+name]; !ok {
 			t.Errorf("memory should has %s", name)


### PR DESCRIPTION
Improve the codes around memory metrics collectors on osx based on mechairoi's feedbacks at #84.