### PR TITLE
Release version 0.28.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.27.1-1.noarch.rpm
-  - packaging/mackerel-agent_0.27.1-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.28.0-1.noarch.rpm
+  - packaging/mackerel-agent_0.28.0-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.28.0 (2016-02-04)
+
+* add a configuration to ignore filesystems #186 (stanaka)
+* fix the code of extending the process's environment #187 (itchyny)
+* s{code.google.com/p/winsvc}{golang.org/x/sys/windows/svc} #188 (Songmu)
+* Max check attempts option for check plugin #189 (mechairoi)
+
+
 ## 0.27.1 (2016-01-08)
 
 * [bugfix] fix timeout interval when calling `df` #184 (Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,16 @@
+mackerel-agent (0.28.0-1) stable; urgency=low
+
+  * add a configuration to ignore filesystems (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent/pull/186>
+  * fix the code of extending the process's environment (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/187>
+  * s{code.google.com/p/winsvc}{golang.org/x/sys/windows/svc} (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/188>
+  * Max check attempts option for check plugin (by mechairoi)
+    <https://github.com/mackerelio/mackerel-agent/pull/189>
+
+ -- Songmu <y.songmu@gmail.com>  Thu, 04 Feb 2016 11:31:56 +0900
+
 mackerel-agent (0.27.1-1) stable; urgency=low
 
   * [bugfix] fix timeout interval when calling `df` (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -71,6 +71,12 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Thu Feb 04 2016 <y.songmu@gmail.com> - 0.28.0-1
+- add a configuration to ignore filesystems (by stanaka)
+- fix the code of extending the process's environment (by itchyny)
+- s{code.google.com/p/winsvc}{golang.org/x/sys/windows/svc} (by Songmu)
+- Max check attempts option for check plugin (by mechairoi)
+
 * Fri Jan 08 2016 <y.songmu@gmail.com> - 0.27.1-1
 - [bugfix] fix timeout interval when calling `df` (by Songmu)
 

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.27.1
+Version:   0.28.0
 Release:   1
 License:   Commercial
 Summary:   mackerel.io agent


### PR DESCRIPTION
- add a configuration to ignore filesystems #186
- fix the code of extending the process's environment #187
- s{code.google.com/p/winsvc}{golang.org/x/sys/windows/svc} #188
- Max check attempts option for check plugin #189