### PR TITLE
Release version 0.26.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.25.1-1.noarch.rpm
-  - packaging/mackerel-agent_0.25.1-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.26.0-1.noarch.rpm
+  - packaging/mackerel-agent_0.26.0-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.26.0 (2015-12-08)
+
+* Make HostID storage replacable #167 (motemen)
+* Publicize command.Context's fields #168 (motemen)
+* Configtest #169 (fujiwara)
+* Refactor config loading and check if Apikey exists in configtest #171 (Songmu)
+* fix exit status of debian init script. #172 (fujiwara)
+* Deprecate version and once option #173 (Songmu)
+
+
 ## 0.25.1 (2015-11-25)
 
 * Go 1.5.1 #164 (Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.26.0-1) stable; urgency=low
+
+  * Make HostID storage replacable (by motemen)
+    <https://github.com/mackerelio/mackerel-agent/pull/167>
+  * Publicize command.Context's fields (by motemen)
+    <https://github.com/mackerelio/mackerel-agent/pull/168>
+  * Configtest (by fujiwara)
+    <https://github.com/mackerelio/mackerel-agent/pull/169>
+  * Refactor config loading and check if Apikey exists in configtest (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/171>
+  * fix exit status of debian init script. (by fujiwara)
+    <https://github.com/mackerelio/mackerel-agent/pull/172>
+  * Deprecate version and once option (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/173>
+
+ -- Songmu <y.songmu@gmail.com>  Tue, 08 Dec 2015 11:17:07 +0900
+
 mackerel-agent (0.25.1-1) stable; urgency=low
 
   * Go 1.5.1 (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -71,6 +71,14 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Tue Dec 08 2015 <y.songmu@gmail.com> - 0.26.0-1
+- Make HostID storage replacable (by motemen)
+- Publicize command.Context's fields (by motemen)
+- Configtest (by fujiwara)
+- Refactor config loading and check if Apikey exists in configtest (by Songmu)
+- fix exit status of debian init script. (by fujiwara)
+- Deprecate version and once option (by Songmu)
+
 * Wed Nov 25 2015 <y.songmu@gmail.com> - 0.25.1-1
 - Go 1.5.1 (by Songmu)
 - logging STDERR of checker command (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.25.1
+Version:   0.26.0
 Release:   1
 License:   Commercial
 Summary:   mackerel.io agent


### PR DESCRIPTION
- Make HostID storage replacable #167
- Publicize command.Context's fields #168
- Configtest #169
- Refactor config loading and check if Apikey exists in configtest #171
- fix exit status of debian init script. #172
- Deprecate version and once option #173