### PR TITLE
Release version 0.19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.18.1-1.noarch.rpm
-  - packaging/mackerel-agent_0.18.1-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.19.0-1.noarch.rpm
+  - packaging/mackerel-agent_0.19.0-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.19.0 (2015-07-22)
+
+* Support gce meta #115 (Songmu)
+* Valid pidfile handling (fix on darwin) #123 (Songmu)
+* -once only takes one second #126 (Songmu)
+* fix shutdown priority in rpm/src/mackerel-agent.initd #127 (Songmu)
+
+
 ## 0.18.1 (2015-07-16)
 
 * s/ami_id/ami-id/ in spec/cloud.go #112 (Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,16 @@
+mackerel-agent (0.19.0-1) stable; urgency=low
+
+  * Support gce meta (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/115>
+  * Valid pidfile handling (fix on darwin) (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/123>
+  * -once only takes one second (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/126>
+  * fix shutdown priority in rpm/src/mackerel-agent.initd (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/127>
+
+ -- Songmu <y.songmu@gmail.com>  Wed, 22 Jul 2015 17:40:14 +0900
+
 mackerel-agent (0.18.1-1) stable; urgency=low
 
   * s/ami_id/ami-id/ in spec/cloud.go (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -73,6 +73,12 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Wed Jul 22 2015 <y.songmu@gmail.com> - 0.19.0-1
+- Support gce meta (by Songmu)
+- Valid pidfile handling (fix on darwin) (by Songmu)
+- -once only takes one second (by Songmu)
+- fix shutdown priority in rpm/src/mackerel-agent.initd (by Songmu)
+
 * Thu Jul 16 2015 <y.songmu@gmail.com> - 0.18.1-1
 - s/ami_id/ami-id/ in spec/cloud.go (by Songmu)
 - remove `UpdateHost()` process from `prepareHost()` for simplicity (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.18.1
+Version:   0.19.0
 Release:   1
 License:   Commercial
 Summary:   macekrel.io agent


### PR DESCRIPTION
- Support gce meta #115
- Valid pidfile handling (fix on darwin) #123
- -once only takes one second #126
- fix shutdown priority in rpm/src/mackerel-agent.initd #127