### PR TITLE
Release version 0.18.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.18.0-1.noarch.rpm
-  - packaging/mackerel-agent_0.18.0-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.18.1-1.noarch.rpm
+  - packaging/mackerel-agent_0.18.1-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.18.1 (2015-07-16)
+
+* s/ami_id/ami-id/ in spec/cloud.go #112 (Songmu)
+* remove `UpdateHost()` process from `prepareHost()` for simplicity #116 (Songmu)
+* filter invalid roleFullNames with warning logs #117 (Songmu)
+* allow using spaces as delimiter for custom metric values #119 (Songmu)
+
+
 ## 0.18.0 (2015-07-08)
 
 * Retry in prepare #108 (Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,16 @@
+mackerel-agent (0.18.1-1) stable; urgency=low
+
+  * s/ami_id/ami-id/ in spec/cloud.go (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/112>
+  * remove `UpdateHost()` process from `prepareHost()` for simplicity (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/116>
+  * filter invalid roleFullNames with warning logs (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/117>
+  * allow using spaces as delimiter for custom metric values (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/119>
+
+ -- Songmu <y.songmu@gmail.com>  Thu, 16 Jul 2015 17:05:43 +0900
+
 mackerel-agent (0.18.0-1) stable; urgency=low
 
   * Retry in prepare (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -73,6 +73,12 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Thu Jul 16 2015 <y.songmu@gmail.com> - 0.18.1-1
+- s/ami_id/ami-id/ in spec/cloud.go (by Songmu)
+- remove `UpdateHost()` process from `prepareHost()` for simplicity (by Songmu)
+- filter invalid roleFullNames with warning logs (by Songmu)
+- allow using spaces as delimiter for custom metric values (by Songmu)
+
 * Wed Jul 08 2015 <tomohiro68@gmail.com> - 0.18.0-1
 - Retry in prepare (by Songmu)
 - [WORKAROUND] downgrade golang version for windows (by Sixeight)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.18.0
+Version:   0.18.1
 Release:   1
 License:   Commercial
 Summary:   macekrel.io agent


### PR DESCRIPTION
- s/ami_id/ami-id/ in spec/cloud.go #112
- remove `UpdateHost()` process from `prepareHost()` for simplicity #116
- filter invalid roleFullNames with warning logs #117
- allow using spaces as delimiter for custom metric values #119