### PR TITLE
add a configuration to ignore filesystems

### DIFF
--- a/command/command_darwin.go
+++ b/command/command_darwin.go
@@ -27,7 +27,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 		&metricsDarwin.CPUUsageGenerator{},
 		&metricsDarwin.MemoryGenerator{},
 		&metricsDarwin.SwapGenerator{},
-		&metricsDarwin.FilesystemGenerator{Ignore: conf.Filesystems.Ignore},
+		&metricsDarwin.FilesystemGenerator{IgnoreRegexp: conf.Filesystems.Ignore.Regexp},
 		&metricsDarwin.InterfaceGenerator{Interval: metricsInterval},
 	}
 

--- a/command/command_darwin.go
+++ b/command/command_darwin.go
@@ -27,7 +27,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 		&metricsDarwin.CPUUsageGenerator{},
 		&metricsDarwin.MemoryGenerator{},
 		&metricsDarwin.SwapGenerator{},
-		&metricsDarwin.FilesystemGenerator{},
+		&metricsDarwin.FilesystemGenerator{Ignore: conf.Filesystems.Ignore},
 		&metricsDarwin.InterfaceGenerator{Interval: metricsInterval},
 	}
 

--- a/command/command_freebsd.go
+++ b/command/command_freebsd.go
@@ -25,7 +25,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 	generators := []metrics.Generator{
 		&metricsFreebsd.Loadavg5Generator{},
 		&metricsFreebsd.CPUUsageGenerator{},
-		&metricsFreebsd.FilesystemGenerator{},
+		&metricsFreebsd.FilesystemGenerator{Ignore: conf.Filesystems.Ignore},
 		&metricsFreebsd.MemoryGenerator{},
 	}
 

--- a/command/command_freebsd.go
+++ b/command/command_freebsd.go
@@ -25,7 +25,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 	generators := []metrics.Generator{
 		&metricsFreebsd.Loadavg5Generator{},
 		&metricsFreebsd.CPUUsageGenerator{},
-		&metricsFreebsd.FilesystemGenerator{Ignore: conf.Filesystems.Ignore},
+		&metricsFreebsd.FilesystemGenerator{IgnoreRegexp: conf.Filesystems.Ignore.Regexp},
 		&metricsFreebsd.MemoryGenerator{},
 	}
 

--- a/command/command_linux.go
+++ b/command/command_linux.go
@@ -8,13 +8,13 @@ import (
 	specLinux "github.com/mackerelio/mackerel-agent/spec/linux"
 )
 
-func specGenerators() []spec.Generator {
+func specGenerators(conf *config.Config) []spec.Generator {
 	return []spec.Generator{
 		&specLinux.KernelGenerator{},
 		&specLinux.CPUGenerator{},
 		&specLinux.MemoryGenerator{},
 		&specLinux.BlockDeviceGenerator{},
-		&specLinux.FilesystemGenerator{},
+		&specLinux.FilesystemGenerator{Ignore: conf.Filesystems.Ignore},
 	}
 }
 
@@ -30,7 +30,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 		&metricsLinux.UptimeGenerator{},
 		&metricsLinux.InterfaceGenerator{Interval: metricsInterval},
 		&metricsLinux.DiskGenerator{Interval: metricsInterval},
-		&metricsLinux.FilesystemGenerator{},
+		&metricsLinux.FilesystemGenerator{Ignore: conf.Filesystems.Ignore},
 	}
 
 	return generators

--- a/command/command_linux.go
+++ b/command/command_linux.go
@@ -30,7 +30,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 		&metricsLinux.UptimeGenerator{},
 		&metricsLinux.InterfaceGenerator{Interval: metricsInterval},
 		&metricsLinux.DiskGenerator{Interval: metricsInterval},
-		&metricsLinux.FilesystemGenerator{Ignore: conf.Filesystems.Ignore},
+		&metricsLinux.FilesystemGenerator{IgnoreRegexp: conf.Filesystems.Ignore.Regexp},
 	}
 
 	return generators

--- a/command/command_linux.go
+++ b/command/command_linux.go
@@ -8,13 +8,13 @@ import (
 	specLinux "github.com/mackerelio/mackerel-agent/spec/linux"
 )
 
