### PR TITLE
use C struct for accessing Windows APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ deploy:
   - snapshot/mackerel-agent_linux_386.tar.gz
   - snapshot/mackerel-agent_linux_amd64.tar.gz
   - snapshot/mackerel-agent_linux_arm.tar.gz
-  - snapshot/mackerel-agent_windows_386.zip
-  - snapshot/mackerel-agent_windows_amd64.zip
   skip_cleanup: true
   on:
     repo: mackerelio/mackerel-agent

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lint: deps
 crossbuild: deps
 	cp mackerel-agent.sample.conf mackerel-agent.conf
 	goxc -build-ldflags=$(BUILD_LDFLAGS) \
-	    -os=$(BUILD_OS_TARGETS) -arch="386 amd64 arm" -d . \
+	    -os="linux darwin freebsd" -arch="386 amd64 arm" -d . \
 	    -resources-include='README*,mackerel-agent.conf' -n $(BIN) \
 	    -main-dirs-exclude ./wix
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,10 @@ install:
   - echo %Path%
   - choco install ruby
   - rd c:\go /s /q
-  - choco install mingw
-  - set PATH=%PATH%;C:\tools\mingw64\bin
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.4.2.windows-amd64.zip
-  - 7z x go1.4.2.windows-amd64.zip -oC:\ >nul
+  #- choco install mingw
+  - set PATH=%PATH%;C:\MinGW\bin
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.4.2.windows-386.zip
+  - 7z x go1.4.2.windows-386.zip -oC:\ >nul
   - go version
   - go env
   - env

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - echo %Path%
   - choco install ruby
   - rd c:\go /s /q
-  - choco install mingw-w64
+  - choco install mingw
   - set PATH=%PATH%;C:\tools\mingw64\bin
   - appveyor DownloadFile https://storage.googleapis.com/golang/go1.3.3.windows-amd64.zip
   - 7z x go1.3.3.windows-amd64.zip -oC:\ >nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,9 @@ install:
   - echo %Path%
   - choco install ruby
   - rd c:\go /s /q
+  - cinst mingw-get
+  - set PATH=%PATH%;C:\MinGW\msys\1.0\bin;C:\MinGW\bin
+  - mingw-get install mingw-developer-toolkit
   - appveyor DownloadFile https://storage.googleapis.com/golang/go1.3.3.windows-amd64.zip
   - 7z x go1.3.3.windows-amd64.zip -oC:\ >nul
   - go version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,8 @@ install:
   - rd c:\go /s /q
   - choco install mingw
   - set PATH=%PATH%;C:\tools\mingw64\bin
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.3.3.windows-amd64.zip
-  - 7z x go1.3.3.windows-amd64.zip -oC:\ >nul
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.4.2.windows-amd64.zip
+  - 7z x go1.4.2.windows-amd64.zip -oC:\ >nul
   - go version
   - go env
   - env

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,8 @@ install:
   - echo %Path%
   - choco install ruby
   - rd c:\go /s /q
-  - cinst mingw-get
-  - set PATH=%PATH%;C:\MinGW\msys\1.0\bin;C:\MinGW\bin
-  - mingw-get install mingw-developer-toolkit
+  - choco install mingw-w64
+  - set PATH=%PATH%;C:\tools\mingw64\bin
   - appveyor DownloadFile https://storage.googleapis.com/golang/go1.3.3.windows-amd64.zip
   - 7z x go1.3.3.windows-amd64.zip -oC:\ >nul
   - go version

