### PR TITLE
Configurable host status on start/stop agent

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -543,7 +543,12 @@ func Run(conf *config.Config, api *mackerel.API, host *mackerel.Host, termCh cha
 		api:  api,
 	}
 
-	return loop(c, termCh)
+	exitCode := loop(c, termCh)
+	if exitCode == 0 && conf.HostStatus.Stop != "" {
+		// TOOD error handling. supoprt retire
+		api.UpdateHostStatus(host.ID, conf.HostStatus.Stop)
+	}
+	return exitCode
 }
 
 func createCheckers(conf *config.Config) []checks.Checker {

--- a/command/command.go
+++ b/command/command.go
@@ -57,7 +57,7 @@ func saveHostID(root string, id string) error {
 
 // prepareHost collects specs of the host and sends them to Mackerel server.
 // A unique host-id is returned by the server if one is not specified.
-func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks []string, displayName string) (*mackerel.Host, error) {
+func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks []string, displayName string, defaultStatus string) (*mackerel.Host, error) {
 	// XXX this configuration should be moved to under spec/linux
 	os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin:"+os.Getenv("PATH"))
 	os.Setenv("LANG", "C") // prevent changing outputs of some command, e.g. ifconfig.
@@ -95,6 +95,13 @@ func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks 
 
 		if err != nil {
 			return nil, fmt.Errorf("Failed to update this host: %s", err.Error())
+		}
+	}
+
+	if defaultStatus != "" && defaultStatus != result.Status {
+		err := api.UpdateHostStatus(result.ID, defaultStatus)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to set default host status: %s, %s", defaultStatus, err.Error())
 		}
 	}
 
@@ -476,7 +483,7 @@ func Prepare(conf *config.Config) (*mackerel.API, *mackerel.Host, error) {
 		return nil, nil, fmt.Errorf("Failed to prepare an api: %s", err.Error())
 	}
 
-	host, err := prepareHost(conf.Root, api, conf.Roles, conf.CheckNames(), conf.DisplayName)
+	host, err := prepareHost(conf.Root, api, conf.Roles, conf.CheckNames(), conf.DisplayName, conf.DefaultStatus)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to prepare host: %s", err.Error())
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -483,7 +483,7 @@ func Prepare(conf *config.Config) (*mackerel.API, *mackerel.Host, error) {
 		return nil, nil, fmt.Errorf("Failed to prepare an api: %s", err.Error())
 	}
 
-	host, err := prepareHost(conf.Root, api, conf.Roles, conf.CheckNames(), conf.DisplayName, conf.HostStatus.Start)
+	host, err := prepareHost(conf.Root, api, conf.Roles, conf.CheckNames(), conf.DisplayName, conf.HostStatus.OnStart)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to prepare host: %s", err.Error())
 	}
@@ -544,9 +544,9 @@ func Run(conf *config.Config, api *mackerel.API, host *mackerel.Host, termCh cha
 	}
 
 	exitCode := loop(c, termCh)
-	if exitCode == 0 && conf.HostStatus.Stop != "" {
+	if exitCode == 0 && conf.HostStatus.OnStop != "" {
 		// TOOD error handling. supoprt retire
-		api.UpdateHostStatus(host.ID, conf.HostStatus.Stop)
+		api.UpdateHostStatus(host.ID, conf.HostStatus.OnStop)
 	}
 	return exitCode
 }

--- a/command/command.go
+++ b/command/command.go
@@ -57,7 +57,7 @@ func saveHostID(root string, id string) error {
 
 // prepareHost collects specs of the host and sends them to Mackerel server.
 // A unique host-id is returned by the server if one is not specified.
-func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks []string, displayName string, defaultStatus string) (*mackerel.Host, error) {
+func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks []string, displayName string, hostSt string) (*mackerel.Host, error) {
 	// XXX this configuration should be moved to under spec/linux
 	os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin:"+os.Getenv("PATH"))
 	os.Setenv("LANG", "C") // prevent changing outputs of some command, e.g. ifconfig.
@@ -98,10 +98,10 @@ func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks 
 		}
 	}
 
-	if defaultStatus != "" && defaultStatus != result.Status {
-		err := api.UpdateHostStatus(result.ID, defaultStatus)
+	if hostSt != "" && hostSt != result.Status {
+		err := api.UpdateHostStatus(result.ID, hostSt)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to set default host status: %s, %s", defaultStatus, err.Error())
+			return nil, fmt.Errorf("Failed to set default host status: %s, %s", hostSt, err.Error())
 		}
 	}
 
@@ -483,7 +483,7 @@ func Prepare(conf *config.Config) (*mackerel.API, *mackerel.Host, error) {
 		return nil, nil, fmt.Errorf("Failed to prepare an api: %s", err.Error())
 	}
 
