### PR TITLE
Set `displayName` via agent

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,8 +31,6 @@ deploy:
   auth_token:
     secure: nT6f+l3sILrBAyVGLE1il+wkv5BvrnEnVkiPGDZQegePa81MUC4AIDTNQ/gX8AWW
   artifact: mackerel-agent-msi
-  draft: true
-  prerelease: true
   appveyor_repo_tag: true
   on:
     appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.14.{build}
+version: 0.16.{build}
 clone_folder: c:\gopath\src\github.com\mackerelio\mackerel-agent
 environment:
   GOPATH: c:\gopath

--- a/command/command.go
+++ b/command/command.go
@@ -57,17 +57,14 @@ func saveHostID(root string, id string) error {
 
 // buildHostSpec build data structure for Host specs
 func buildHostSpec(name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string, checks []string, nickname string) map[string]interface{} {
-	var spec = map[string]interface{}{
+	return map[string]interface{}{
 		"name":          name,
 		"meta":          meta,
 		"interfaces":    interfaces,
 		"roleFullnames": roleFullnames,
 		"checks":        checks,
+		"nickname":      nickname,
 	}
-	if nickname != "" {
-		spec["nickname"] = nickname
-	}
-	return spec
 }
 
 // prepareHost collects specs of the host and sends them to Mackerel server.

--- a/command/command.go
+++ b/command/command.go
@@ -56,19 +56,23 @@ func saveHostID(root string, id string) error {
 }
 
 // buildHostSpec build data structure for Host specs
-func buildHostSpec(name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string, checks []string) map[string]interface{} {
-	return map[string]interface{}{
+func buildHostSpec(name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string, checks []string, nickname string) map[string]interface{} {
+	var spec = map[string]interface{}{
 		"name":          name,
 		"meta":          meta,
 		"interfaces":    interfaces,
 		"roleFullnames": roleFullnames,
 		"checks":        checks,
 	}
+	if nickname != "" {
+		spec["nickname"] = nickname
+	}
+	return spec
 }
 
 // prepareHost collects specs of the host and sends them to Mackerel server.
 // A unique host-id is returned by the server if one is not specified.
-func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks []string) (*mackerel.Host, error) {
+func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks []string, nickname string) (*mackerel.Host, error) {
 	// XXX this configuration should be moved to under spec/linux
 	os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin:"+os.Getenv("PATH"))
 	os.Setenv("LANG", "C") // prevent changing outputs of some command, e.g. ifconfig.
@@ -81,7 +85,7 @@ func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks 
 	var result *mackerel.Host
 	if hostID, err := loadHostID(root); err != nil { // create
 		logger.Debugf("Registering new host on mackerel...")
-		createdHostID, err := api.CreateHost(hostname, meta, interfaces, roleFullnames)
+		createdHostID, err := api.CreateHost(hostname, meta, interfaces, roleFullnames, nickname)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to register this host: %s", err.Error())
 		}
@@ -95,7 +99,7 @@ func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks 
 		if err != nil {
 			return nil, fmt.Errorf("Failed to find this host on mackerel (You may want to delete file \"%s\" to register this host to an another organization): %s", idFilePath(root), err.Error())
 		}
-		err := api.UpdateHost(hostID, buildHostSpec(hostname, meta, interfaces, roleFullnames, checks))
+		err := api.UpdateHost(hostID, buildHostSpec(hostname, meta, interfaces, roleFullnames, checks, nickname))
 		if err != nil {
 			return nil, fmt.Errorf("Failed to update this host: %s", err.Error())
 		}
@@ -455,7 +459,7 @@ func UpdateHostSpecs(conf *config.Config, api *mackerel.API, host *mackerel.Host
 		return
 	}
 
-	err = api.UpdateHost(host.ID, buildHostSpec(hostname, meta, interfaces, conf.Roles, conf.CheckNames()))
+	err = api.UpdateHost(host.ID, buildHostSpec(hostname, meta, interfaces, conf.Roles, conf.CheckNames(), conf.Nickname))
 	if err != nil {
 		logger.Errorf("Error while updating host specs: %s", err)
 	} else {
@@ -471,7 +475,7 @@ func Prepare(conf *config.Config) (*mackerel.API, *mackerel.Host, error) {
 		return nil, nil, fmt.Errorf("Failed to prepare an api: %s", err.Error())
 	}
 
-	host, err := prepareHost(conf.Root, api, conf.Roles, conf.CheckNames())
+	host, err := prepareHost(conf.Root, api, conf.Roles, conf.CheckNames(), conf.Nickname)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to prepare host: %s", err.Error())
 	}
@@ -491,7 +495,7 @@ func RunOnce(conf *config.Config) {
 	logger.Infof("Collecting metrics may take one minutes.")
 	metrics := ag.CollectMetrics(time.Now())
 	payload := map[string]interface{}{
-		"host":    buildHostSpec(hostname, meta, interfaces, conf.Roles, conf.CheckNames()),
+		"host":    buildHostSpec(hostname, meta, interfaces, conf.Roles, conf.CheckNames(), conf.Nickname),
 		"metrics": metrics,
 	}
 	json, err := json.Marshal(payload)

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -30,8 +30,9 @@ func TestBuildHostSpec(t *testing.T) {
 	}
 	roleFullnames := []string{"My-Service:app-default"}
 	checks := []string{"heartbeat"}
+	displayName := "label"
 
-	hostSpec := buildHostSpec("Host123", meta, interfaces, roleFullnames, checks)
+	hostSpec := buildHostSpec("Host123", meta, interfaces, roleFullnames, checks, displayName)
 
 	if hostSpec["name"] != "Host123" {
 		t.Error("name should 'Host123' but:", hostSpec["name"])
@@ -50,6 +51,10 @@ func TestBuildHostSpec(t *testing.T) {
 	_, ok = hostSpec["roleFullnames"].([]string)
 	if !ok {
 		t.Error("the type of meta should be '[]string'")
+	}
+
+	if hostSpec["displayName"] != displayName {
+		t.Error("name should 'label' but:", hostSpec["displayName"])
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	Roles       []string
 	Verbose     bool
 	Connection  ConnectionConfig
-	DisplayName string
+	DisplayName string `toml:"display_name"`
 
 	// Corresponds to the set of [plugin.<kind>.<name>] sections
 	// the key of the map is <kind>, which should be one of "metrics" or "checks".

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	Roles      []string
 	Verbose    bool
 	Connection ConnectionConfig
+	Nickname   string
 
 	// Corresponds to the set of [plugin.<kind>.<name>] sections
 	// the key of the map is <kind>, which should be one of "metrics" or "checks".

--- a/config/config.go
+++ b/config/config.go
@@ -22,15 +22,15 @@ func getApibase() string {
 
 // Config represents mackerel-agent's configuration file.
 type Config struct {
-	Apibase    string
-	Apikey     string
-	Root       string
-	Pidfile    string
-	Conffile   string
-	Roles      []string
-	Verbose    bool
-	Connection ConnectionConfig
-	Nickname   string
+	Apibase     string
+	Apikey      string
+	Root        string
+	Pidfile     string
+	Conffile    string
+	Roles       []string
+	Verbose     bool
+	Connection  ConnectionConfig
+	DisplayName string
 
 	// Corresponds to the set of [plugin.<kind>.<name>] sections
 	// the key of the map is <kind>, which should be one of "metrics" or "checks".

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,7 @@ import (
 
 var sampleConfig = `
 apikey = "abcde"
+displayname = "fghij"
 
 [connection]
 post_metrics_retry_delay_seconds = 600
@@ -49,6 +50,10 @@ func TestLoadConfig(t *testing.T) {
 		t.Error("should be abcde (config value should be used)")
 	}
 
+	if config.DisplayName != "fghij" {
+		t.Error("should be fghij (config value should be used)")
+	}
+
 	if config.Connection.PostMetricsDequeueDelaySeconds != 30 {
 		t.Error("should be 30 (default value should be used)")
 	}
@@ -81,6 +86,10 @@ func TestLoadConfigFile(t *testing.T) {
 
 	if config.Apikey != "abcde" {
 		t.Error("Apikey should be abcde")
+	}
+
+	if config.DisplayName != "fghij" {
+		t.Error("DisplayName should be fghij")
 	}
 
 	if config.Connection.PostMetricsRetryMax != 5 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,7 +11,7 @@ import (
 
 var sampleConfig = `
 apikey = "abcde"
-displayname = "fghij"
+display_name = "fghij"
 
 [connection]
 post_metrics_retry_delay_seconds = 600

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -116,7 +116,7 @@ func (api *API) FindHost(id string) (*Host, error) {
 }
 
 // CreateHost XXX
-func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string, nickname string) (string, error) {
+func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string, displayName string) (string, error) {
 	requestJSON, err := json.Marshal(map[string]interface{}{
 		"name":          name,
 		"type":          "unknown",
@@ -124,7 +124,7 @@ func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces 
 		"meta":          meta,
 		"interfaces":    interfaces,
 		"roleFullnames": roleFullnames,
-		"nickname":      nickname,
+		"displayName":   displayName,
 	})
 	if err != nil {
 		return "", err

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -116,15 +116,19 @@ func (api *API) FindHost(id string) (*Host, error) {
 }
 
 // CreateHost XXX
-func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string) (string, error) {
-	requestJSON, err := json.Marshal(map[string]interface{}{
+func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string, nickname string) (string, error) {
+	var spec = map[string]interface{}{
 		"name":          name,
 		"type":          "unknown",
 		"status":        "working",
 		"meta":          meta,
 		"interfaces":    interfaces,
 		"roleFullnames": roleFullnames,
-	})
+	}
+	if nickname != "" {
+		spec["nickname"] = nickname
+	}
+	requestJSON, err := json.Marshal(spec)
 	if err != nil {
 		return "", err
 	}

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -117,18 +117,15 @@ func (api *API) FindHost(id string) (*Host, error) {
 
 // CreateHost XXX
 func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string, nickname string) (string, error) {
-	var spec = map[string]interface{}{
+	requestJSON, err := json.Marshal(map[string]interface{}{
 		"name":          name,
 		"type":          "unknown",
 		"status":        "working",
 		"meta":          meta,
 		"interfaces":    interfaces,
 		"roleFullnames": roleFullnames,
-	}
-	if nickname != "" {
-		spec["nickname"] = nickname
-	}
-	requestJSON, err := json.Marshal(spec)
+		"nickname":      nickname,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -159,7 +159,7 @@ func TestCreateHost(t *testing.T) {
 	})
 	hostID, err := api.CreateHost("dummy", map[string]interface{}{
 		"memo": "hello",
-	}, interfaces, []string{"My-Service:app-default"})
+	}, interfaces, []string{"My-Service:app-default"}, "label")
 
 	if err != nil {
 		t.Error("should not raise error: ", err)
@@ -213,7 +213,7 @@ func TestCreateHostWithNilArgs(t *testing.T) {
 	api, _ := NewAPI(ts.URL, "dummy-key", false)
 
 	// with nil args
-	hostID, err := api.CreateHost("nilsome", nil, nil, nil)
+	hostID, err := api.CreateHost("nilsome", nil, nil, nil, "")
 	if err != nil {
 		t.Error("should not return error but got: ", err)
 	}

--- a/tool/travis/autotag.sh
+++ b/tool/travis/autotag.sh
@@ -12,5 +12,5 @@ openssl aes-256-cbc -K $encrypted_e129501e13c5_key -iv $encrypted_e129501e13c5_i
 chmod 600 $deploykey
 git config --global user.email "mackerel-developers@hatena.ne.jp"
 git config --global user.name  "mackerel"
-git remote set-url origin git@github.com:mackerelio/mackerel-agent-plugins.git
+git remote set-url origin git@github.com:mackerelio/mackerel-agent.git
 tool/autotag


### PR DESCRIPTION
Host has "Display Name" to manage host using any name.
You can set "Display Name" via Web UI but you cannot set via agent.

This PR proposes new `displayName` setting.
And send the setting with other host specs when agent has started.
