### PR TITLE
Make HostID storage replacable

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -78,7 +78,10 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 			return filterErrorForRetry(lastErr)
 		})
 		if lastErr != nil {
-			return nil, fmt.Errorf("Failed to find this host on mackerel (You may want to delete file \"%s\" to register this host to an another organization): %s", conf.HostIDFile(), lastErr.Error())
+			if fsStorage, ok := conf.HostIDStorage.(*config.FileSystemHostIDStorage); ok {
+				return nil, fmt.Errorf("Failed to find this host on mackerel (You may want to delete file \"%s\" to register this host to an another organization): %s", fsStorage.HostIDFile(), lastErr.Error())
+			}
+			return nil, fmt.Errorf("Failed to find this host on mackerel: %s", lastErr.Error())
 		}
 	}
 

--- a/command/command.go
+++ b/command/command.go
@@ -4,11 +4,8 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/Songmu/retry"
@@ -25,52 +22,12 @@ import (
 var logger = logging.GetLogger("command")
 var metricsInterval = 60 * time.Second
 
-const idFileName = "id"
-
-func idFilePath(root string) string {
-	return filepath.Join(root, idFileName)
-}
-
-// LoadHostID loads hostID
-func LoadHostID(root string) (string, error) {
-	content, err := ioutil.ReadFile(idFilePath(root))
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimRight(string(content), "\r\n"), nil
-}
-
-// RemoveIDFile removes idfile
-func RemoveIDFile(root string) error {
-	return os.Remove(idFilePath(root))
-}
-
-func saveHostID(root string, id string) error {
-	err := os.MkdirAll(root, 0755)
-	if err != nil {
-		return err
-	}
-
-	file, err := os.Create(idFilePath(root))
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = file.Write([]byte(id))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 var retryNum uint = 20
 var retryInterval = 3 * time.Second
 
 // prepareHost collects specs of the host and sends them to Mackerel server.
 // A unique host-id is returned by the server if one is not specified.
-func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks []string, displayName string, hostSt string) (*mackerel.Host, error) {
+func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error) {
 	// XXX this configuration should be moved to under spec/linux
 	os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin:"+os.Getenv("PATH"))
 	os.Setenv("LANG", "C") // prevent changing outputs of some command, e.g. ifconfig.
@@ -96,11 +53,11 @@ func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks 
 	}
 
 	var result *mackerel.Host
-	if hostID, err := LoadHostID(root); err != nil { // create
+	if hostID, err := conf.LoadHostID(); err != nil { // create
 		logger.Debugf("Registering new host on mackerel...")
 
 		doRetry(func() error {
-			hostID, lastErr = api.CreateHost(hostname, meta, interfaces, roleFullnames, displayName)
+			hostID, lastErr = api.CreateHost(hostname, meta, interfaces, conf.Roles, conf.DisplayName)
 			return filterErrorForRetry(lastErr)
 		})
 
@@ -121,10 +78,11 @@ func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks 
 			return filterErrorForRetry(lastErr)
 		})
 		if lastErr != nil {
-			return nil, fmt.Errorf("Failed to find this host on mackerel (You may want to delete file \"%s\" to register this host to an another organization): %s", idFilePath(root), lastErr.Error())
+			return nil, fmt.Errorf("Failed to find this host on mackerel (You may want to delete file \"%s\" to register this host to an another organization): %s", conf.HostIDFile(), lastErr.Error())
 		}
 	}
 