-func specGenerators(conf *config.Config) []spec.Generator {
+func specGenerators() []spec.Generator {
 	return []spec.Generator{
 		&specLinux.KernelGenerator{},
 		&specLinux.CPUGenerator{},
 		&specLinux.MemoryGenerator{},
 		&specLinux.BlockDeviceGenerator{},
-		&specLinux.FilesystemGenerator{Ignore: conf.Filesystems.Ignore},
+		&specLinux.FilesystemGenerator{},
 	}
 }
 

--- a/command/command_netbsd.go
+++ b/command/command_netbsd.go
@@ -25,7 +25,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 	generators := []metrics.Generator{
 		&metricsNetbsd.Loadavg5Generator{},
 		&metricsNetbsd.CPUUsageGenerator{},
-		&metricsNetbsd.FilesystemGenerator{Ignore: conf.Filesystems.Ignore},
+		&metricsNetbsd.FilesystemGenerator{IgnoreRegexp: conf.Filesystems.Ignore.Regexp},
 		&metricsNetbsd.MemoryGenerator{},
 	}
 

--- a/command/command_netbsd.go
+++ b/command/command_netbsd.go
@@ -25,7 +25,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 	generators := []metrics.Generator{
 		&metricsNetbsd.Loadavg5Generator{},
 		&metricsNetbsd.CPUUsageGenerator{},
-		&metricsNetbsd.FilesystemGenerator{},
+		&metricsNetbsd.FilesystemGenerator{Ignore: conf.Filesystems.Ignore},
 		&metricsNetbsd.MemoryGenerator{},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -44,8 +44,9 @@ type Config struct {
 	Verbose     bool
 	Diagnostic  bool `toml:"diagnostic"`
 	Connection  ConnectionConfig
-	DisplayName string     `toml:"display_name"`
-	HostStatus  HostStatus `toml:"host_status"`
+	DisplayName string      `toml:"display_name"`
+	HostStatus  HostStatus  `toml:"host_status"`
+	Filesystems Filesystems `toml:"filesystems"`
 
 	// Corresponds to the set of [plugin.<kind>.<name>] sections
 	// the key of the map is <kind>, which should be one of "metrics" or "checks".
@@ -86,6 +87,11 @@ type ConnectionConfig struct {
 type HostStatus struct {
 	OnStart string `toml:"on_start"`
 	OnStop  string `toml:"on_stop"`
+}
+
+// Filesystems configure filesystem related settings
+type Filesystems struct {
+	Ignore string `toml:"ignore"`
 }
 
 // CheckNames return list of plugin.checks._name_

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -91,7 +92,19 @@ type HostStatus struct {
 
 // Filesystems configure filesystem related settings
 type Filesystems struct {
-	Ignore string `toml:"ignore"`
+	Ignore Regexpwrapper `toml:"ignore"`
+}
+
+// Regexpwrapper is a wrapper type for marshalling string
+type Regexpwrapper struct {
+	*regexp.Regexp
+}
+
+// UnmarshalText for compiling regexp string while loading toml
+func (r *Regexpwrapper) UnmarshalText(text []byte) error {
+	var err error
+	r.Regexp, err = regexp.Compile(string(text))
+	return err
 }
 
 // CheckNames return list of plugin.checks._name_

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,6 +14,9 @@ apikey = "abcde"
 display_name = "fghij"
 diagnostic = true
 
+[filesystems]
+ignore = "/dev/ram.*"
+
 [connection]
 post_metrics_retry_delay_seconds = 600
 post_metrics_retry_max = 5
@@ -110,6 +113,29 @@ func TestLoadConfigWithHostStatus(t *testing.T) {
 
 	if config.HostStatus.OnStop != "poweroff" {
 		t.Error(`HostStatus.OnStop should be "poweroff"`)
+	}
+}
+
+var sampleConfigWithInvalidIgnoreRegexp = `
+apikey = "abcde"
+display_name = "fghij"
+
+[filesystems]
+ignore = "**"
+`
+
+func TestLoadConfigWithInvalidIgnoreRegexp(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	if err = ioutil.WriteFile(tmpFile.Name(), []byte(sampleConfigWithInvalidIgnoreRegexp), 0644); err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+
+	_, err = LoadConfig(tmpFile.Name())
+	if err == nil {
+		t.Errorf("should raise error: %v", err)
 	}
 }
 

--- a/mackerel-agent.sample.conf
+++ b/mackerel-agent.sample.conf
@@ -3,6 +3,13 @@
 # verbose = false
 # apikey = ""
 
+# [host_status]
+# on_start = "working"
+# on_stop  = "poweroff"
+
+# [filesystems]
+# ignore = "/dev/ram.*"
+
 # Configuration for connection
 # [connection]
 # post_metrics_dequeue_delay_seconds = 30 # delay for dequeuing from buffer queue

--- a/metrics/darwin/filesystem.go
+++ b/metrics/darwin/filesystem.go
@@ -12,6 +12,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
+	Ignore string
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -30,6 +31,9 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
+		if g.Ignore != "" && regexp.MustCompile(g.Ignore).FindStringSubmatch(name) != nil {
+			continue
+		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {
 			device := regexp.MustCompile(`[^A-Za-z0-9_-]`).ReplaceAllString(matches[1], "_")
 			for key, value := range values {

--- a/metrics/darwin/filesystem.go
+++ b/metrics/darwin/filesystem.go
@@ -5,6 +5,7 @@ package darwin
 import (
 	"regexp"
 
+	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 	"github.com/mackerelio/mackerel-agent/util"
@@ -12,7 +13,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
-	Ignore string
+	Ignore config.Regexpwrapper
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -31,7 +32,7 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
-		if g.Ignore != "" && regexp.MustCompile(g.Ignore).FindStringSubmatch(name) != nil {
+		if g.Ignore.Regexp != nil && g.Ignore.Regexp.FindStringSubmatch(name) != nil {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {

--- a/metrics/darwin/filesystem.go
+++ b/metrics/darwin/filesystem.go
@@ -5,7 +5,6 @@ package darwin
 import (
 	"regexp"
 
-	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 	"github.com/mackerelio/mackerel-agent/util"
@@ -13,7 +12,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
-	Ignore config.Regexpwrapper
+	IgnoreRegexp *regexp.Regexp
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -32,7 +31,7 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
-		if g.Ignore.Regexp != nil && g.Ignore.Regexp.FindStringSubmatch(name) != nil {
+		if g.IgnoreRegexp != nil && g.IgnoreRegexp.MatchString(name) {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {

--- a/metrics/freebsd/filesystem.go
+++ b/metrics/freebsd/filesystem.go
@@ -5,7 +5,6 @@ package freebsd
 import (
 	"regexp"
 
-	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 	"github.com/mackerelio/mackerel-agent/util"
@@ -13,7 +12,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
-	Ignore config.Regexpwrapper
+	IgnoreRegexp *regexp.Regexp
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -32,7 +31,7 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
-		if g.Ignore.Regexp != nil && g.Ignore.Regexp.FindStringSubmatch(name) != nil {
+		if g.IgnoreRegexp != nil && g.Ignore.MatchString(name) {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {

--- a/metrics/freebsd/filesystem.go
+++ b/metrics/freebsd/filesystem.go
@@ -12,6 +12,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
+	Ignore string
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -30,6 +31,9 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
+		if g.Ignore != "" && regexp.MustCompile(g.Ignore).FindStringSubmatch(name) != nil {
+			continue
+		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {
 			device := regexp.MustCompile(`[^A-Za-z0-9_-]`).ReplaceAllString(matches[1], "_")
 			for key, value := range values {

--- a/metrics/freebsd/filesystem.go
+++ b/metrics/freebsd/filesystem.go
@@ -31,7 +31,7 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
-		if g.IgnoreRegexp != nil && g.Ignore.MatchString(name) {
+		if g.IgnoreRegexp != nil && g.IgnoreRegexp.MatchString(name) {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {

--- a/metrics/freebsd/filesystem.go
+++ b/metrics/freebsd/filesystem.go
@@ -5,6 +5,7 @@ package freebsd
 import (
 	"regexp"
 
+	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 	"github.com/mackerelio/mackerel-agent/util"
@@ -12,7 +13,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
-	Ignore string
+	Ignore config.Regexpwrapper
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -31,7 +32,7 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
-		if g.Ignore != "" && regexp.MustCompile(g.Ignore).FindStringSubmatch(name) != nil {
+		if g.Ignore.Regexp != nil && g.Ignore.Regexp.FindStringSubmatch(name) != nil {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {

--- a/metrics/linux/filesystem.go
+++ b/metrics/linux/filesystem.go
@@ -5,7 +5,6 @@ package linux
 import (
 	"regexp"
 
-	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 	"github.com/mackerelio/mackerel-agent/util"
@@ -13,7 +12,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
-	Ignore config.Regexpwrapper
+	IgnoreRegexp *regexp.Regexp
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -34,7 +33,7 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 	for name, values := range filesystems {
 		// https://github.com/docker/docker/blob/v1.5.0/daemon/graphdriver/devmapper/deviceset.go#L981
 		if regexp.MustCompile(`^/dev/mapper/docker-`).FindStringSubmatch(name) != nil ||
-			(g.Ignore.Regexp != nil && g.Ignore.Regexp.FindStringSubmatch(name) != nil) {
+			(g.IgnoreRegexp != nil && g.IgnoreRegexp.MatchString(name)) {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {

--- a/metrics/linux/filesystem.go
+++ b/metrics/linux/filesystem.go
@@ -5,6 +5,7 @@ package linux
 import (
 	"regexp"
 
+	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 	"github.com/mackerelio/mackerel-agent/util"
@@ -12,7 +13,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
-	Ignore string
+	Ignore config.Regexpwrapper
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -33,7 +34,7 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 	for name, values := range filesystems {
 		// https://github.com/docker/docker/blob/v1.5.0/daemon/graphdriver/devmapper/deviceset.go#L981
 		if regexp.MustCompile(`^/dev/mapper/docker-`).FindStringSubmatch(name) != nil ||
-			(g.Ignore != "" && regexp.MustCompile(g.Ignore).FindStringSubmatch(name) != nil) {
+			(g.Ignore.Regexp != nil && g.Ignore.Regexp.FindStringSubmatch(name) != nil) {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {

--- a/metrics/linux/filesystem.go
+++ b/metrics/linux/filesystem.go
@@ -12,6 +12,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
+	Ignore string
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -31,7 +32,8 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
 		// https://github.com/docker/docker/blob/v1.5.0/daemon/graphdriver/devmapper/deviceset.go#L981
-		if regexp.MustCompile(`^/dev/mapper/docker-`).FindStringSubmatch(name) != nil {
+		if regexp.MustCompile(`^/dev/mapper/docker-`).FindStringSubmatch(name) != nil ||
+			(g.Ignore != "" && regexp.MustCompile(g.Ignore).FindStringSubmatch(name) != nil) {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {

--- a/metrics/netbsd/filesystem.go
+++ b/metrics/netbsd/filesystem.go
@@ -12,6 +12,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
+	Ignore string
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -30,6 +31,9 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
+		if g.Ignore != "" && regexp.MustCompile(g.Ignore).FindStringSubmatch(name) != nil {
+			continue
+		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {
 			device := regexp.MustCompile(`[^A-Za-z0-9_-]`).ReplaceAllString(matches[1], "_")
 			for key, value := range values {

--- a/metrics/netbsd/filesystem.go
+++ b/metrics/netbsd/filesystem.go
@@ -5,6 +5,7 @@ package netbsd
 import (
 	"regexp"
 
+	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 	"github.com/mackerelio/mackerel-agent/util"
@@ -12,7 +13,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
-	Ignore string
+	Ignore config.Regexpwrapper
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -31,7 +32,7 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
-		if g.Ignore != "" && regexp.MustCompile(g.Ignore).FindStringSubmatch(name) != nil {
+		if g.Ignore.Regexp != nil && g.Ignore.Regexp.FindStringSubmatch(name) != nil {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {

--- a/metrics/netbsd/filesystem.go
+++ b/metrics/netbsd/filesystem.go
@@ -31,7 +31,7 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
-		if g.IgnoreRegexp != nil && g.Ignore.MatchString(name) {
+		if g.IgnoreRegexp != nil && g.IgnoreRegexp.MatchString(name) {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {

--- a/metrics/netbsd/filesystem.go
+++ b/metrics/netbsd/filesystem.go
@@ -5,7 +5,6 @@ package netbsd
 import (
 	"regexp"
 
-	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 	"github.com/mackerelio/mackerel-agent/util"
@@ -13,7 +12,7 @@ import (
 
 // FilesystemGenerator XXX
 type FilesystemGenerator struct {
-	Ignore config.Regexpwrapper
+	IgnoreRegexp *regexp.Regexp
 }
 
 var logger = logging.GetLogger("metrics.filesystem")
@@ -32,7 +31,7 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 
 	ret := make(map[string]float64)
 	for name, values := range filesystems {
-		if g.Ignore.Regexp != nil && g.Ignore.Regexp.FindStringSubmatch(name) != nil {
+		if g.IgnoreRegexp != nil && g.Ignore.MatchString(name) {
 			continue
 		}
 		if matches := regexp.MustCompile(`^/dev/(.*)$`).FindStringSubmatch(name); matches != nil {


### PR DESCRIPTION
Some types of filesystems, like temporary ram disks, do not need to be targets for collecting informations.

To ignore these kinds of filesystems, add the following settings.

```
[filesystems]
ignore = "/dev/ram.*"
```