### PR TITLE
Configtest

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,7 @@ diagnostic=false
 	confFile.Sync()
 	confFile.Close()
 	defer os.Remove(confFile.Name())
-	mergedConfig, _, err := resolveConfig([]string{"-conf=" + confFile.Name(), "-role=My-Service:default,INVALID#SERVICE", "-verbose", "-diagnostic"})
+	mergedConfig, _ := resolveConfig([]string{"-conf=" + confFile.Name(), "-role=My-Service:default,INVALID#SERVICE", "-verbose", "-diagnostic"})
 
 	t.Logf("      apibase: %v", mergedConfig.Apibase)
 	t.Logf("       apikey: %v", mergedConfig.Apikey)
@@ -58,7 +58,7 @@ diagnostic=false
 }
 
 func TestParseFlagsPrintVersion(t *testing.T) {
-	config, otherOptions, _ := resolveConfig([]string{"-version"})
+	config, otherOptions := resolveConfig([]string{"-version"})
 
 	if config.Verbose != false {
 		t.Error("with -version args, variables of config should have default values")
@@ -70,7 +70,7 @@ func TestParseFlagsPrintVersion(t *testing.T) {
 }
 
 func TestParseFlagsRunOnce(t *testing.T) {
-	config, otherOptions, _ := resolveConfig([]string{"-once"})
+	config, otherOptions := resolveConfig([]string{"-once"})
 
 	if config.Verbose != false {
 		t.Error("with -version args, variables of config should have default values")
@@ -186,11 +186,11 @@ func TestConfigTestOK(t *testing.T) {
 	confFile.Close()
 	defer os.Remove(confFile.Name())
 
-	argv := []string{"-conf=" + confFile.Name(), "-configtest"}
-	conf, _, err := resolveConfig(argv)
+	argv := []string{"-conf=" + confFile.Name()}
+	status := doConfigtest(argv)
 
-	if conf != nil || err != nil {
-		t.Errorf("configtest(ok) must be return conf=nil, err=nil")
+	if status != exitStatusOK {
+		t.Errorf("configtest(ok) must be return exitStatusOK")
 	}
 }
 
@@ -206,11 +206,11 @@ func TestConfigTestNotFound(t *testing.T) {
 	confFile.Close()
 	defer os.Remove(confFile.Name())
 
-	argv := []string{"-conf=" + confFile.Name() + "xxx", "-configtest"}
-	conf, _, err := resolveConfig(argv)
+	argv := []string{"-conf=" + confFile.Name() + "xxx"}
+	status := doConfigtest(argv)
 
-	if conf != nil || err == nil {
-		t.Errorf("configtest(failed) must be return conf=nil, err!=nil")
+	if status != exitStatusError {
+		t.Errorf("configtest(failed) must be return existStatusError")
 	}
 }
 
@@ -228,10 +228,10 @@ command = "bar"
 	confFile.Close()
 	defer os.Remove(confFile.Name())
 
-	argv := []string{"-conf=" + confFile.Name(), "-configtest"}
-	conf, _, err := resolveConfig(argv)
+	argv := []string{"-conf=" + confFile.Name()}
+	status := doConfigtest(argv)
 
-	if conf != nil || err == nil {
-		t.Errorf("configtest(failed) must be return conf=nil, err!=nil")
+	if status != exitStatusError {
+		t.Errorf("configtest(failed) must be return exitStatusError")
 	}
 }

--- a/packaging/deb/debian/mackerel-agent.initd
+++ b/packaging/deb/debian/mackerel-agent.initd
@@ -131,7 +131,7 @@ case "$1" in
         esac
         ;;
     *)
-        echo "Usage: $SCRIPTNAME {start|stop|restart|reload|status}" >&2
+        echo "Usage: $SCRIPTNAME {start|stop|restart|reload|status|configtest}" >&2
         exit 3
     ;;
 esac

--- a/packaging/deb/debian/mackerel-agent.initd
+++ b/packaging/deb/debian/mackerel-agent.initd
@@ -39,6 +39,12 @@ do_start()
     return $?
 }
 
+do_configtest()
+{
+    $DAEMON --configtest ${APIBASE:+--apibase=$APIBASE} ${APIKEY:+--apikey=$APIKEY} --pidfile=$PIDFILE --root=$ROOT $OTHER_OPTS >>$LOGFILE 2>&1
+    return $?
+}
+
 do_retire()
 {
     $DAEMON retire -force ${APIBASE:+--apibase=$APIBASE} ${APIKEY:+--apikey=$APIKEY} --root=$ROOT $OTHER_OPTS >>$LOGFILE 2>&1
@@ -82,6 +88,7 @@ case "$1" in
         status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
         ;;
     reload)
+        do_configtest || exit 1
         log_daemon_msg "Restarting $DESC" "$NAME"
         do_stop
         case "$?" in
@@ -113,6 +120,14 @@ case "$1" in
                 # Failed to stop
                 log_end_msg 1
             ;;
+        esac
+        ;;
+    configtest)
+        log_daemon_msg "Testing configuration of $NAME"
+        do_configtest
+        case "$?" in
+            0) log_end_msg 0 ;;
+            *) log_end_msg 1; exit 1;;
         esac
         ;;
     *)