+	hostSt := conf.HostStatus.OnStart
 	if hostSt != "" && hostSt != result.Status {
 		doRetry(func() error {
 			lastErr = api.UpdateHostStatus(result.ID, hostSt)
@@ -135,7 +93,7 @@ func prepareHost(root string, api *mackerel.API, roleFullnames []string, checks 
 		}
 	}
 
-	lastErr = saveHostID(root, result.ID)
+	lastErr = conf.SaveHostID(result.ID)
 	if lastErr != nil {
 		return nil, fmt.Errorf("Failed to save host ID: %s", lastErr.Error())
 	}
@@ -520,7 +478,7 @@ func Prepare(conf *config.Config) (*Context, error) {
 		return nil, fmt.Errorf("Failed to prepare an api: %s", err.Error())
 	}
 
-	host, err := prepareHost(conf.Root, api, conf.Roles, conf.CheckNames(), conf.DisplayName, conf.HostStatus.OnStart)
+	host, err := prepareHost(conf, api)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to prepare host: %s", err.Error())
 	}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -151,7 +151,7 @@ func TestPrepareWithUpdate(t *testing.T) {
 	defer ts.Close()
 	tempDir, _ := ioutil.TempDir("", "")
 	conf.Root = tempDir
-	saveHostID(tempDir, "xxx12345678901")
+	conf.SaveHostID("xxx12345678901")
 
 	mockHandlers["PUT /api/v0/hosts/xxx12345678901"] = func(req *http.Request) (int, jsonObject) {
 		return 200, jsonObject{

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,9 @@ type Config struct {
 
 	DeprecatedSensu map[string]PluginConfigs `toml:"sensu"` // DEPRECATED this is for backward compatibility
 	Include         string
+
+	// Cannot exist in configuration files
+	HostIDStorage HostIDStorage
 }
 
 // PluginConfigs represents a set of [plugin.<kind>.<name>] sections in the configuration file
@@ -213,29 +216,68 @@ func includeConfigFile(config *Config, include string) error {
 	return nil
 }
 
-const idFileName = "id"
-
-func (c Config) HostIDFile() string {
-	return filepath.Join(c.Root, idFileName)
+func (conf *Config) hostIDStorage() HostIDStorage {
+	if conf.HostIDStorage == nil {
+		conf.HostIDStorage = &FileSystemHostIDStorage{Root: conf.Root}
+	}
+	return conf.HostIDStorage
 }
 
-// LoadHostID loads the HostID of the host where the agent is running on.
-// The HostID is chosen and given by Mackerel on host registration.
-func (c Config) LoadHostID() (string, error) {
-	content, err := ioutil.ReadFile(c.HostIDFile())
+// LoadHostID loads the previously saved host id.
+func (conf *Config) LoadHostID() (string, error) {
+	return conf.hostIDStorage().LoadHostID()
+}
+
+// SaveHostID saves the host id, which may be restored by LoadHostID.
+func (conf *Config) SaveHostID(id string) error {
+	return conf.hostIDStorage().SaveHostID(id)
+}
+
+// DeleteSavedHostID deletes the host id saved by SaveHostID.
+func (conf *Config) DeleteSavedHostID() error {
+	return conf.hostIDStorage().DeleteSavedHostID()
+}
+
+// HostIDStorage is an interface which maintains persistency
+// of the "Host ID" for the current host where the agent is running on.
+// The ID is always generated and given by Mackerel (mackerel.io).
+type HostIDStorage interface {
+	LoadHostID() (string, error)
+	SaveHostID(id string) error
+	DeleteSavedHostID() error
+}
+
+// FileSystemHostIDStorage is the default HostIDStorage
+// which saves/loads the host id using an id file on the local filesystem.
+// The file will be located at /var/lib/mackerel-agent/id by default on linux.
+type FileSystemHostIDStorage struct {
+	Root string
+}
+
+const idFileName = "id"
+
+// HostIDFile is the location of the host id file.
+func (s FileSystemHostIDStorage) HostIDFile() string {
+	return filepath.Join(s.Root, idFileName)
+}
+
+// LoadHostID loads the current host ID from the mackerel-agent's id file.
+func (s FileSystemHostIDStorage) LoadHostID() (string, error) {
+	content, err := ioutil.ReadFile(s.HostIDFile())
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimRight(string(content), "\r\n"), nil
 }
 
-func (c Config) SaveHostID(id string) error {
-	err := os.MkdirAll(c.Root, 0755)
+// SaveHostID saves the host ID to the mackerel-agent's id file.
+func (s FileSystemHostIDStorage) SaveHostID(id string) error {
+	err := os.MkdirAll(s.Root, 0755)
 	if err != nil {
 		return err
 	}
 
-	file, err := os.Create(c.HostIDFile())
+	file, err := os.Create(s.HostIDFile())
 	if err != nil {
 		return err
 	}
@@ -249,6 +291,7 @@ func (c Config) SaveHostID(id string) error {
 	return nil
 }
 
-func (c Config) DeleteSavedHostID() error {
-	return os.Remove(c.HostIDFile())
+// DeleteSavedHostID deletes the mackerel-agent's id file.
+func (s FileSystemHostIDStorage) DeleteSavedHostID() error {
+	return os.Remove(s.HostIDFile())
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -241,3 +241,34 @@ command = "bar"
 	assert(t, config.Plugin["metrics"]["foo2"].Command == "foo2", "plugin.metrics.foo2 should exist")
 	assert(t, config.Plugin["metrics"]["bar"].Command == "bar", "plugin.metrics.bar should be overwritten")
 }
+
+func TestFileSystemHostIDStorage(t *testing.T) {
+	root, err := ioutil.TempDir("", "mackerel-agent-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := FileSystemHostIDStorage{Root: root}
+	err = s.SaveHostID("test-host-id")
+	assertNoError(t, err)
+
+	hostID, err := s.LoadHostID()
+	assertNoError(t, err)
+	assert(t, hostID == "test-host-id", "SaveHostID and LoadHostID should preserve the host id")
+
+	err = s.DeleteSavedHostID()
+	assertNoError(t, err)
+
+	_, err = s.LoadHostID()
+	assert(t, err != nil, "LoadHostID after DeleteSavedHostID must fail")
+}
+
+func TestConfig_HostIDStorage(t *testing.T) {
+	conf := Config{
+		Root: "test-root",
+	}
+
+	storage, ok := conf.hostIDStorage().(*FileSystemHostIDStorage)
+	assert(t, ok, "Default hostIDStorage must be *FileSystemHostIDStorage")
+	assert(t, storage.Root == "test-root", "FileSystemHostIDStorage must have the same Root of Config")
+}

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func doRetire(argv []string) int {
 		return exitStatusError
 	}
 
-	hostID, err := command.LoadHostID(conf.Root)
+	hostID, err := conf.LoadHostID()
 	if err != nil {
 		logger.Warningf("HostID file is not found")
 		return exitStatusError
@@ -130,7 +130,7 @@ func doRetire(argv []string) int {
 	}
 	logger.Infof("This host (hostID: %s) has been retired.", hostID)
 	// just to try to remove hostID file.
-	err = command.RemoveIDFile(conf.Root)
+	err = conf.DeleteSavedHostID()
 	if err != nil {
 		logger.Warningf("Failed to remove HostID file: %s", err)
 	}


### PR DESCRIPTION
Currently, the storage of HostID is fixed to a file on the local filesystem. If we want to use mackerel-agent as a Go library, this is a bit inconvenient behavior.

In this pull request, I have changed config.Config to have HostIDStorage which handles saving/loading of HostID and defaults to local filesystem.

---

HostID の読み書きがローカルのファイルシステムを前提としていて、mackerel-agent バイナリ以外から利用したいときに不便だったので、これをインターフェース化して差し替え可能にしてみました。いかがでしょうか？