### PR TITLE
fix the code of extending the process's environment

### DIFF
--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -6,6 +6,7 @@ package util
 
 import (
 	"bufio"
+	"os"
 	"os/exec"
 	"regexp"
 	"runtime"
@@ -59,7 +60,7 @@ func init() {
 // CollectDfValues XXX
 func CollectDfValues(dfColumnSpecs []DfColumnSpec) (map[string]map[string]interface{}, error) {
 	cmd := exec.Command("df", dfOpt...)
-	cmd.Env = append(cmd.Env, "LANG=C")
+	cmd.Env = append(os.Environ(), "LANG=C")
 	tio := &timeout.Timeout{
 		Cmd:       cmd,
 		Duration:  15 * time.Second,


### PR DESCRIPTION
The original code seems to append `LANG=C` to the environment variables, but cmd.Env is nil until it is set. This pull request fixes the code; use `os.Environ()` to obtain the current process's environment.