### PR TITLE
fix the exit status on stopping the agent in the init script of debian

### DIFF
--- a/packaging/deb/debian/mackerel-agent.initd
+++ b/packaging/deb/debian/mackerel-agent.initd
@@ -80,9 +80,7 @@ case "$1" in
         do_stop
         retval=$?
         if [ "$AUTO_RETIREMENT" != "" ] && [ "$AUTO_RETIREMENT" != "0" ]; then
-          if ! do_retire; then
-            retval=$?
-          fi
+          do_retire || retval=$?
         fi
         case "$retval" in
             0|1) log_end_msg 0 ;;

--- a/packaging/deb/debian/mackerel-agent.initd
+++ b/packaging/deb/debian/mackerel-agent.initd
@@ -79,7 +79,11 @@ case "$1" in
         log_daemon_msg "Stopping $DESC" "$NAME"
         do_stop
         retval=$?
-        [ "$AUTO_RETIREMENT" != "" ] && [ "$AUTO_RETIREMENT" != "0" ] && do_retire || exit $?
+        if [ "$AUTO_RETIREMENT" != "" ] && [ "$AUTO_RETIREMENT" != "0" ]; then
+          if ! do_retire; then
+            retval=$?
+          fi
+        fi
         case "$retval" in
             0|1) log_end_msg 0 ;;
             *)   log_end_msg 1; exit $retval ;;


### PR DESCRIPTION
This pull request fixes the exit status of `/etc/init.d/mackerel-agent stop` on debian. With the current script, the `stop` command exits with 1 in most case; when `$AUTO_RETIREMENT` is not set.

ref: #172