### PR TITLE
Add mkr to deb/rpm package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,16 +50,22 @@ crossbuild: deps
 cover: deps
 	tool/cover.sh
 
-rpm:
+rpm: mkr
 	GOOS=linux GOARCH=386 make build
 	cp mackerel-agent.sample.conf packaging/rpm/src/mackerel-agent.conf
 	rpmbuild --define "_sourcedir `pwd`/packaging/rpm/src" --define "_builddir `pwd`/build" -ba packaging/rpm/mackerel-agent.spec
 
-deb:
+deb: mkr
 	GOOS=linux GOARCH=386 make build
-	cp build/$(BIN)        packaging/deb/debian/mackerel-agent.bin
+	cp build/$(BIN)               packaging/deb/debian/mackerel-agent.bin
+	cp build/mkr                  packaging/deb/debian/mkr.bin
 	cp mackerel-agent.sample.conf packaging/deb/debian/mackerel-agent.conf
 	cd packaging/deb && debuild --no-tgz-check -rfakeroot -uc -us
+
+mkr:
+	mkdir -p build
+	curl -Ls -o build/mkr https://github.com/mackerelio/mkr/releases/download/v0.1.0/mkr_linux_386
+	chmod +x build/mkr
 
 release:
 	tool/releng
@@ -68,4 +74,4 @@ clean:
 	rm -f build/$(BIN)
 	go clean
 
-.PHONY: test build run deps clean lint crossbuild cover rpm deb
+.PHONY: test build run deps clean lint crossbuild cover rpm deb mkr

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -10,6 +10,7 @@ override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/${package}/usr/local/bin/
 	install    -m 655 debian/${package}.bin  debian/${package}/usr/local/bin/${package}
+	install    -m 655 debian/mkr.bin  debian/${package}/usr/local/bin/mkr
 	install -d -m 755 debian/${package}/etc/init.d/
 	install    -m 755 debian/${package}.initd debian/${package}/etc/init.d/${package}
 	install -d -m 755 debian/${package}/etc/logrotate.d/

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -33,6 +33,7 @@ mackerel.io agent beta
 rm -rf %{buildroot}
 install -d -m 755 %{buildroot}/%{_localbindir}
 install    -m 655 %{_builddir}/%{name}  %{buildroot}/%{_localbindir}
+install    -m 655 %{_builddir}/mkr  %{buildroot}/%{_localbindir}
 
 install -d -m 755 %{buildroot}/%{_localstatedir}/log/
 
@@ -66,6 +67,7 @@ fi
 %defattr(-,root,root)
 %{_initrddir}/%{name}
 %{_localbindir}/%{name}
+%{_localbindir}/mkr
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %config(noreplace) %{_sysconfdir}/mackerel-agent/%{name}.conf
 %{_sysconfdir}/logrotate.d/%{name}


### PR DESCRIPTION
I want to include mkr into deb/rpm package.
Because some operation with mkr on server that is installed mackerel-agent. 
(check status, retire and so on)