--- a/command/command.go
+++ b/command/command.go
@@ -203,7 +203,7 @@ func loop(c *Context, termCh chan struct{}) int {
 
 	// fan-out termCh
 	go func() {
-		for _ = range termCh {
+		for range termCh {
 			termCheckerCh <- struct{}{}
 			termMetricsCh <- struct{}{}
 		}
@@ -456,7 +456,7 @@ func runCheckersLoop(c *Context, termCheckerCh <-chan struct{}, quit <-chan stru
 	} else {
 		// consume termCheckerCh
 		go func() {
-			for _ = range termCheckerCh {
+			for range termCheckerCh {
 			}
 		}()
 	}

--- a/metrics/windows/cpuusage.go
+++ b/metrics/windows/cpuusage.go
@@ -4,7 +4,6 @@ package windows
 
 import (
 	"syscall"
-	"unsafe"
 
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
@@ -68,12 +67,10 @@ func (g *CPUUsageGenerator) Generate() (metrics.Values, error) {
 
 	results := make(map[string]float64)
 	for _, v := range g.counters {
-		var fmtValue windows.PDH_FMT_COUNTERVALUE_DOUBLE
-		r, _, err := windows.PdhGetFormattedCounterValue.Call(uintptr(v.Counter), windows.PDH_FMT_DOUBLE, uintptr(0), uintptr(unsafe.Pointer(&fmtValue)))
-		if r != 0 && r != windows.PDH_INVALID_DATA {
+		results[v.PostName], err = windows.GetCounterValue(v.Counter)
+		if err != nil {
 			return nil, err
 		}
-		results[v.PostName] = fmtValue.DoubleValue
 	}
 
 	cpuUsageLogger.Debugf("cpuusage: %q", results)

--- a/metrics/windows/disk.go
+++ b/metrics/windows/disk.go
@@ -102,12 +102,10 @@ func (g *DiskGenerator) Generate() (metrics.Values, error) {
 
 	results := make(map[string]float64)
 	for _, v := range g.counters {
-		var fmtValue windows.PDH_FMT_COUNTERVALUE_DOUBLE
-		r, _, err := windows.PdhGetFormattedCounterValue.Call(uintptr(v.Counter), windows.PDH_FMT_DOUBLE, uintptr(0), uintptr(unsafe.Pointer(&fmtValue)))
-		if r != 0 && r != windows.PDH_INVALID_DATA {
+		results[v.PostName], err = windows.GetCounterValue(v.Counter)
+		if err != nil {
 			return nil, err
 		}
-		results[v.PostName] = fmtValue.DoubleValue
 	}
 
 	diskLogger.Debugf("%q", results)

--- a/metrics/windows/interface.go
+++ b/metrics/windows/interface.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-	"unsafe"
 
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
@@ -107,12 +106,10 @@ func (g *InterfaceGenerator) Generate() (metrics.Values, error) {
 
 	results := make(map[string]float64)
 	for _, v := range g.counters {
-		var fmtValue windows.PDH_FMT_COUNTERVALUE_DOUBLE
-		r, _, err := windows.PdhGetFormattedCounterValue.Call(uintptr(v.Counter), windows.PDH_FMT_DOUBLE, uintptr(0), uintptr(unsafe.Pointer(&fmtValue)))
-		if r != 0 && r != windows.PDH_INVALID_DATA {
+		results[v.PostName], err = windows.GetCounterValue(v.Counter)
+		if err != nil {
 			return nil, err
 		}
-		results[v.PostName] = fmtValue.DoubleValue
 	}
 
 	interfaceLogger.Debugf("%q", results)

--- a/metrics/windows/processor_queue_length.go
+++ b/metrics/windows/processor_queue_length.go
@@ -4,7 +4,6 @@ package windows
 
 import (
 	"syscall"
-	"unsafe"
 
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
@@ -53,12 +52,10 @@ func (g *ProcessorQueueLengthGenerator) Generate() (metrics.Values, error) {
 
 	results := make(map[string]float64)
 	for _, v := range g.counters {
-		var fmtValue windows.PDH_FMT_COUNTERVALUE_DOUBLE
-		r, _, err := windows.PdhGetFormattedCounterValue.Call(uintptr(v.Counter), windows.PDH_FMT_DOUBLE, uintptr(0), uintptr(unsafe.Pointer(&fmtValue)))
-		if r != 0 && r != windows.PDH_INVALID_DATA {
+		results[v.PostName], err = windows.GetCounterValue(v.Counter)
+		if err != nil {
 			return nil, err
 		}
-		results[v.PostName] = fmtValue.DoubleValue
 	}
 
 	processorQueueLengthLogger.Debugf("processor_queue_length: %q", results)

--- a/util/windows/windows_api.go
+++ b/util/windows/windows_api.go
@@ -179,6 +179,7 @@ func CreateCounter(query syscall.Handle, k, v string) (*CounterInfo, error) {
 	}, nil
 }
 
+// GetCounterValue get counter value from handle
 func GetCounterValue(counter syscall.Handle) (float64, error) {
 	var value C.PDH_FMT_COUNTERVALUE_DOUBLE
 	r, _, err := PdhGetFormattedCounterValue.Call(uintptr(counter), PDH_FMT_DOUBLE, uintptr(0), uintptr(unsafe.Pointer(&value)))

--- a/util/windows/windows_api.go
+++ b/util/windows/windows_api.go
@@ -8,6 +8,17 @@ import (
 	"unsafe"
 )
 
+/*
+//#include <pdh.h>
+typedef unsigned long DWORD;
+// Union specialization for double values
+typedef struct _PDH_FMT_COUNTERVALUE_DOUBLE {
+	DWORD  CStatus;
+	double DoubleValue;
+} PDH_FMT_COUNTERVALUE_DOUBLE;
+*/
+import "C"
+
 // SYSTEM_INFO XXX
 type SYSTEM_INFO struct {
 	ProcessorArchitecture     uint16
@@ -166,6 +177,15 @@ func CreateCounter(query syscall.Handle, k, v string) (*CounterInfo, error) {
 		CounterName: v,
 		Counter:     counter,
 	}, nil
+}
+
+func GetCounterValue(counter syscall.Handle) (float64, error) {
+	var value C.PDH_FMT_COUNTERVALUE_DOUBLE
+	r, _, err := PdhGetFormattedCounterValue.Call(uintptr(counter), PDH_FMT_DOUBLE, uintptr(0), uintptr(unsafe.Pointer(&value)))
+	if r != 0 && r != PDH_INVALID_DATA {
+		return 0.0, err
+	}
+	return float64(value.DoubleValue), nil
 }
 
 // GetAdapterList XXX


### PR DESCRIPTION
Using a pointer of Go struct as an argument of Windows API causes panic. To fix this, C struct should be used.

This pull request provides a helper method to retrieve a value with C struct of Windows API, and changes to use it, not to use methods with Go struct.

ref. https://github.com/lxn/win/issues/12