### PR TITLE
Release version 0.20.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.19.0-1.noarch.rpm
-  - packaging/mackerel-agent_0.19.0-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.20.0-1.noarch.rpm
+  - packaging/mackerel-agent_0.20.0-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.20.0 (2015-07-29)
+
+* support subcommand #122 (Songmu)
+* remove trailing newline chars when loading hostID #129 (Songmu)
+* add sub-command `retire` and support $AUTO_RETIREMENT in initd #130 (Songmu)
+* add postinst to register mackerel-agent to start-up (deb package) #131 (stanaka)
+* bump bundled mkr version to 0.3.1 #132 (Songmu)
+
+
 ## 0.19.0 (2015-07-22)
 
 * Support gce meta #115 (Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent (0.20.0-1) stable; urgency=low
+
+  * support subcommand (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/122>
+  * remove trailing newline chars when loading hostID (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/129>
+  * add sub-command `retire` and support $AUTO_RETIREMENT in initd (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/130>
+  * add postinst to register mackerel-agent to start-up (deb package) (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent/pull/131>
+  * bump bundled mkr version to 0.3.1 (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/132>
+
+ -- Songmu <y.songmu@gmail.com>  Wed, 29 Jul 2015 14:42:44 +0900
+
 mackerel-agent (0.19.0-1) stable; urgency=low
 
   * Support gce meta (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.19.0
+Version:   0.20.0
 Release:   1
 License:   Commercial
 Summary:   macekrel.io agent

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -73,6 +73,13 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Wed Jul 29 2015 <y.songmu@gmail.com> - 0.20.0-1
+- support subcommand (by Songmu)
+- remove trailing newline chars when loading hostID (by Songmu)
+- add sub-command `retire` and support $AUTO_RETIREMENT in initd (by Songmu)
+- add postinst to register mackerel-agent to start-up (deb package) (by stanaka)
+- bump bundled mkr version to 0.3.1 (by Songmu)
+
 * Wed Jul 22 2015 <y.songmu@gmail.com> - 0.19.0-1
 - Support gce meta (by Songmu)
 - Valid pidfile handling (fix on darwin) (by Songmu)


### PR DESCRIPTION
- support subcommand #122
- remove trailing newline chars when loading hostID #129
- add sub-command `retire` and support $AUTO_RETIREMENT in initd #130
- add postinst to register mackerel-agent to start-up (deb package) #131
- bump bundled mkr version to 0.3.1 #132