### PR TITLE
Add an agent memory usage metrics generator for diagnostic use

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -556,9 +556,9 @@ func createCheckers(conf *config.Config) []checks.Checker {
 }
 
 func prepareGenerators(conf *config.Config) []metrics.Generator {
-	diagnosticMode := conf.DiagnosticMode
+	diagnostic := conf.Diagnostic
 	generators := metricsGenerators(conf)
-	if diagnosticMode {
+	if diagnostic {
 		generators = append(generators, &metrics.AgentGenerator{})
 	}
 	return generators

--- a/command/command.go
+++ b/command/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/mackerel"
+	"github.com/mackerelio/mackerel-agent/metrics"
 	"github.com/mackerelio/mackerel-agent/spec"
 	"github.com/mackerelio/mackerel-agent/util"
 )
@@ -517,7 +518,7 @@ func RunOnce(conf *config.Config) {
 // NewAgent creates a new instance of agent.Agent from its configuration conf.
 func NewAgent(conf *config.Config) *agent.Agent {
 	return &agent.Agent{
-		MetricsGenerators: metricsGenerators(conf),
+		MetricsGenerators: prepareGenerators(conf),
 		PluginGenerators:  pluginGenerators(conf),
 		Checkers:          createCheckers(conf),
 	}
@@ -552,4 +553,13 @@ func createCheckers(conf *config.Config) []checks.Checker {
 	}
 
 	return checkers
+}
+
+func prepareGenerators(conf *config.Config) []metrics.Generator {
+	diagnosticMode := conf.DiagnosticMode
+	generators := metricsGenerators(conf)
+	if diagnosticMode {
+		generators = append(generators, &metrics.AgentGenerator{})
+	}
+	return generators
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,15 +22,16 @@ func getApibase() string {
 
 // Config represents mackerel-agent's configuration file.
 type Config struct {
-	Apibase     string
-	Apikey      string
-	Root        string
-	Pidfile     string
-	Conffile    string
-	Roles       []string
-	Verbose     bool
-	Connection  ConnectionConfig
-	DisplayName string `toml:"display_name"`
+	Apibase        string
+	Apikey         string
+	Root           string
+	Pidfile        string
+	Conffile       string
+	Roles          []string
+	Verbose        bool
+	DiagnosticMode bool `toml:"diagnostic_mode"`
+	Connection     ConnectionConfig
+	DisplayName    string `toml:"display_name"`
 
 	// Corresponds to the set of [plugin.<kind>.<name>] sections
 	// the key of the map is <kind>, which should be one of "metrics" or "checks".
@@ -64,7 +65,7 @@ type ConnectionConfig struct {
 }
 
 // CheckNames return list of plugin.checks._name_
-func (conf *Config)CheckNames ()([]string) {
+func (conf *Config) CheckNames() []string {
 	checks := []string{}
 	for name := range conf.Plugin["checks"] {
 		checks = append(checks, name)
@@ -88,6 +89,9 @@ func LoadConfig(conffile string) (*Config, error) {
 	}
 	if config.Verbose == false {
 		config.Verbose = DefaultConfig.Verbose
+	}
+	if config.DiagnosticMode == false {
+		config.DiagnosticMode = DefaultConfig.DiagnosticMode
 	}
 	if config.Connection.PostMetricsDequeueDelaySeconds == 0 {
 		config.Connection.PostMetricsDequeueDelaySeconds = DefaultConfig.Connection.PostMetricsDequeueDelaySeconds

--- a/config/config.go
+++ b/config/config.go
@@ -22,16 +22,16 @@ func getApibase() string {
 
 // Config represents mackerel-agent's configuration file.
 type Config struct {
-	Apibase        string
-	Apikey         string
-	Root           string
-	Pidfile        string
-	Conffile       string
-	Roles          []string
-	Verbose        bool
-	DiagnosticMode bool `toml:"diagnostic_mode"`
-	Connection     ConnectionConfig
-	DisplayName    string `toml:"display_name"`
+	Apibase     string
+	Apikey      string
+	Root        string
+	Pidfile     string
+	Conffile    string
+	Roles       []string
+	Verbose     bool
+	Diagnostic  bool `toml:"diagnostic"`
+	Connection  ConnectionConfig
+	DisplayName string `toml:"display_name"`
 
 	// Corresponds to the set of [plugin.<kind>.<name>] sections
 	// the key of the map is <kind>, which should be one of "metrics" or "checks".
@@ -90,8 +90,8 @@ func LoadConfig(conffile string) (*Config, error) {
 	if config.Verbose == false {
 		config.Verbose = DefaultConfig.Verbose
 	}
-	if config.DiagnosticMode == false {
-		config.DiagnosticMode = DefaultConfig.DiagnosticMode
+	if config.Diagnostic == false {
+		config.Diagnostic = DefaultConfig.Diagnostic
 	}
 	if config.Connection.PostMetricsDequeueDelaySeconds == 0 {
 		config.Connection.PostMetricsDequeueDelaySeconds = DefaultConfig.Connection.PostMetricsDequeueDelaySeconds

--- a/config/config_darwin.go
+++ b/config/config_darwin.go
@@ -7,13 +7,13 @@ var mackerelRoot = filepath.Join(os.Getenv("HOME"), "Library", "mackerel-agent")
 
 // The default configuration for dawrin.
 var DefaultConfig = &Config{
-	Apibase:        getApibase(),
-	Root:           mackerelRoot,
-	Pidfile:        filepath.Join(mackerelRoot, "pid"),
-	Conffile:       filepath.Join(mackerelRoot, "mackerel-agent.conf"),
-	Roles:          []string{},
-	Verbose:        false,
-	DiagnosticMode: false,
+	Apibase:    getApibase(),
+	Root:       mackerelRoot,
+	Pidfile:    filepath.Join(mackerelRoot, "pid"),
+	Conffile:   filepath.Join(mackerelRoot, "mackerel-agent.conf"),
+	Roles:      []string{},
+	Verbose:    false,
+	Diagnostic: false,
 	Connection: ConnectionConfig{
 		PostMetricsDequeueDelaySeconds: 30,     // Check the metric values queue for each half minutes
 		PostMetricsRetryDelaySeconds:   60,     // Wait a minute before retrying metric value posts

--- a/config/config_darwin.go
+++ b/config/config_darwin.go
@@ -7,12 +7,13 @@ var mackerelRoot = filepath.Join(os.Getenv("HOME"), "Library", "mackerel-agent")
 
 // The default configuration for dawrin.
 var DefaultConfig = &Config{
-	Apibase:  getApibase(),
-	Root:     mackerelRoot,
-	Pidfile:  filepath.Join(mackerelRoot, "pid"),
-	Conffile: filepath.Join(mackerelRoot, "mackerel-agent.conf"),
-	Roles:    []string{},
-	Verbose:  false,
+	Apibase:        getApibase(),
+	Root:           mackerelRoot,
+	Pidfile:        filepath.Join(mackerelRoot, "pid"),
+	Conffile:       filepath.Join(mackerelRoot, "mackerel-agent.conf"),
+	Roles:          []string{},
+	Verbose:        false,
+	DiagnosticMode: false,
 	Connection: ConnectionConfig{
 		PostMetricsDequeueDelaySeconds: 30,     // Check the metric values queue for each half minutes
 		PostMetricsRetryDelaySeconds:   60,     // Wait a minute before retrying metric value posts

--- a/config/config_freebsd.go
+++ b/config/config_freebsd.go
@@ -9,12 +9,13 @@ var mackerelRoot = filepath.Join(os.Getenv("HOME"), "Library", "mackerel-agent")
 
 // DefaultConfig The default configuration for freebsd
 var DefaultConfig = &Config{
-	Apibase:  getApibase(),
-	Root:     mackerelRoot,
-	Pidfile:  filepath.Join(mackerelRoot, "pid"),
-	Conffile: filepath.Join(mackerelRoot, "mackerel-agent.conf"),
-	Roles:    []string{},
-	Verbose:  false,
+	Apibase:        getApibase(),
+	Root:           mackerelRoot,
+	Pidfile:        filepath.Join(mackerelRoot, "pid"),
+	Conffile:       filepath.Join(mackerelRoot, "mackerel-agent.conf"),
+	Roles:          []string{},
+	Verbose:        false,
+	DiagnosticMode: false,
 	Connection: ConnectionConfig{
 		PostMetricsDequeueDelaySeconds: 30,     // Check the metric values queue for each half minutes
 		PostMetricsRetryDelaySeconds:   60,     // Wait a minute before retrying metric value posts

--- a/config/config_freebsd.go
+++ b/config/config_freebsd.go
@@ -9,13 +9,13 @@ var mackerelRoot = filepath.Join(os.Getenv("HOME"), "Library", "mackerel-agent")
 
 // DefaultConfig The default configuration for freebsd
 var DefaultConfig = &Config{
-	Apibase:        getApibase(),
-	Root:           mackerelRoot,
-	Pidfile:        filepath.Join(mackerelRoot, "pid"),
-	Conffile:       filepath.Join(mackerelRoot, "mackerel-agent.conf"),
-	Roles:          []string{},
-	Verbose:        false,
-	DiagnosticMode: false,
+	Apibase:    getApibase(),
+	Root:       mackerelRoot,
+	Pidfile:    filepath.Join(mackerelRoot, "pid"),
+	Conffile:   filepath.Join(mackerelRoot, "mackerel-agent.conf"),
+	Roles:      []string{},
+	Verbose:    false,
+	Diagnostic: false,
 	Connection: ConnectionConfig{
 		PostMetricsDequeueDelaySeconds: 30,     // Check the metric values queue for each half minutes
 		PostMetricsRetryDelaySeconds:   60,     // Wait a minute before retrying metric value posts

--- a/config/config_linux.go
+++ b/config/config_linux.go
@@ -2,12 +2,13 @@ package config
 
 // DefaultConfig The default configuration for linux
 var DefaultConfig = &Config{
-	Apibase:  getApibase(),
-	Root:     "/var/lib/mackerel-agent",
-	Pidfile:  "/var/run/mackerel-agent.pid",
-	Conffile: "/etc/mackerel-agent/mackerel-agent.conf",
-	Roles:    []string{},
-	Verbose:  false,
+	Apibase:        getApibase(),
+	Root:           "/var/lib/mackerel-agent",
+	Pidfile:        "/var/run/mackerel-agent.pid",
+	Conffile:       "/etc/mackerel-agent/mackerel-agent.conf",
+	Roles:          []string{},
+	Verbose:        false,
+	DiagnosticMode: false,
 	Connection: ConnectionConfig{
 		PostMetricsDequeueDelaySeconds: 30,     // Check the metric values queue for each half minutes
 		PostMetricsRetryDelaySeconds:   60,     // Wait a minute before retrying metric value posts

--- a/config/config_linux.go
+++ b/config/config_linux.go
@@ -2,13 +2,13 @@ package config
 
 // DefaultConfig The default configuration for linux
 var DefaultConfig = &Config{
-	Apibase:        getApibase(),
-	Root:           "/var/lib/mackerel-agent",
-	Pidfile:        "/var/run/mackerel-agent.pid",
-	Conffile:       "/etc/mackerel-agent/mackerel-agent.conf",
-	Roles:          []string{},
-	Verbose:        false,
-	DiagnosticMode: false,
+	Apibase:    getApibase(),
+	Root:       "/var/lib/mackerel-agent",
+	Pidfile:    "/var/run/mackerel-agent.pid",
+	Conffile:   "/etc/mackerel-agent/mackerel-agent.conf",
+	Roles:      []string{},
+	Verbose:    false,
+	Diagnostic: false,
 	Connection: ConnectionConfig{
 		PostMetricsDequeueDelaySeconds: 30,     // Check the metric values queue for each half minutes
 		PostMetricsRetryDelaySeconds:   60,     // Wait a minute before retrying metric value posts

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,7 @@ import (
 var sampleConfig = `
 apikey = "abcde"
 display_name = "fghij"
+diagnostic_mode = true
 
 [connection]
 post_metrics_retry_delay_seconds = 600
@@ -54,6 +55,10 @@ func TestLoadConfig(t *testing.T) {
 		t.Error("should be fghij (config value should be used)")
 	}
 
+	if config.DiagnosticMode != true {
+		t.Error("should be true (config value should be used)")
+	}
+
 	if config.Connection.PostMetricsDequeueDelaySeconds != 30 {
 		t.Error("should be 30 (default value should be used)")
 	}
@@ -90,6 +95,10 @@ func TestLoadConfigFile(t *testing.T) {
 
 	if config.DisplayName != "fghij" {
 		t.Error("DisplayName should be fghij")
+	}
+
+	if config.DiagnosticMode != true {
+		t.Error("DiagnosticMode should be true")
 	}
 
 	if config.Connection.PostMetricsRetryMax != 5 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,7 +12,7 @@ import (
 var sampleConfig = `
 apikey = "abcde"
 display_name = "fghij"
-diagnostic_mode = true
+diagnostic = true
 
 [connection]
 post_metrics_retry_delay_seconds = 600
@@ -55,7 +55,7 @@ func TestLoadConfig(t *testing.T) {
 		t.Error("should be fghij (config value should be used)")
 	}
 
-	if config.DiagnosticMode != true {
+	if config.Diagnostic != true {
 		t.Error("should be true (config value should be used)")
 	}
 
@@ -97,8 +97,8 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Error("DisplayName should be fghij")
 	}
 
-	if config.DiagnosticMode != true {
-		t.Error("DiagnosticMode should be true")
+	if config.Diagnostic != true {
+		t.Error("Diagnostic should be true")
 	}
 
 	if config.Connection.PostMetricsRetryMax != 5 {

--- a/config/config_windows.go
+++ b/config/config_windows.go
@@ -19,13 +19,13 @@ var execdir = execdirInit()
 
 // The default configuration for windows
 var DefaultConfig = &Config{
-	Apibase:        getApibase(),
-	Root:           execdir,
-	Pidfile:        filepath.Join(execdir, "mackerel-agent.pid"),
-	Conffile:       filepath.Join(execdir, "mackerel-agent.conf"),
-	Roles:          []string{},
-	Verbose:        false,
-	DiagnosticMode: false,
+	Apibase:    getApibase(),
+	Root:       execdir,
+	Pidfile:    filepath.Join(execdir, "mackerel-agent.pid"),
+	Conffile:   filepath.Join(execdir, "mackerel-agent.conf"),
+	Roles:      []string{},
+	Verbose:    false,
+	Diagnostic: false,
 	Connection: ConnectionConfig{
 		PostMetricsDequeueDelaySeconds: 30,
 		PostMetricsRetryDelaySeconds:   60,

--- a/config/config_windows.go
+++ b/config/config_windows.go
@@ -19,12 +19,13 @@ var execdir = execdirInit()
 
 // The default configuration for windows
 var DefaultConfig = &Config{
-	Apibase:  getApibase(),
-	Root:     execdir,
-	Pidfile:  filepath.Join(execdir, "mackerel-agent.pid"),
-	Conffile: filepath.Join(execdir, "mackerel-agent.conf"),
-	Roles:    []string{},
-	Verbose:  false,
+	Apibase:        getApibase(),
+	Root:           execdir,
+	Pidfile:        filepath.Join(execdir, "mackerel-agent.pid"),
+	Conffile:       filepath.Join(execdir, "mackerel-agent.conf"),
+	Roles:          []string{},
+	Verbose:        false,
+	DiagnosticMode: false,
 	Connection: ConnectionConfig{
 		PostMetricsDequeueDelaySeconds: 30,
 		PostMetricsRetryDelaySeconds:   60,

--- a/main.go
+++ b/main.go
@@ -90,13 +90,14 @@ func resolveConfig() (*config.Config, *otherOptions) {
 	otherOptions := &otherOptions{}
 
 	var (
-		conffile     = flag.String("conf", config.DefaultConfig.Conffile, "Config file path (Configs in this file are over-written by command line options)")
-		apibase      = flag.String("apibase", config.DefaultConfig.Apibase, "API base")
-		pidfile      = flag.String("pidfile", config.DefaultConfig.Pidfile, "File containing PID")
-		root         = flag.String("root", config.DefaultConfig.Root, "Directory containing variable state information")
-		apikey       = flag.String("apikey", "", "API key from mackerel.io web site")
-		runOnce      = flag.Bool("once", false, "Show spec and metrics to stdout once")
-		printVersion = flag.Bool("version", false, "Prints version and exit")
+		conffile       = flag.String("conf", config.DefaultConfig.Conffile, "Config file path (Configs in this file are over-written by command line options)")
+		apibase        = flag.String("apibase", config.DefaultConfig.Apibase, "API base")
+		pidfile        = flag.String("pidfile", config.DefaultConfig.Pidfile, "File containing PID")
+		root           = flag.String("root", config.DefaultConfig.Root, "Directory containing variable state information")
+		apikey         = flag.String("apikey", "", "API key from mackerel.io web site")
+		diagnosticMode = flag.Bool("diagnostic", false, "Enables diagnostic features")
+		runOnce        = flag.Bool("once", false, "Show spec and metrics to stdout once")
+		printVersion   = flag.Bool("version", false, "Prints version and exit")
 	)
 
 	var verbose bool
@@ -137,6 +138,8 @@ func resolveConfig() (*config.Config, *otherOptions) {
 			conf.Pidfile = *pidfile
 		case "root":
 			conf.Root = *root
+		case "diagnostic":
+			conf.DiagnosticMode = *diagnosticMode
 		case "verbose", "v":
 			conf.Verbose = verbose
 		case "role":

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func resolveConfig() (*config.Config, *otherOptions) {
 		pidfile        = flag.String("pidfile", config.DefaultConfig.Pidfile, "File containing PID")
 		root           = flag.String("root", config.DefaultConfig.Root, "Directory containing variable state information")
 		apikey         = flag.String("apikey", "", "API key from mackerel.io web site")
-		diagnosticMode = flag.Bool("diagnostic", false, "Enables diagnostic features")
+		diagnostic = flag.Bool("diagnostic", false, "Enables diagnostic features")
 		runOnce        = flag.Bool("once", false, "Show spec and metrics to stdout once")
 		printVersion   = flag.Bool("version", false, "Prints version and exit")
 	)
@@ -139,7 +139,7 @@ func resolveConfig() (*config.Config, *otherOptions) {
 		case "root":
 			conf.Root = *root
 		case "diagnostic":
-			conf.DiagnosticMode = *diagnosticMode
+			conf.Diagnostic = *diagnostic
 		case "verbose", "v":
 			conf.Verbose = verbose
 		case "role":

--- a/main_test.go
+++ b/main_test.go
@@ -17,12 +17,13 @@ func TestParseFlags(t *testing.T) {
 	confFile.WriteString(`verbose=false
 root="/hoge/fuga"
 apikey="DUMMYAPIKEY"
+diagnostic_mode=false
 `)
 	confFile.Sync()
 	confFile.Close()
 	defer os.Remove(confFile.Name())
 
-	os.Args = []string{"mackerel-agent", "-conf=" + confFile.Name(), "-role=My-Service:default", "-verbose"}
+	os.Args = []string{"mackerel-agent", "-conf=" + confFile.Name(), "-role=My-Service:default", "-verbose", "-diagnostic"}
 	// Overrides Args from go test command
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.PanicOnError)
 
@@ -32,6 +33,7 @@ apikey="DUMMYAPIKEY"
 	t.Logf("       apikey: %v", mergedConfig.Apikey)
 	t.Logf("         root: %v", mergedConfig.Root)
 	t.Logf("      pidfile: %v", mergedConfig.Pidfile)
+	t.Logf("   diagnostic: %v", mergedConfig.DiagnosticMode)
 	t.Logf("roleFullnames: %v", mergedConfig.Roles)
 	t.Logf("      verbose: %v", mergedConfig.Verbose)
 
@@ -45,6 +47,10 @@ apikey="DUMMYAPIKEY"
 
 	if mergedConfig.Verbose != true {
 		t.Error("Verbose(overwritten by command line option) shoud be true")
+	}
+
+	if mergedConfig.DiagnosticMode != true {
+		t.Error("DiagnosticMode(overwritten by command line option) shoud be true")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,7 @@ func TestParseFlags(t *testing.T) {
 	confFile.WriteString(`verbose=false
 root="/hoge/fuga"
 apikey="DUMMYAPIKEY"
-diagnostic_mode=false
+diagnostic=false
 `)
 	confFile.Sync()
 	confFile.Close()
@@ -33,7 +33,7 @@ diagnostic_mode=false
 	t.Logf("       apikey: %v", mergedConfig.Apikey)
 	t.Logf("         root: %v", mergedConfig.Root)
 	t.Logf("      pidfile: %v", mergedConfig.Pidfile)
-	t.Logf("   diagnostic: %v", mergedConfig.DiagnosticMode)
+	t.Logf("   diagnostic: %v", mergedConfig.Diagnostic)
 	t.Logf("roleFullnames: %v", mergedConfig.Roles)
 	t.Logf("      verbose: %v", mergedConfig.Verbose)
 
@@ -49,8 +49,8 @@ diagnostic_mode=false
 		t.Error("Verbose(overwritten by command line option) shoud be true")
 	}
 
-	if mergedConfig.DiagnosticMode != true {
-		t.Error("DiagnosticMode(overwritten by command line option) shoud be true")
+	if mergedConfig.Diagnostic != true {
+		t.Error("Diagnostic(overwritten by command line option) shoud be true")
 	}
 }
 

--- a/metrics/agent.go
+++ b/metrics/agent.go
@@ -1,0 +1,26 @@
+package metrics
+
+import (
+	"runtime"
+)
+
+// AgentGenerator is generator of metrics
+// about the runnning agent itself
+type AgentGenerator struct {
+}
+
+var memStats = new(runtime.MemStats)
+
+// Generate generates the memory usage of the running agent itself
+func (g *AgentGenerator) Generate() (Values, error) {
+	runtime.ReadMemStats(memStats)
+
+	ret := map[string]float64{
+		"custom.agent.memory.alloc":     float64(memStats.Alloc),
+		"custom.agent.memory.sys":       float64(memStats.Sys),
+		"custom.agent.memory.heapAlloc": float64(memStats.HeapAlloc),
+		"custom.agent.memory.heapSys":   float64(memStats.HeapSys),
+	}
+
+	return ret, nil
+}

--- a/metrics/agent_test.go
+++ b/metrics/agent_test.go
@@ -1,0 +1,24 @@
+package metrics
+
+import (
+	"testing"
+)
+
+func TestAgentGenerate(t *testing.T) {
+	g := &AgentGenerator{}
+	values, _ := g.Generate()
+
+	agentMetricNames := []string{
+		"custom.agent.memory.alloc", "custom.agent.memory.sys",
+		"custom.agent.memory.heapAlloc", "custom.agent.memory.heapSys",
+	}
+
+	for _, name := range agentMetricNames {
+		value, ok := values[name]
+		if !ok {
+			t.Errorf("AgentGenerator should generate metric value for '%s'", name)
+		} else {
+			t.Logf("Agent Status '%s' collected: %+v", name, value)
+		}
+	}
+}


### PR DESCRIPTION
To avoid memory leaks, investigating memory usage of the agent should be available.

This PR  includes a metrics generator that collects metrics of memory usage of the agent. Those metrics are sent as custom metrics. This functionality is can be turned on by putting `diagnostic_mode` configuration to the agent config file. 