### PR TITLE
Report checker execution timeout as Unknown status

### DIFF
--- a/checks/checker.go
+++ b/checks/checker.go
@@ -68,16 +68,18 @@ func (c Checker) Check() (*Report, error) {
 	if stderr != "" {
 		logger.Warningf("Checker %q output stderr: %s", c.Name, stderr)
 	}
-	if err != nil {
-		return nil, err
-	}
 
 	status := StatusUnknown
-	if s, ok := exitCodeToStatus[exitCode]; ok {
-		status = s
-	}
 
-	logger.Debugf("Checker %q status=%s message=%q", c.Name, status, message)
+	if err != nil {
+		message = err.Error()
+	} else {
+		if s, ok := exitCodeToStatus[exitCode]; ok {
+			status = s
+		}
+
+		logger.Debugf("Checker %q status=%s message=%q", c.Name, status, message)
+	}
 
 	return &Report{
 		Name:                 c.Name,

--- a/checks/checker_test.go
+++ b/checks/checker_test.go
@@ -19,6 +19,12 @@ func TestChecker_Check(t *testing.T) {
 		},
 	}
 
+	// checkerTimeout := Checker{
+	// 	Config: config.PluginConfig{
+	// 		Command: "sleep 35",
+	// 	},
+	// }
+
 	{
 		report, err := checkerOK.Check()
 		if err != nil {
@@ -44,4 +50,17 @@ func TestChecker_Check(t *testing.T) {
 			t.Errorf("wrong message: %q", report.Message)
 		}
 	}
+
+	// {
+	// 	report, err := checkerTimeout.Check()
+	// 	if err != nil {
+	// 		t.Errorf("err should be nil: %v", err)
+	// 	}
+	// 	if report.Status != StatusUnknown {
+	// 		t.Errorf("status should be UNKNOWN: %v", report.Status)
+	// 	}
+	// 	if report.Message != "command timed out" {
+	// 		t.Errorf("wrong message: %q", report.Message)
+	// 	}
+	// }
 }


### PR DESCRIPTION
In the current implementation timeouts of check plugins are only logged to the agent's log but not reported to the server.
Since a checker command timeouts due to unusual conditions such as a heavy load on the machine, unstable networking or other misconfigurations, I suppose the events shall be immediately reported as incidents.