### PR TITLE
Release version 0.23.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.22.0-1.noarch.rpm
-  - packaging/mackerel-agent_0.22.0-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.23.0-1.noarch.rpm
+  - packaging/mackerel-agent_0.23.0-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.23.0 (2015-09-14)
+
+* send check monitor report to server when check script failed even if the monitor result is not changed #143 (Songmu)
+* Correct sample nginx comment. #144 (kamatama41)
+
+
 ## 0.22.0 (2015-09-02)
 
 * add `reload` to init scripts #139 (Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.23.0-1) stable; urgency=low
+
+  * send check monitor report to server when check script failed even if the monitor result is not changed (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/143>
+  * Correct sample nginx comment. (by kamatama41)
+    <https://github.com/mackerelio/mackerel-agent/pull/144>
+
+ -- itchyny <itchyny@hatena.ne.jp>  Mon, 14 Sep 2015 11:36:02 +0900
+
 mackerel-agent (0.22.0-1) stable; urgency=low
 
   * add `reload` to init scripts (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.22.0
+Version:   0.23.0
 Release:   1
 License:   Commercial
 Summary:   macekrel.io agent

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -71,6 +71,10 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Mon Sep 14 2015 <itchyny@hatena.ne.jp> - 0.23.0-1
+- send check monitor report to server when check script failed even if the monitor result is not changed (by Songmu)
+- Correct sample nginx comment. (by kamatama41)
+
 * Wed Sep 02 2015 <tomohiro68@gmail.com> - 0.22.0-1
 - add `reload` to init scripts (by Songmu)
 


### PR DESCRIPTION
- send check monitor report to server when check script failed even if the monitor result is not changed #143
- Correct sample nginx comment. #144