### PR TITLE
Release version 0.16.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.16.0-1.noarch.rpm
-  - packaging/mackerel-agent_0.16.0-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.16.1-1.noarch.rpm
+  - packaging/mackerel-agent_0.16.1-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.16.1 (2015-05-12)
+
+* Code sharing around dfValues #85 (Songmu)
+* [FreeBSD] Fix 'panic: runtime error: index out of range'. #89 (iwadon)
+* separete out metrics/darwin/swap.go from memory.go #90 (Songmu)
+
+
 ## 0.16.0 (2015-05-08)
 
 * suppress logging #78 (stanaka)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent (0.16.1-1) stable; urgency=low
+
+  * Code sharing around dfValues (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/85>
+  * [FreeBSD] Fix 'panic: runtime error: index out of range'. (by iwadon)
+    <https://github.com/mackerelio/mackerel-agent/pull/89>
+  * separete out metrics/darwin/swap.go from memory.go (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/90>
+
+ -- Songmu <y.songmu@gmail.com>  Tue, 12 May 2015 15:30:58 +0900
+
 mackerel-agent (0.16.0-1) stable; urgency=low
 
   * suppress logging (by stanaka)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -71,6 +71,11 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Tue May 12 2015 <y.songmu@gmail.com> - 0.16.1-1
+- Code sharing around dfValues (by Songmu)
+- [FreeBSD] Fix 'panic: runtime error: index out of range'. (by iwadon)
+- separete out metrics/darwin/swap.go from memory.go (by Songmu)
+
 * Fri May 08 2015 <y.songmu@gmail.com> - 0.16.0-1
 - suppress logging (by stanaka)
 - "Check" functionality (by motemen)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.16.0
+Version:   0.16.1
 Release:   1
 License:   Commercial
 Summary:   macekrel.io agent


### PR DESCRIPTION
- Code sharing around dfValues #85
- [FreeBSD] Fix 'panic: runtime error: index out of range'. #89
- separete out metrics/darwin/swap.go from memory.go #90