### PR TITLE
Correct sample nginx comment.

### DIFF
--- a/mackerel-agent.sample.conf
+++ b/mackerel-agent.sample.conf
@@ -66,7 +66,7 @@
 # command = "/usr/local/bin/mackerel-plugin-mysql"
 
 # Plugin for Nginx
-#   By default, the plugin accesses to http://localhost/nginx_status
+#   By default, the plugin accesses to http://localhost:8080/nginx_status
 # [plugin.metrics.nginx]
 # command = "/usr/local/bin/mackerel-plugin-nginx"
 


### PR DESCRIPTION
At the mackerel-plugin-nginx, the default value of `port` is [8080](https://github.com/mackerelio/mackerel-agent-plugins/blob/master/mackerel-plugin-nginx/nginx.go#L173).