### PR TITLE
add postinst to register mackerel-agent to start-up (deb package)

### DIFF
--- a/packaging/deb/debian/postinst
+++ b/packaging/deb/debian/postinst
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+
+# summary of how this script can be called:
+#        * <postinst> `configure' <most-recently-configured-version>
+#        * <old-postinst> `abort-upgrade' <new version>
+#        * <conflictor's-postinst> `abort-remove' `in-favour' <package>
+#          <new-version>
+#        * <postinst> `abort-remove'
+#        * <deconfigured's-postinst> `abort-deconfigure' `in-favour'
+#          <failed-install-package> <version> `removing'
+#          <conflicting-package> <version>
+# for details, see http://www.debian.org/doc/debian-policy/ or
+# the debian-policy package
+
+case "$1" in
+
+  configure)
+    update-rc.d mackerel-agent defaults
+    update-rc.d mackerel-agent enable >/dev/null 2>&1
+  ;;
+
+  abort-upgrade|abort-remove|abort-deconfigure)
+    exit 0
+  ;;
+
+  *)
+    echo "postinst called with unknown argument \`$1'" >&2
+    exit 1
+  ;;
+
+esac


### PR DESCRIPTION
With current deb package, mackerel-agent will not start after rebooting.
This pullreq add `postinst` file for mackerel-agent to startup.