--- a/packaging/deb/debian/mackerel-agent.initd
+++ b/packaging/deb/debian/mackerel-agent.initd
@@ -41,7 +41,7 @@ do_start()
 
 do_configtest()
 {
-    $DAEMON --configtest ${APIBASE:+--apibase=$APIBASE} ${APIKEY:+--apikey=$APIKEY} --pidfile=$PIDFILE --root=$ROOT $OTHER_OPTS >>$LOGFILE 2>&1
+    $DAEMON configtest ${APIBASE:+--apibase=$APIBASE} ${APIKEY:+--apikey=$APIKEY} --pidfile=$PIDFILE --root=$ROOT $OTHER_OPTS >>$LOGFILE 2>&1
     return $?
 }
 

--- a/packaging/rpm/src/mackerel-agent.initd
+++ b/packaging/rpm/src/mackerel-agent.initd
@@ -54,6 +54,24 @@ start() {
     return 0
 }
 
+configtest_q() {
+    $BIN --configtest ${APIBASE:+--apibase=$APIBASE} ${APIKEY:+--apikey=$APIKEY} --pidfile=$PIDFILE --root=$ROOT $OTHER_OPTS >>$LOGFILE 2>&1
+}
+
+configtest() {
+    echo -n $"Testing configuration of $prog: "
+
+    configtest_q
+    if [ "$?" -eq 0 ]; then
+        success
+        echo
+    else
+        failure
+        echo
+        return 1
+    fi
+}
+
 stop() {
     echo -n $"Stopping $prog: "
 
@@ -130,6 +148,7 @@ case "$1" in
         exit $retval
         ;;
     reload)
+        configtest_q || exit 1
         restart
         ;;
     restart)
@@ -138,8 +157,11 @@ case "$1" in
     status)
         rh_status
         ;;
+    configtest)
+        configtest
+        ;;
     *)
-        echo $"Usage: $0 {start|stop|restart|reload|status}"
+        echo $"Usage: $0 {start|stop|restart|reload|status|configtest}"
         exit 2
 esac
 

--- a/packaging/rpm/src/mackerel-agent.initd
+++ b/packaging/rpm/src/mackerel-agent.initd
@@ -55,7 +55,7 @@ start() {
 }
 
 configtest_q() {
-    $BIN --configtest ${APIBASE:+--apibase=$APIBASE} ${APIKEY:+--apikey=$APIKEY} --pidfile=$PIDFILE --root=$ROOT $OTHER_OPTS >>$LOGFILE 2>&1
+    $BIN configtest ${APIBASE:+--apibase=$APIBASE} ${APIKEY:+--apikey=$APIKEY} --pidfile=$PIDFILE --root=$ROOT $OTHER_OPTS >>$LOGFILE 2>&1
 }
 
 configtest() {


### PR DESCRIPTION
related #94.

- Added `-configtest` option to mackerel-agent.
- Added argument `configtest` to init scripts.
