### PR TITLE
Publicize command.Context's fields

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -153,10 +153,10 @@ func delayByHost(host *mackerel.Host) int {
 
 // Context context object
 type Context struct {
-	ag   *agent.Agent
-	conf *config.Config
-	host *mackerel.Host
-	api  *mackerel.API
+	Agent  *agent.Agent
+	Config *config.Config
+	Host   *mackerel.Host
+	API    *mackerel.API
 }
 
 type postValue struct {
@@ -185,17 +185,17 @@ func loop(c *Context, termCh chan struct{}) int {
 	// Periodically update host specs.
 	go updateHostSpecsLoop(c, quit)
 
-	postQueue := make(chan *postValue, c.conf.Connection.PostMetricsBufferSize)
+	postQueue := make(chan *postValue, c.Config.Connection.PostMetricsBufferSize)
 	go enqueueLoop(c, postQueue, quit)
 
-	postDelaySeconds := delayByHost(c.host)
+	postDelaySeconds := delayByHost(c.Host)
 	initialDelay := postDelaySeconds / 2
 	logger.Debugf("wait %d seconds before initial posting.", initialDelay)
 	select {
 	case <-termCh:
 		return 0
 	case <-time.After(time.Duration(initialDelay) * time.Second):
-		c.ag.InitPluginGenerators(c.api)
+		c.Agent.InitPluginGenerators(c.API)
 	}
 
 	termCheckerCh := make(chan struct{})
@@ -236,10 +236,10 @@ func loop(c *Context, termCh chan struct{}) int {
 			case loopStateFirst: // request immediately to create graph defs of host
 				// nop
 			case loopStateQueued:
-				delaySeconds = c.conf.Connection.PostMetricsDequeueDelaySeconds
+				delaySeconds = c.Config.Connection.PostMetricsDequeueDelaySeconds
 			case loopStateHadError:
 				// TODO: better interval calculation. exponential backoff or so.
-				delaySeconds = c.conf.Connection.PostMetricsRetryDelaySeconds
+				delaySeconds = c.Config.Connection.PostMetricsRetryDelaySeconds
 			case loopStateTerminating:
 				// dequeue and post every one second when terminating.
 				delaySeconds = 1
@@ -278,7 +278,7 @@ func loop(c *Context, termCh chan struct{}) int {
 			for _, v := range origPostValues {
 				postValues = append(postValues, v.values...)
 			}
-			err := c.api.PostMetricsValues(postValues)
+			err := c.API.PostMetricsValues(postValues)
 			if err != nil {
 				logger.Errorf("Failed to post metrics value (will retry): %s", err.Error())
 				if lState != loopStateTerminating {
@@ -289,7 +289,7 @@ func loop(c *Context, termCh chan struct{}) int {
 						v.retryCnt++
 						// It is difficult to distinguish the error is server error or data error.
 						// So, if retryCnt exceeded the configured limit, postValue is considered invalid and abandoned.
-						if v.retryCnt > c.conf.Connection.PostMetricsRetryMax {
+						if v.retryCnt > c.Config.Connection.PostMetricsRetryMax {
 							json, err := json.Marshal(v.values)
 							if err != nil {
 								logger.Errorf("Something wrong with post values. marshaling failed.")
@@ -325,7 +325,7 @@ func updateHostSpecsLoop(c *Context, quit chan struct{}) {
 }
 
 func enqueueLoop(c *Context, postQueue chan *postValue, quit chan struct{}) {
-	metricsResult := c.ag.Watch()
+	metricsResult := c.Agent.Watch()
 	for {
 		select {
 		case <-quit:
@@ -335,14 +335,14 @@ func enqueueLoop(c *Context, postQueue chan *postValue, quit chan struct{}) {
 			creatingValues := [](*mackerel.CreatingMetricsValue){}
 			for name, value := range (map[string]float64)(result.Values) {
 				if math.IsNaN(value) || math.IsInf(value, 0) {
-					logger.Warningf("Invalid value: hostID = %s, name = %s, value = %f\n is not sent.", c.host.ID, name, value)
+					logger.Warningf("Invalid value: hostID = %s, name = %s, value = %f\n is not sent.", c.Host.ID, name, value)
 					continue
 				}
 
 				creatingValues = append(
 					creatingValues,
 					&mackerel.CreatingMetricsValue{
-						HostID: c.host.ID,
+						HostID: c.Host.ID,
 						Name:   name,
 						Time:   created,
 						Value:  value,
@@ -363,7 +363,7 @@ func runCheckersLoop(c *Context, termCheckerCh <-chan struct{}, quit <-chan stru
 		checkReportCh          chan *checks.Report
 		reportCheckImmediateCh chan struct{}
 	)
-	for _, checker := range c.ag.Checkers {
+	for _, checker := range c.Agent.Checkers {
 		if checkReportCh == nil {
 			checkReportCh = make(chan *checks.Report)
 			reportCheckImmediateCh = make(chan struct{})
@@ -439,7 +439,7 @@ func runCheckersLoop(c *Context, termCheckerCh <-chan struct{}, quit <-chan stru
 					continue
 				}
 
-				err := c.api.ReportCheckMonitors(c.host.ID, reports)
+				err := c.API.ReportCheckMonitors(c.Host.ID, reports)
 				if err != nil {
 					logger.Errorf("ReportCheckMonitors: %s", err)
 
@@ -496,13 +496,13 @@ func (c *Context) UpdateHostSpecs() {
 		return
 	}
 
-	err = c.api.UpdateHost(c.host.ID, mackerel.HostSpec{
+	err = c.API.UpdateHost(c.Host.ID, mackerel.HostSpec{
 		Name:          hostname,
 		Meta:          meta,
 		Interfaces:    interfaces,
-		RoleFullnames: c.conf.Roles,
-		Checks:        c.conf.CheckNames(),
-		DisplayName:   c.conf.DisplayName,
+		RoleFullnames: c.Config.Roles,
+		Checks:        c.Config.CheckNames(),
+		DisplayName:   c.Config.DisplayName,
 	})
 
 	if err != nil {
@@ -526,10 +526,10 @@ func Prepare(conf *config.Config) (*Context, error) {
 	}
 
 	return &Context{
-		ag:   NewAgent(conf),
-		conf: conf,
-		host: host,
-		api:  api,
+		Agent:  NewAgent(conf),
+		Config: conf,
+		Host:   host,
+		API:    api,
 	}, nil
 }
 
@@ -588,12 +588,12 @@ func NewAgent(conf *config.Config) *agent.Agent {
 
 // Run starts the main metric collecting logic and this function will never return.
 func Run(c *Context, termCh chan struct{}) int {
-	logger.Infof("Start: apibase = %s, hostName = %s, hostID = %s", c.conf.Apibase, c.host.Name, c.host.ID)
+	logger.Infof("Start: apibase = %s, hostName = %s, hostID = %s", c.Config.Apibase, c.Host.Name, c.Host.ID)
 
 	exitCode := loop(c, termCh)
-	if exitCode == 0 && c.conf.HostStatus.OnStop != "" {
+	if exitCode == 0 && c.Config.HostStatus.OnStop != "" {
 		// TOOD error handling. supoprt retire(?)
-		err := c.api.UpdateHostStatus(c.host.ID, c.conf.HostStatus.OnStop)
+		err := c.API.UpdateHostStatus(c.Host.ID, c.Config.HostStatus.OnStop)
 		if err != nil {
 			logger.Errorf("Failed update host status on stop: %s", err)
 		}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -107,8 +107,8 @@ func TestPrepareWithCreate(t *testing.T) {
 	}
 
 	c, _ := Prepare(&conf)
-	api := c.api
-	host := c.host
+	api := c.API
+	host := c.Host
 
 	if api.BaseURL.String() != ts.URL {
 		t.Errorf("Apibase mismatch: %s != %s", api.BaseURL, ts.URL)
@@ -171,8 +171,8 @@ func TestPrepareWithUpdate(t *testing.T) {
 	}
 
 	c, _ := Prepare(&conf)
-	api := c.api
-	host := c.host
+	api := c.API
+	host := c.Host
 
 	if api.BaseURL.String() != ts.URL {
 		t.Errorf("Apibase mismatch: %s != %s", api.BaseURL, ts.URL)
@@ -311,10 +311,10 @@ func TestLoop(t *testing.T) {
 	termCh := make(chan struct{})
 	exitCh := make(chan int)
 	c := &Context{
-		ag:   ag,
-		conf: &conf,
-		api:  api,
-		host: host,
+		Agent:  ag,
+		Config: &conf,
+		API:    api,
+		Host:   host,
 	}
 	// Start looping!
 	go func() {


### PR DESCRIPTION
`command.Context` is the main interface of mackerel-agent and it should be convenient to have its fields published, e.g. adding PluginGenerators after `command.Prepare`.