### PR TITLE
allow using spaces as delimiter for split custom metric values

### DIFF
--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -212,6 +212,8 @@ func (g *pluginGenerator) makeCreateGraphDefsPayload() []mackerel.CreateGraphDef
 	return payloads
 }
 
+var delimReg = regexp.MustCompile(`[\s\t]+`)
+
 func (g *pluginGenerator) collectValues() (Values, error) {
 	command := g.Config.Command
 	pluginLogger.Debugf("Executing plugin: command = \"%s\"", command)
@@ -228,7 +230,7 @@ func (g *pluginGenerator) collectValues() (Values, error) {
 	for _, line := range strings.Split(stdout, "\n") {
 		// Key, value, timestamp
 		// ex.) tcp.CLOSING 0 1397031808
-		items := strings.Split(line, "\t")
+		items := delimReg.Split(line, 3)
 		if len(items) != 3 {
 			continue
 		}

--- a/metrics/plugin_test.go
+++ b/metrics/plugin_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux darwin freebsd
 
 package metrics
 
@@ -68,6 +68,30 @@ func TestPluginCollectValuesCommand(t *testing.T) {
 			t.Errorf("Wrong name: %s", name)
 		}
 		if value != 1.0 {
+			t.Errorf("Wrong value: %+v", value)
+		}
+	}
+}
+
+func TestPluginCollectValuesCommandWithSpaces(t *testing.T) {
+	g := &pluginGenerator{Config: config.PluginConfig{
+		Command: `echo "just.echo.2   2   1397822016"`,
+	}}
+
+	values, err := g.collectValues()
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+
+	if len(values) != 1 {
+		t.Error("Only 1 value shoud be generated")
+	}
+
+	for name, value := range values {
+		if name != "custom.just.echo.2" {
+			t.Errorf("Wrong name: %s", name)
+		}
+		if value != 2.0 {
 			t.Errorf("Wrong value: %+v", value)
 		}
 	}

--- a/metrics/windows/plugin.go
+++ b/metrics/windows/plugin.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -43,6 +44,8 @@ func (g *PluginGenerator) Generate() (metrics.Values, error) {
 	return results, nil
 }
 
+var delimReg = regexp.MustCompile(`[\s\t]+`)
+
 func (g *PluginGenerator) collectValues(command string) (metrics.Values, error) {
 	pluginLogger.Debugf("Executing plugin: command = \"%s\"", command)
 
@@ -63,7 +66,7 @@ func (g *PluginGenerator) collectValues(command string) (metrics.Values, error) 
 	for _, line := range strings.Split(string(outBuffer.Bytes()), "\n") {
 		// Key, value, timestamp
 		// ex.) localhost.localdomain.tcp.CLOSING 0 1397031808
-		items := strings.Split(line, "\t")
+		items := delimReg.Split(line, 3)
 		if len(items) != 3 {
 			continue
 		}


### PR DESCRIPTION
fix #118