### PR TITLE
[WORKAROUND] downgrade golang version for windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ install:
   - echo %Path%
   - choco install ruby
   - rd c:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.4.2.windows-amd64.zip
-  - 7z x go1.4.2.windows-amd64.zip -oC:\ >nul
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.3.3.windows-amd64.zip
+  - 7z x go1.3.3.windows-amd64.zip -oC:\ >nul
   - go version
   - go env
   - env

--- a/command/command.go
+++ b/command/command.go
@@ -174,7 +174,7 @@ func loop(c *context, termCh chan struct{}) int {
 
 	// fan-out termCh
 	go func() {
-		for range termCh {
+		for _ = range termCh {
 			termCheckerCh <- struct{}{}
 			termMetricsCh <- struct{}{}
 		}
@@ -426,7 +426,7 @@ func runCheckersLoop(c *context, termCheckerCh <-chan struct{}, quit <-chan stru
 	} else {
 		// consume termCheckerCh
 		go func() {
-			for range termCheckerCh {
+			for _ = range termCheckerCh {
 			}
 		}()
 	}


### PR DESCRIPTION
We have a some problem with go 1.4.2 on windows agent.
Thus, I propose temporary fix that using go 1.3.3 for windows build.

