### PR TITLE
Release version 0.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.16.1-1.noarch.rpm
-  - packaging/mackerel-agent_0.16.1-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.17.0-1.noarch.rpm
+  - packaging/mackerel-agent_0.17.0-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.17.0 (2015-06-10)
+
+* Set `displayName` via agent #92 (Sixeight)
+* refactoring around api access #97 (Songmu)
+* Configurable host status on start/stop agent #100 (Songmu)
+* Add an agent memory usage metrics generator for diagnostic use #101 (hakobe)
+* Add mkr to deb/rpm package #102 (Sixeight)
+
+
 ## 0.16.1 (2015-05-12)
 
 * Code sharing around dfValues #85 (Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent (0.17.0-1) stable; urgency=low
+
+  * Set `displayName` via agent (by Sixeight)
+    <https://github.com/mackerelio/mackerel-agent/pull/92>
+  * refactoring around api access (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/97>
+  * Configurable host status on start/stop agent (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/100>
+  * Add an agent memory usage metrics generator for diagnostic use (by hakobe)
+    <https://github.com/mackerelio/mackerel-agent/pull/101>
+  * Add mkr to deb/rpm package (by Sixeight)
+    <https://github.com/mackerelio/mackerel-agent/pull/102>
+
+ -- Tomohiro Nishimura <tomohiro68@gmail.com>  Wed, 10 Jun 2015 12:14:33 +0900
+
 mackerel-agent (0.16.1-1) stable; urgency=low
 
   * Code sharing around dfValues (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -73,6 +73,13 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Wed Jun 10 2015 <tomohiro68@gmail.com> - 0.17.0-1
+- Set `displayName` via agent (by Sixeight)
+- refactoring around api access (by Songmu)
+- Configurable host status on start/stop agent (by Songmu)
+- Add an agent memory usage metrics generator for diagnostic use (by hakobe)
+- Add mkr to deb/rpm package (by Sixeight)
+
 * Tue May 12 2015 <y.songmu@gmail.com> - 0.16.1-1
 - Code sharing around dfValues (by Songmu)
 - [FreeBSD] Fix 'panic: runtime error: index out of range'. (by iwadon)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.16.1
+Version:   0.17.0
 Release:   1
 License:   Commercial
 Summary:   macekrel.io agent


### PR DESCRIPTION
- Set `displayName` via agent #92
- refactoring around api access #97
- Configurable host status on start/stop agent #100
- Add an agent memory usage metrics generator for diagnostic use #101
- Add mkr to deb/rpm package #102