### PR TITLE
Release version 0.29.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.28.1-1.noarch.rpm
-  - packaging/mackerel-agent_0.28.1-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.29.0-1.noarch.rpm
+  - packaging/mackerel-agent_0.29.0-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.29.0 (2016-03-02)
+
+* remove deprecated command line options (-version and -once) #194 (Songmu)
+* Report checker execution timeout as Unknown status #197 (hanazuki)
+
+
 ## 0.28.1 (2016-02-18)
 
 * fix the exit status on stopping the agent in the init script of debian #192 (itchyny)

--- a/checks/checker_test.go
+++ b/checks/checker_test.go
@@ -1,12 +1,9 @@
 package checks
 
 import (
-	"runtime"
 	"testing"
-	"time"
 
 	"github.com/mackerelio/mackerel-agent/config"
-	"github.com/mackerelio/mackerel-agent/util"
 )
 
 func TestChecker_Check(t *testing.T) {
@@ -44,37 +41,6 @@ func TestChecker_Check(t *testing.T) {
 			t.Errorf("status should be WARNING: %v", report.Status)
 		}
 		if report.Message != "something_is_going_wrong\n" {
-			t.Errorf("wrong message: %q", report.Message)
-		}
-	}
-
-}
-
-func TestChecker_CheckTimeout(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skipf("skip check timeout test in windows")
-	}
-	origTimeoutDur := util.TimeoutDuration
-	defer func() {
-		util.TimeoutDuration = origTimeoutDur
-	}()
-	util.TimeoutDuration = 1 * time.Second
-
-	checkerTimeout := Checker{
-		Config: config.PluginConfig{
-			Command: "sleep 2",
-		},
-	}
-
-	{
-		report, err := checkerTimeout.Check()
-		if err != nil {
-			t.Errorf("err should be nil: %v", err)
-		}
-		if report.Status != StatusUnknown {
-			t.Errorf("status should be UNKNOWN: %v", report.Status)
-		}
-		if report.Message != "command timed out" {
 			t.Errorf("wrong message: %q", report.Message)
 		}
 	}

--- a/checks/checker_unix_test.go
+++ b/checks/checker_unix_test.go
@@ -1,0 +1,38 @@
+// +build linux darwin freebsd netbsd
+
+package checks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mackerelio/mackerel-agent/config"
+	"github.com/mackerelio/mackerel-agent/util"
+)
+
+func TestChecker_CheckTimeout(t *testing.T) {
+	origTimeoutDur := util.TimeoutDuration
+	defer func() {
+		util.TimeoutDuration = origTimeoutDur
+	}()
+	util.TimeoutDuration = 1 * time.Second
+
+	checkerTimeout := Checker{
+		Config: config.PluginConfig{
+			Command: "sleep 2",
+		},
+	}
+
+	{
+		report, err := checkerTimeout.Check()
+		if err != nil {
+			t.Errorf("err should be nil: %v", err)
+		}
+		if report.Status != StatusUnknown {
+			t.Errorf("status should be UNKNOWN: %v", report.Status)
+		}
+		if report.Message != "command timed out" {
+			t.Errorf("wrong message: %q", report.Message)
+		}
+	}
+}

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.29.0-1) stable; urgency=low
+
+  * remove deprecated command line options (-version and -once) (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/194>
+  * Report checker execution timeout as Unknown status (by hanazuki)
+    <https://github.com/mackerelio/mackerel-agent/pull/197>
+
+ -- Songmu <y.songmu@gmail.com>  Wed, 02 Mar 2016 15:14:15 +0900
+
 mackerel-agent (0.28.1-1) stable; urgency=low
 
   * fix the exit status on stopping the agent in the init script of debian (by itchyny)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.28.1
+Version:   0.29.0
 Release:   1
 License:   Commercial
 Summary:   mackerel.io agent

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -71,6 +71,10 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Wed Mar 02 2016 <y.songmu@gmail.com> - 0.29.0-1
+- remove deprecated command line options (-version and -once) (by Songmu)
+- Report checker execution timeout as Unknown status (by hanazuki)
+
 * Thu Feb 18 2016 <stefafafan@hatena.ne.jp> - 0.28.1-1
 - fix the exit status on stopping the agent in the init script of debian (by itchyny)
 


### PR DESCRIPTION
- remove deprecated command line options (-version and -once) #194
- Report checker execution timeout as Unknown status #197