### PR TITLE
/proc/cpuinfo parser for old ARM Linux kernels

### DIFF
--- a/spec/linux/cpu.go
+++ b/spec/linux/cpu.go
@@ -4,6 +4,7 @@ package linux
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"regexp"
 
@@ -21,24 +22,24 @@ func (g *CPUGenerator) Key() string {
 
 var cpuLogger = logging.GetLogger("spec.cpu")
 
-// Generate XXX
-func (g *CPUGenerator) Generate() (interface{}, error) {
-	file, err := os.Open("/proc/cpuinfo")
-	if err != nil {
-		cpuLogger.Errorf("Failed (skip this spec): %s", err)
-		return nil, err
-	}
-
+func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
 	scanner := bufio.NewScanner(file)
 
 	var results []map[string]interface{}
 	var cur map[string]interface{}
+	var modelName string
+
 	for scanner.Scan() {
 		line := scanner.Text()
 
 		if matches := regexp.MustCompile(`^processor\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
 			cur = make(map[string]interface{})
+			if modelName != "" {
+				cur["model_name"] = modelName
+			}
 			results = append(results, cur)
+		} else if matches := regexp.MustCompile(`^Processor\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
+			modelName = matches[1]
 		} else if matches := regexp.MustCompile(`^vendor_id\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
 			cur["vendor_id"] = matches[1]
 		} else if matches := regexp.MustCompile(`^cpu family\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
@@ -68,5 +69,24 @@ func (g *CPUGenerator) Generate() (interface{}, error) {
 		return nil, err
 	}
 
+	// Old kernels with CONFIG_SMP disabled has no "processor: " line
+	if len(results) == 0 && modelName != "" {
+		cur = make(map[string]interface{})
+		cur["model_name"] = modelName
+		results = append(results, cur)
+	}
+
 	return results, nil
+}
+
+// Generate XXX
+func (g *CPUGenerator) Generate() (interface{}, error) {
+	file, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		cpuLogger.Errorf("Failed (skip this spec): %s", err)
+		return nil, err
+	}
+	defer file.Close()
+
+	return g.generate(file)
 }

--- a/spec/linux/cpu_test.go
+++ b/spec/linux/cpu_test.go
@@ -3,6 +3,7 @@
 package linux
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -69,5 +70,254 @@ func TestCPUGenerate(t *testing.T) {
 	}
 	if _, ok := cpu1["flags"].([]string); !ok {
 		t.Error("cpu.flags should be slice of string")
+	}
+}
+
+func TestCPUgenerate_linux4_0_amd64(t *testing.T) {
+	cpuinfo := `processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 2
+model name	: QEMU Virtual CPU version 1.1.2
+stepping	: 3
+microcode	: 0x1
+cpu MHz		: 3392.292
+cache size	: 4096 KB
+physical id	: 0
+siblings	: 1
+core id		: 0
+cpu cores	: 1
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 4
+wp		: yes
+flags		: fpu de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pse36 clflush mmx fxsr sse sse2 syscall nx lm rep_good nopl pni cx16 popcnt hypervisor lahf_lm
+bugs		:
+bogomips	: 6784.58
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 40 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 2
+model name	: QEMU Virtual CPU version 1.1.2
+stepping	: 3
+microcode	: 0x1
+cpu MHz		: 3392.292
+cache size	: 4096 KB
+physical id	: 1
+siblings	: 1
+core id		: 0
+cpu cores	: 1
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 4
+wp		: yes
+flags		: fpu de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pse36 clflush mmx fxsr sse sse2 syscall nx lm rep_good nopl pni cx16 popcnt hypervisor lahf_lm
+bugs		:
+bogomips	: 6784.58
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 40 bits physical, 48 bits virtual
+power management:`
+
+	g := &CPUGenerator{}
+	value, err := g.generate(bytes.NewBufferString(cpuinfo))
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+
+	cpus, typeOk := value.([]map[string]interface{})
+	if !typeOk {
+		t.Errorf("value should be slice of map. %+v", value)
+	}
+
+	if len(cpus) != 2 {
+		t.Fatal("should have exactly 2 cpus")
+	}
+
+	for _, cpu := range cpus {
+		modelName, ok := cpu["model_name"]
+		if !ok {
+			t.Error("cpu should have model_name")
+		}
+		if modelName != "QEMU Virtual CPU version 1.1.2" {
+			t.Error("cpu should have correct model_name")
+		}
+
+		mhz, ok := cpu["mhz"]
+		if !ok {
+			t.Error("cpu should have mhz")
+		}
+		if mhz != "3392.292" {
+			t.Error("cpu should have correct mhz")
+		}
+	}
+}
+
+func TestCPUgenerate_linux3_18_arm(t *testing.T) {
+	cpuinfo := `processor       : 0
+model name      : ARMv7 Processor rev 5 (v7l)
+BogoMIPS        : 38.40
+Features        : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant     : 0x0
+CPU part        : 0xc07
+CPU revision    : 5
+
+processor       : 1
+model name      : ARMv7 Processor rev 5 (v7l)
+BogoMIPS        : 38.40
+Features        : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant     : 0x0
+CPU part        : 0xc07
+CPU revision    : 5
+
+processor       : 2
+model name      : ARMv7 Processor rev 5 (v7l)
+BogoMIPS        : 38.40
+Features        : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant     : 0x0
+CPU part        : 0xc07
+CPU revision    : 5
+
+processor       : 3
+model name      : ARMv7 Processor rev 5 (v7l)
+BogoMIPS        : 38.40
+Features        : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant     : 0x0
+CPU part        : 0xc07
+CPU revision    : 5
+
+Hardware        : BCM2709
+Revision        : 1a01040`
+
+	g := &CPUGenerator{}
+	value, err := g.generate(bytes.NewBufferString(cpuinfo))
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+
+	cpus, typeOk := value.([]map[string]interface{})
+	if !typeOk {
+		t.Errorf("value should be slice of map. %+v", value)
+	}
+
+	if len(cpus) != 4 {
+		t.Fatal("should have exactly 4 cpus")
+	}
+
+	for _, cpu := range cpus {
+		modelName, ok := cpu["model_name"]
+		if !ok {
+			t.Error("cpu should have model_name")
+		}
+		if modelName != "ARMv7 Processor rev 5 (v7l)" {
+			t.Error("cpu should have correct model_name")
+		}
+	}
+}
+
+func TestCPUgenerate_linux3_4_smp_arm(t *testing.T) {
+	cpuinfo := `Processor       : ARMv7 Processor rev 0 (v7l)
+processor       : 0
+BogoMIPS        : 38.40
+
+processor       : 1
+BogoMIPS        : 38.40
+
+processor       : 2
+BogoMIPS        : 38.40
+
+processor       : 3
+BogoMIPS        : 38.40
+
+Features        : swp half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt
+CPU implementer : 0x51
+CPU architecture: 7
+CPU variant     : 0x2
+CPU part        : 0x06f
+CPU revision    : 0
+
+Hardware        : Qualcomm MSM 8974 (Flattened Device Tree)
+Revision        : 0000
+Serial          : 0000000000000000`
+
+	g := &CPUGenerator{}
+	value, err := g.generate(bytes.NewBufferString(cpuinfo))
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+
+	cpus, typeOk := value.([]map[string]interface{})
+	if !typeOk {
+		t.Errorf("value should be slice of map. %+v", value)
+	}
+
+	if len(cpus) != 4 {
+		t.Fatal("should have exactly 4 cpus")
+	}
+
+	for _, cpu := range cpus {
+		modelName, ok := cpu["model_name"]
+		if !ok {
+			t.Error("cpu should have model_name")
+		}
+		if modelName != "ARMv7 Processor rev 0 (v7l)" {
+			t.Error("cpu should have correct model_name")
+		}
+	}
+}
+
+func TestCPUgenerate_linux3_0_nosmp_arm(t *testing.T) {
+	cpuinfo := `Processor       : Marvell PJ4Bv7 Processor rev 1 (v7l)
+BogoMIPS        : 1196.85
+Features        : swp half thumb fastmult vfp edsp vfpv3 vfpv3d16
+CPU implementer : 0x56
+CPU architecture: 7
+CPU variant     : 0x1
+CPU part        : 0x581
+CPU revision    : 1
+
+Hardware        : Marvell Armada-370
+Revision        : 0000
+Serial          : 0000000000000000`
+
+	g := &CPUGenerator{}
+	value, err := g.generate(bytes.NewBufferString(cpuinfo))
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+
+	cpus, typeOk := value.([]map[string]interface{})
+	if !typeOk {
+		t.Errorf("value should be slice of map. %+v", value)
+	}
+
+	if len(cpus) != 1 {
+		t.Fatal("should have exactly 1 cpu")
+	}
+
+	cpu1 := cpus[0]
+	modelName, ok := cpu1["model_name"]
+	if !ok {
+		t.Error("cpu should have model_name")
+	}
+	if modelName != "Marvell PJ4Bv7 Processor rev 1 (v7l)" {
+		t.Error("cpu should have correct model_name")
 	}
 }


### PR DESCRIPTION
Linux kernels prior to 3.8 has a different format of /proc/cpuinfo for ARM processors
than that for x86 ones.

In those old kernels the format depends on the CONFIG_SMP kernel configuration.
With the configuration enabled, /proc/cpuinfo has a `Processor: ` line with the CPU's
modle name and a `processor: %d` line for each CPU cores.

With the configuration disabled (which implies that the kernel handles only one CPU),
/proc/cpuinfo has a `Processor: ` line with the CPU's model name and no `processor: ` line.

ref: https://github.com/torvalds/linux/commit/b4b8f770eb10a1bccaf8aa0ec1956e2dd7ed1e0a