### PR TITLE
Notification Interval for check monitoring

### DIFF
--- a/checks/checker.go
+++ b/checks/checker.go
@@ -46,10 +46,11 @@ type Checker struct {
 
 // Report is what Checker produces by invoking its command.
 type Report struct {
-	Name       string
-	Status     Status
-	Message    string
-	OccurredAt time.Time
+	Name                 string
+	Status               Status
+	Message              string
+	OccurredAt           time.Time
+	NotificationInterval *int32
 }
 
 func (c Checker) String() string {
@@ -78,10 +79,11 @@ func (c Checker) Check() (*Report, error) {
 	logger.Debugf("Checker %q status=%s message=%q", c.Name, status, message)
 
 	return &Report{
-		Name:       c.Name,
-		Status:     status,
-		Message:    message,
-		OccurredAt: now,
+		Name:                 c.Name,
+		Status:               status,
+		Message:              message,
+		OccurredAt:           now,
+		NotificationInterval: c.Config.NotificationInterval,
 	}, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,8 @@ type PluginConfigs map[string]PluginConfig
 
 // PluginConfig represents a section of [plugin.*].
 type PluginConfig struct {
-	Command string
+	Command              string
+	NotificationInterval *int32 `toml:"notification_interval"`
 }
 
 const postMetricsDequeueDelaySecondsMax = 59   // max delay seconds for dequeuing from buffer queue

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,6 +27,7 @@ type = "metric"
 
 [plugin.checks.heartbeat]
 command = "heartbeat.sh"
+notification_interval = 60
 `
 
 func TestLoadConfig(t *testing.T) {
@@ -165,6 +166,9 @@ func TestLoadConfigFile(t *testing.T) {
 	checks := config.Plugin["checks"]["heartbeat"]
 	if checks.Command != "heartbeat.sh" {
 		t.Error("sensu command should be 'heartbeat.sh'")
+	}
+	if *checks.NotificationInterval != 60 {
+		t.Error("notification_interval should be 60")
 	}
 }
 

--- a/mackerel/check.go
+++ b/mackerel/check.go
@@ -16,7 +16,7 @@ type checkReport struct {
 	Status               checks.Status     `json:"status"`
 	Message              string            `json:"message"`
 	OccurredAt           Time              `json:"occurredAt"`
-	NotificationInterval *int32            `json:"notificationInterval"`
+	NotificationInterval *int32            `json:"notificationInterval,omitempty"`
 }
 
 type monitorTargetHost struct {

--- a/mackerel/check.go
+++ b/mackerel/check.go
@@ -11,11 +11,12 @@ type monitoringChecksPayload struct {
 }
 
 type checkReport struct {
-	Source     monitorTargetHost `json:"source"`
-	Name       string            `json:"name"`
-	Status     checks.Status     `json:"status"`
-	Message    string            `json:"message"`
-	OccurredAt Time              `json:"occurredAt"`
+	Source               monitorTargetHost `json:"source"`
+	Name                 string            `json:"name"`
+	Status               checks.Status     `json:"status"`
+	Message              string            `json:"message"`
+	OccurredAt           Time              `json:"occurredAt"`
+	NotificationInterval *int32            `json:"notificationInterval"`
 }
 
 type monitorTargetHost struct {
@@ -37,11 +38,12 @@ func (api *API) ReportCheckMonitors(hostID string, reports []*checks.Report) err
 	}
 	for i, report := range reports {
 		payload.Reports[i] = &checkReport{
-			Source:     monitorTargetHost{HostID: hostID},
-			Name:       report.Name,
-			Status:     report.Status,
-			Message:    report.Message,
-			OccurredAt: Time(report.OccurredAt),
+			Source:               monitorTargetHost{HostID: hostID},
+			Name:                 report.Name,
+			Status:               report.Status,
+			Message:              report.Message,
+			OccurredAt:           Time(report.OccurredAt),
+			NotificationInterval: report.NotificationInterval,
 		}
 	}
 	resp, err := api.postJSON("/api/v0/monitoring/checks/report", payload)


### PR DESCRIPTION
This pull request sends the notification_interval settings to mackerel.io for check monitorings. This allows the user to configure notification interval for check plugins as well.