-	host, err := prepareHost(conf.Root, api, conf.Roles, conf.CheckNames(), conf.DisplayName, conf.DefaultStatus)
+	host, err := prepareHost(conf.Root, api, conf.Roles, conf.CheckNames(), conf.DisplayName, conf.HostStatus.Start)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to prepare host: %s", err.Error())
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -545,8 +545,11 @@ func Run(conf *config.Config, api *mackerel.API, host *mackerel.Host, termCh cha
 
 	exitCode := loop(c, termCh)
 	if exitCode == 0 && conf.HostStatus.OnStop != "" {
-		// TOOD error handling. supoprt retire
-		api.UpdateHostStatus(host.ID, conf.HostStatus.OnStop)
+		// TOOD error handling. supoprt retire(?)
+		err := api.UpdateHostStatus(host.ID, conf.HostStatus.OnStop)
+		if err != nil {
+			logger.Errorf("Failed update host status on stop: %s", err)
+		}
 	}
 	return exitCode
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,15 +22,16 @@ func getApibase() string {
 
 // Config represents mackerel-agent's configuration file.
 type Config struct {
-	Apibase     string
-	Apikey      string
-	Root        string
-	Pidfile     string
-	Conffile    string
-	Roles       []string
-	Verbose     bool
-	Connection  ConnectionConfig
-	DisplayName string `toml:"display_name"`
+	Apibase       string
+	Apikey        string
+	Root          string
+	Pidfile       string
+	Conffile      string
+	Roles         []string
+	Verbose       bool
+	Connection    ConnectionConfig
+	DisplayName   string `toml:"display_name"`
+	DefaultStatus string `toml:"default_status"`
 
 	// Corresponds to the set of [plugin.<kind>.<name>] sections
 	// the key of the map is <kind>, which should be one of "metrics" or "checks".
@@ -64,7 +65,7 @@ type ConnectionConfig struct {
 }
 
 // CheckNames return list of plugin.checks._name_
-func (conf *Config)CheckNames ()([]string) {
+func (conf *Config) CheckNames() []string {
 	checks := []string{}
 	for name := range conf.Plugin["checks"] {
 		checks = append(checks, name)

--- a/config/config.go
+++ b/config/config.go
@@ -66,8 +66,8 @@ type ConnectionConfig struct {
 
 // HostStatus configure host status on agent start/stop
 type HostStatus struct {
-	Start string
-	Stop  string
+	OnStart string `toml:"on_start"`
+	OnStop  string `toml:"on_stop"`
 }
 
 // CheckNames return list of plugin.checks._name_

--- a/config/config.go
+++ b/config/config.go
@@ -22,16 +22,16 @@ func getApibase() string {
 
 // Config represents mackerel-agent's configuration file.
 type Config struct {
-	Apibase       string
-	Apikey        string
-	Root          string
-	Pidfile       string
-	Conffile      string
-	Roles         []string
-	Verbose       bool
-	Connection    ConnectionConfig
-	DisplayName   string `toml:"display_name"`
-	DefaultStatus string `toml:"default_status"`
+	Apibase     string
+	Apikey      string
+	Root        string
+	Pidfile     string
+	Conffile    string
+	Roles       []string
+	Verbose     bool
+	Connection  ConnectionConfig
+	DisplayName string     `toml:"display_name"`
+	HostStatus  HostStatus `toml:"host_status"`
 
 	// Corresponds to the set of [plugin.<kind>.<name>] sections
 	// the key of the map is <kind>, which should be one of "metrics" or "checks".
@@ -62,6 +62,11 @@ type ConnectionConfig struct {
 	PostMetricsRetryDelaySeconds   int `toml:"post_metrics_retry_delay_seconds"`   // delay for retrying a request that caused errors
 	PostMetricsRetryMax            int `toml:"post_metrics_retry_max"`             // max numbers of retries for a request that causes errors
 	PostMetricsBufferSize          int `toml:"post_metrics_buffer_size"`           // max numbers of requests stored in buffer queue.
+}
+
+type HostStatus struct {
+	Start string
+	Stop  string
 }
 
 // CheckNames return list of plugin.checks._name_

--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,7 @@ type ConnectionConfig struct {
 	PostMetricsBufferSize          int `toml:"post_metrics_buffer_size"`           // max numbers of requests stored in buffer queue.
 }
 
+// HostStatus configure host status on agent start/stop
 type HostStatus struct {
 	Start string
 	Stop  string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -72,8 +72,8 @@ apikey = "abcde"
 display_name = "fghij"
 
 [host_status]
-start = "working"
-stop  = "poweroff"
+on_start = "working"
+on_stop  = "poweroff"
 `
 
 func TestLoadConfigWithHostStatus(t *testing.T) {
@@ -98,12 +98,12 @@ func TestLoadConfigWithHostStatus(t *testing.T) {
 		t.Error("should be fghij (config value should be used)")
 	}
 
-	if config.HostStatus.Start != "working" {
-		t.Error(`HostStatus.Start should be "working"`)
+	if config.HostStatus.OnStart != "working" {
+		t.Error(`HostStatus.OnStart should be "working"`)
 	}
 
-	if config.HostStatus.Stop != "poweroff" {
-		t.Error(`HostStatus.Stop should be "poweroff"`)
+	if config.HostStatus.OnStop != "poweroff" {
+		t.Error(`HostStatus.OnStop should be "poweroff"`)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -67,6 +67,46 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
+var sampleConfigWithHostStatus = `
+apikey = "abcde"
+display_name = "fghij"
+
+[host_status]
+start = "working"
+stop  = "poweroff"
+`
+
+func TestLoadConfigWithHostStatus(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	if err = ioutil.WriteFile(tmpFile.Name(), []byte(sampleConfigWithHostStatus), 0644); err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+
+	config, err := LoadConfig(tmpFile.Name())
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+
+	if config.Apikey != "abcde" {
+		t.Error("should be abcde (config value should be used)")
+	}
+
+	if config.DisplayName != "fghij" {
+		t.Error("should be fghij (config value should be used)")
+	}
+
+	if config.HostStatus.Start != "working" {
+		t.Error(`HostStatus.Start should be "working"`)
+	}
+
+	if config.HostStatus.Stop != "poweroff" {
+		t.Error(`HostStatus.Stop should be "poweroff"`)
+	}
+}
+
 func TestLoadConfigFile(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "mackerel-config-test")
 	if err != nil {

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -146,6 +146,18 @@ func (api *API) UpdateHost(hostID string, hostSpec HostSpec) error {
 	return nil
 }
 
+// UpdateHostStatus updates the status of the host
+func (api *API) UpdateHostStatus(hostId string, status string) error {
+	resp, err := api.postJSON(fmt.Sprintf("/api/v0/hosts/%s/status", hostId), map[string]string{
+		"status": status,
+	})
+	defer closeResp(resp)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // PostMetricsValues post metrics
 func (api *API) PostMetricsValues(metricsValues [](*CreatingMetricsValue)) error {
 	resp, err := api.postJSON("/api/v0/tsdb", metricsValues)

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -147,8 +147,8 @@ func (api *API) UpdateHost(hostID string, hostSpec HostSpec) error {
 }
 
 // UpdateHostStatus updates the status of the host
-func (api *API) UpdateHostStatus(hostId string, status string) error {
-	resp, err := api.postJSON(fmt.Sprintf("/api/v0/hosts/%s/status", hostId), map[string]string{
+func (api *API) UpdateHostStatus(hostID string, status string) error {
+	resp, err := api.postJSON(fmt.Sprintf("/api/v0/hosts/%s/status", hostID), map[string]string{
 		"status": status,
 	})
 	defer closeResp(resp)

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -328,12 +328,12 @@ func TestUpdateHostStatus(t *testing.T) {
 			t.Error("request sends json including status but: ", data.Status)
 		}
 
-		respJson, _ := json.Marshal(map[string]bool{
+		respJSON, _ := json.Marshal(map[string]bool{
 			"success": true,
 		})
 
 		res.Header()["Content-Type"] = []string{"application/json"}
-		fmt.Fprint(res, string(respJson))
+		fmt.Fprint(res, string(respJSON))
 	}))
 	defer ts.Close()
 

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -305,6 +305,46 @@ func TestUpdateHost(t *testing.T) {
 	}
 }
 
+func TestUpdateHostStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v0/hosts/9rxGOHfVF8F/status" {
+			t.Error("request URL should be /api/v0/hosts/9rxGOHfVF8F/status but :", req.URL.Path)
+		}
+		if req.Method != "POST" {
+			t.Error("request method should be POST but: ", req.Method)
+		}
+
+		body, _ := ioutil.ReadAll(req.Body)
+
+		var data struct {
+			Status string `json:"status"`
+		}
+		err := json.Unmarshal(body, &data)
+		if err != nil {
+			t.Fatal("request body should be decoded as json", string(body))
+		}
+
+		if data.Status != "maintenance" {
+			t.Error("request sends json including status but: ", data.Status)
+		}
+
+		respJson, _ := json.Marshal(map[string]bool{
+			"success": true,
+		})
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		fmt.Fprint(res, string(respJson))
+	}))
+	defer ts.Close()
+
+	api, _ := NewAPI(ts.URL, "dummy-key", false)
+	err := api.UpdateHostStatus("9rxGOHfVF8F", "maintenance")
+
+	if err != nil {
+		t.Error("err shoud be nil but: ", err)
+	}
+}
+
 func TestFindHost(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if req.URL.Path != "/api/v0/hosts/9rxGOHfVF8F" {


### PR DESCRIPTION
Specify host status on start/stop agent in configuration as follows.

```
[host_status]
on_start = "working"
on_stop  = "poweroff"
```