### PR TITLE
Refactor net interface (multi ip support and bug fix)

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -424,7 +424,7 @@ func runCheckersLoop(c *Context, termCheckerCh <-chan struct{}, quit <-chan stru
 }
 
 // collectHostSpecs collects host specs (correspond to "name", "meta" and "interfaces" fields in API v0)
-func collectHostSpecs() (string, map[string]interface{}, []map[string]interface{}, error) {
+func collectHostSpecs() (string, map[string]interface{}, []spec.NetInterface, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to obtain hostname: %s", err.Error())
@@ -437,13 +437,10 @@ func collectHostSpecs() (string, map[string]interface{}, []map[string]interface{
 	}
 	meta := spec.Collect(specGens)
 
-	interfacesSpec, err := interfaceGenerator().Generate()
+	interfaces, err := interfaceGenerator().Generate()
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to collect interfaces: %s", err.Error())
 	}
-
-	interfaces, _ := interfacesSpec.([]map[string]interface{})
-
 	return hostname, meta, interfaces, nil
 }
 

--- a/command/command_darwin.go
+++ b/command/command_darwin.go
@@ -17,7 +17,7 @@ func specGenerators() []spec.Generator {
 	}
 }
 
-func interfaceGenerator() spec.Generator {
+func interfaceGenerator() spec.InterfaceGenerator {
 	return &specDarwin.InterfaceGenerator{}
 }
 

--- a/command/command_freebsd.go
+++ b/command/command_freebsd.go
@@ -17,7 +17,7 @@ func specGenerators() []spec.Generator {
 	}
 }
 
-func interfaceGenerator() spec.Generator {
+func interfaceGenerator() spec.InterfaceGenerator {
 	return &specFreebsd.InterfaceGenerator{}
 }
 

--- a/command/command_linux.go
+++ b/command/command_linux.go
@@ -18,7 +18,7 @@ func specGenerators() []spec.Generator {
 	}
 }
 
-func interfaceGenerator() spec.Generator {
+func interfaceGenerator() spec.InterfaceGenerator {
 	return &specLinux.InterfaceGenerator{}
 }
 

--- a/command/command_netbsd.go
+++ b/command/command_netbsd.go
@@ -17,7 +17,7 @@ func specGenerators() []spec.Generator {
 	}
 }
 
-func interfaceGenerator() spec.Generator {
+func interfaceGenerator() spec.InterfaceGenerator {
 	return &specNetbsd.InterfaceGenerator{}
 }
 

--- a/command/command_windows.go
+++ b/command/command_windows.go
@@ -18,7 +18,7 @@ func specGenerators() []spec.Generator {
 	}
 }
 
-func interfaceGenerator() spec.Generator {
+func interfaceGenerator() spec.InterfaceGenerator {
 	return &specWindows.InterfaceGenerator{}
 }
 

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -131,7 +131,7 @@ func (api *API) FindHost(id string) (*Host, error) {
 }
 
 // CreateHost register the host to mackerel
-func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces []map[string]interface{}, roleFullnames []string, displayName string) (string, error) {
+func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces interface{}, roleFullnames []string, displayName string) (string, error) {
 	resp, err := api.postJSON("/api/v0/hosts", map[string]interface{}{
 		"name":          name,
 		"type":          "unknown",

--- a/mackerel/host.go
+++ b/mackerel/host.go
@@ -10,10 +10,10 @@ type Host struct {
 
 // HostSpec is host specifications sent Mackerel server per hour
 type HostSpec struct {
-	Name          string                   `json:"name"`
-	Meta          map[string]interface{}   `json:"meta"`
-	Interfaces    []map[string]interface{} `json:"interfaces"`
-	RoleFullnames []string                 `json:"roleFullnames"`
-	Checks        []string                 `json:"checks"`
-	DisplayName   string                   `json:"displayName,omitempty"`
+	Name          string                 `json:"name"`
+	Meta          map[string]interface{} `json:"meta"`
+	Interfaces    interface{}            `json:"interfaces"`
+	RoleFullnames []string               `json:"roleFullnames"`
+	Checks        []string               `json:"checks"`
+	DisplayName   string                 `json:"displayName,omitempty"`
 }

--- a/spec/darwin/interface_test.go
+++ b/spec/darwin/interface_test.go
@@ -22,30 +22,23 @@ func TestInterfaceGenerate(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	interfaces, typeOk := value.([]map[string]interface{})
-	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
-	}
-
 	if os.Getenv("TRAVIS") != "" {
 		t.Skip("Skip in Travis for now")
 	}
 
-	if len(interfaces) == 0 {
+	if len(value) == 0 {
 		t.Error("should have at least 1 interface")
+		return
 	}
 
-	iface := interfaces[0]
-	if _, ok := iface["ipAddress"]; !ok {
-		t.Error("interface should have ipAddress")
+	iface := value[0]
+	if len(iface.IPv4Addresses) <= 0 {
+		t.Error("interface should have ipv4Addresses")
 	}
-	if _, ok := iface["macAddress"]; !ok {
+	if iface.MacAddress == "" {
 		t.Error("interface should have macAddress")
 	}
-	if _, ok := iface["netmask"]; !ok {
-		t.Error("interface should have netmask")
-	}
-	if _, ok := iface["defaultGateway"]; !ok {
+	if iface.DefaultGateway == "" {
 		t.Error("interface should have defaultGateway")
 	}
 }
@@ -62,20 +55,17 @@ func TestGenerateByIfconfigCommand(t *testing.T) {
 		t.Log("Skip: should have interfaces")
 	}
 
-	iface := interfaces[name]
-	if len(iface) == 0 {
+	iface, ok := interfaces[name]
+	if !ok {
 		t.Log("Skip: should have item")
 	}
-	if _, ok := iface["ipAddress"]; !ok {
-		t.Log("Skip: interface should have ipAddress")
+	if len(iface.IPv4Addresses) <= 0 {
+		t.Log("Skip: interface should have ipv4Addresses")
 	}
-	if _, ok := iface["macAddress"]; !ok {
+	if iface.MacAddress == "" {
 		t.Log("Skip: interface should have macAddress")
 	}
-	if _, ok := iface["netmask"]; !ok {
-		t.Log("Skip: interface should have netmask")
-	}
-	if _, ok := iface["defaultGateway"]; !ok {
+	if iface.DefaultGateway == "" {
 		t.Log("Skip: interface should have defaultGateway")
 	}
 }

--- a/spec/freebsd/interface.go
+++ b/spec/freebsd/interface.go
@@ -2,6 +2,8 @@
 
 package freebsd
 
+import "github.com/mackerelio/mackerel-agent/spec"
+
 // InterfaceGenerator XXX
 type InterfaceGenerator struct {
 }
@@ -12,10 +14,7 @@ func (g *InterfaceGenerator) Key() string {
 }
 
 // Generate XXX
-func (g *InterfaceGenerator) Generate() (interface{}, error) {
-	var interfaces map[string]map[string]interface{}
-
+func (g *InterfaceGenerator) Generate() ([]spec.NetInterface, error) {
 	// TODO
-
-	return interfaces, nil
+	return []spec.NetInterface{}, nil
 }

--- a/spec/linux/interface.go
+++ b/spec/linux/interface.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/mackerel-agent/spec"
 )
 
 // InterfaceGenerator XXX
@@ -22,8 +23,8 @@ func (g *InterfaceGenerator) Key() string {
 var interfaceLogger = logging.GetLogger("spec.interface")
 
 // Generate XXX
-func (g *InterfaceGenerator) Generate() (interface{}, error) {
-	var interfaces map[string]map[string]interface{}
+func (g *InterfaceGenerator) Generate() ([]spec.NetInterface, error) {
+	var interfaces spec.NetInterfaces
 	_, err := exec.LookPath("ip")
 	// has ip command
 	if err == nil {
@@ -37,28 +38,33 @@ func (g *InterfaceGenerator) Generate() (interface{}, error) {
 			return nil, err
 		}
 	}
-
-	var results []map[string]interface{}
-	for key, iface := range interfaces {
-		if iface["encap"] == nil || iface["encap"] == "Loopback" {
+	var results []spec.NetInterface
+	for _, iface := range interfaces {
+		if iface.Encap == "" || iface.Encap == "Loopback" {
 			continue
 		}
-		ipv4s, okv4 := iface["ipv4Addresses"].([]string)
-		ipv6s, okv6 := iface["ipv6Addresses"].([]string)
-		if !okv4 || !okv6 || (len(ipv4s) == 0 && len(ipv6s) == 0) {
+		if len(iface.IPv4Addresses) == 0 && len(iface.IPv6Addresses) == 0 {
 			continue
 		}
-		iface["name"] = key
 		results = append(results, iface)
 	}
-
 	return results, nil
 }
 
-func (g *InterfaceGenerator) generateByIPCommand() (map[string]map[string]interface{}, error) {
-	interfaces := make(map[string]map[string]interface{})
-	name := ""
+var (
+	// ex.) 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+	ipCmdNameReg = regexp.MustCompile(`^(\d+): ([0-9a-zA-Z@:\.\-_]*?)(@[0-9a-zA-Z]+|):\s`)
+	// ex.) link/ether 12:34:56:78:9a:bc brd ff:ff:ff:ff:ff:ff
+	ipCmdEncapReg = regexp.MustCompile(`link\/(\w+) ([\da-f\:]+) `)
+	// ex.) inet 10.0.4.7/24 brd 10.0.5.255 scope global eth0
+	ipCmdIPv4Reg = regexp.MustCompile(`inet (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(\/(\d{1,2}))?`)
+	//inet6 fe80::44b3:b3ff:fe1c:d17c/64 scope link
+	ipCmdIPv6Reg = regexp.MustCompile(`inet6 ([a-f0-9\:]+)\/(\d+) scope (\w+)`)
+)
 
+func (g *InterfaceGenerator) generateByIPCommand() (spec.NetInterfaces, error) {
+	interfaces := make(spec.NetInterfaces)
+	name := ""
 	{
 		// ip addr
 		out, err := exec.Command("ip", "addr").Output()
@@ -66,30 +72,19 @@ func (g *InterfaceGenerator) generateByIPCommand() (map[string]map[string]interf
 			interfaceLogger.Errorf("Failed to run ip command (skip this spec): %s", err)
 			return nil, err
 		}
-
 		for _, line := range strings.Split(string(out), "\n") {
-			// ex.) 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
-			if matches := regexp.MustCompile(`^(\d+): ([0-9a-zA-Z@:\.\-_]*?)(@[0-9a-zA-Z]+|):\s`).FindStringSubmatch(line); matches != nil {
+			if matches := ipCmdNameReg.FindStringSubmatch(line); matches != nil {
 				name = matches[2]
-				interfaces[name] = make(map[string]interface{}, 0)
-				interfaces[name]["ipv4Addresses"] = []string{}
-				interfaces[name]["ipv6Addresses"] = []string{}
 			}
-
-			// ex.) link/ether 12:34:56:78:9a:bc brd ff:ff:ff:ff:ff:ff
-			if matches := regexp.MustCompile(`link\/(\w+) ([\da-f\:]+) `).FindStringSubmatch(line); matches != nil {
-				interfaces[name]["encap"] = g.translateEncap(matches[1])
-				interfaces[name]["macAddress"] = matches[2]
+			if matches := ipCmdEncapReg.FindStringSubmatch(line); matches != nil {
+				interfaces.SetEncap(name, translateEncap(matches[1]))
+				interfaces.SetMacAddress(name, matches[2])
 			}
-
-			// ex.) inet 10.0.4.7/24 brd 10.0.5.255 scope global eth0
-			if matches := regexp.MustCompile(`inet (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(\/(\d{1,2}))?`).FindStringSubmatch(line); matches != nil {
-				interfaces[name]["ipv4Addresses"] = append(interfaces[name]["ipv4Addresses"].([]string), matches[1])
+			if matches := ipCmdIPv4Reg.FindStringSubmatch(line); matches != nil {
+				interfaces.AppendIPv4Address(name, matches[1])
 			}
-
-			//inet6 fe80::44b3:b3ff:fe1c:d17c/64 scope link
-			if matches := regexp.MustCompile(`inet6 ([a-f0-9\:]+)\/(\d+) scope (\w+)`).FindStringSubmatch(line); matches != nil {
-				interfaces[name]["ipv6Addresses"] = append(interfaces[name]["ipv6Addresses"].([]string), matches[1])
+			if matches := ipCmdIPv6Reg.FindStringSubmatch(line); matches != nil {
+				interfaces.AppendIPv6Address(name, matches[1])
 			}
 		}
 	}
@@ -101,40 +96,75 @@ func (g *InterfaceGenerator) generateByIPCommand() (map[string]map[string]interf
 			interfaceLogger.Errorf("Failed to run ip command (skip this spec): %s", err)
 			return interfaces, err
 		}
-
 		for _, line := range strings.Split(string(out), "\n") {
-			// ex.) 10.0.3.0/24 dev eth0  proto kernel  scope link  src 10.0.4.7
-			// ex.) fe80::/64 dev eth0  proto kernel  metric 256
-			if matches := regexp.MustCompile(`^([^\s]+)\s(.*)$`).FindStringSubmatch(line); matches != nil {
-				if matches := regexp.MustCompile(`\bdev\s+([^\s]+)\b`).FindStringSubmatch(matches[2]); matches != nil {
-					name = matches[1]
-				} else {
-					continue
-				}
-
-				// ex.) 10.0.3.0/24
-				if matches := regexp.MustCompile(`(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(\/(\d{1,2}))?`).FindStringSubmatch(matches[1]); matches != nil {
-					interfaces[name]["address"] = matches[1]
-				}
-
-				// ex.) fe80::/64
-				if matches := regexp.MustCompile(`([a-f0-9\:]+)\/(\d+)`).FindStringSubmatch(matches[1]); matches != nil {
-					interfaces[name]["v6address"] = matches[1]
-				}
-
-				// ex.) default via 10.0.3.1 dev eth0
-				if matches := regexp.MustCompile(`\bvia\s+([^\s]+)\b`).FindStringSubmatch(matches[2]); matches != nil {
-					interfaces[name]["defaultGateway"] = matches[1]
-				}
+			name, addr, v6addr, defaultGateway := parseIProuteLine(line)
+			if name == "" {
+				continue
+			}
+			if addr != "" {
+				interfaces.SetAddress(name, addr)
+			}
+			if v6addr != "" {
+				interfaces.SetV6Address(name, v6addr)
+			}
+			if defaultGateway != "" {
+				interfaces.SetDefaultGateway(name, defaultGateway)
 			}
 		}
 	}
-
 	return interfaces, nil
 }
 
-func (g *InterfaceGenerator) generateByIfconfigCommand() (map[string]map[string]interface{}, error) {
-	interfaces := make(map[string]map[string]interface{})
+var (
+	// ex.) 10.0.3.0/24 dev eth0  proto kernel  scope link  src 10.0.4.7
+	// ex.) fe80::/64 dev eth0  proto kernel  metric 256
+	ipRouteLineReg   = regexp.MustCompile(`^([^\s]+)\s(.*)$`)
+	ipRouteDeviceReg = regexp.MustCompile(`\bdev\s+([^\s]+)\b`)
+	// ex.) 10.0.3.0/24
+	ipRouteIPv4Reg = regexp.MustCompile(`(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(\/(\d{1,2}))?`)
+	// ex.) fe80::/64
+	ipRouteIPv6Reg = regexp.MustCompile(`([a-f0-9\:]+)\/(\d+)`)
+	// ex.) default via 10.0.3.1 dev eth0
+	ipRouteDefaultGatewayReg = regexp.MustCompile(`\bvia\s+([^\s]+)\b`)
+)
+
+func parseIProuteLine(line string) (name, addr, v6addr, defaultGateway string) {
+	matches := ipRouteLineReg.FindStringSubmatch(line)
+	if matches == nil && len(matches) < 3 {
+		return
+	}
+	if matches := ipRouteDeviceReg.FindStringSubmatch(matches[2]); matches != nil {
+		name = matches[1]
+	} else {
+		return
+	}
+	if matches := ipRouteIPv4Reg.FindStringSubmatch(matches[1]); matches != nil {
+		addr = matches[1]
+	}
+	if matches := ipRouteIPv6Reg.FindStringSubmatch(matches[1]); matches != nil {
+		v6addr = matches[1]
+	}
+	if matches := ipRouteDefaultGatewayReg.FindStringSubmatch(matches[2]); matches != nil {
+		defaultGateway = matches[1]
+	}
+	return
+}
+
+var (
+	// ex.) eth0      Link encap:Ethernet  HWaddr 12:34:56:78:9a:bc
+	ifconfigNameReg = regexp.MustCompile(`^([0-9a-zA-Z@\.\:\-_]+)\s+`)
+	// ex.) eth0      Link encap:Ethernet  HWaddr 12:34:56:78:9a:bc
+	ifconfigEncapReg = regexp.MustCompile(`Link encap:(Local Loopback)|Link encap:(.+?)\s`)
+	// ex.) eth0      Link encap:Ethernet  HWaddr 00:16:3e:4f:f3:41
+	ifconfigMacAddrReg = regexp.MustCompile(`HWaddr (.+?)\s`)
+	// ex.) inet addr:10.0.4.7  Bcast:10.0.5.255  Mask:255.255.255.0
+	ifconfigV4AddrReg = regexp.MustCompile(`inet addr:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})`)
+	// ex.) inet6 addr: fe80::44b3:b3ff:fe1c:d17c/64 Scope:Link
+	ifconfigV6AddrReg = regexp.MustCompile(`inet6 addr: ([a-f0-9\:]+)\/(\d+) Scope:(\w+)`)
+)
+
+func (g *InterfaceGenerator) generateByIfconfigCommand() (spec.NetInterfaces, error) {
+	interfaces := make(spec.NetInterfaces)
 	name := ""
 
 	{
@@ -144,34 +174,25 @@ func (g *InterfaceGenerator) generateByIfconfigCommand() (map[string]map[string]
 			interfaceLogger.Errorf("Failed to run ifconfig command (skip this spec): %s", err)
 			return nil, err
 		}
-
 		for _, line := range strings.Split(string(out), "\n") {
-			// ex.) eth0      Link encap:Ethernet  HWaddr 12:34:56:78:9a:bc
-			if matches := regexp.MustCompile(`^([0-9a-zA-Z@\.\:\-_]+)\s+`).FindStringSubmatch(line); matches != nil {
+			if matches := ifconfigNameReg.FindStringSubmatch(line); matches != nil {
 				name = matches[1]
-				interfaces[name] = make(map[string]interface{}, 0)
-				interfaces[name]["ipv4Addresses"] = []string{}
-				interfaces[name]["ipv6Addresses"] = []string{}
 			}
-			// ex.) eth0      Link encap:Ethernet  HWaddr 12:34:56:78:9a:bc
-			if matches := regexp.MustCompile(`Link encap:(Local Loopback)|Link encap:(.+?)\s`).FindStringSubmatch(line); matches != nil {
-				if matches[1] != "" {
-					interfaces[name]["encap"] = g.translateEncap(matches[1])
-				} else {
-					interfaces[name]["encap"] = g.translateEncap(matches[2])
+			if matches := ifconfigEncapReg.FindStringSubmatch(line); matches != nil {
+				encap := matches[1]
+				if encap == "" {
+					encap = matches[2]
 				}
+				interfaces.SetEncap(name, translateEncap(encap))
 			}
-			// ex.) eth0      Link encap:Ethernet  HWaddr 00:16:3e:4f:f3:41
-			if matches := regexp.MustCompile(`HWaddr (.+?)\s`).FindStringSubmatch(line); matches != nil {
-				interfaces[name]["macAddress"] = matches[1]
+			if matches := ifconfigMacAddrReg.FindStringSubmatch(line); matches != nil {
+				interfaces.SetMacAddress(name, matches[1])
 			}
-			// ex.) inet addr:10.0.4.7  Bcast:10.0.5.255  Mask:255.255.255.0
-			if matches := regexp.MustCompile(`inet addr:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})`).FindStringSubmatch(line); matches != nil {
-				interfaces[name]["ipv4Addresses"] = append(interfaces[name]["ipv4Addresses"].([]string), matches[1])
+			if matches := ifconfigV4AddrReg.FindStringSubmatch(line); matches != nil {
+				interfaces.AppendIPv4Address(name, matches[1])
 			}
-			// ex.) inet6 addr: fe80::44b3:b3ff:fe1c:d17c/64 Scope:Link
-			if matches := regexp.MustCompile(`inet6 addr: ([a-f0-9\:]+)\/(\d+) Scope:(\w+)`).FindStringSubmatch(line); matches != nil {
-				interfaces[name]["ipv6Addresses"] = append(interfaces[name]["ipv6Addresses"].([]string), matches[1])
+			if matches := ifconfigV6AddrReg.FindStringSubmatch(line); matches != nil {
+				interfaces.AppendIPv6Address(name, matches[1])
 			}
 		}
 	}
@@ -183,18 +204,12 @@ func (g *InterfaceGenerator) generateByIfconfigCommand() (map[string]map[string]
 			interfaceLogger.Errorf("Failed to run route command (skip this spec): %s", err)
 			return interfaces, err
 		}
-
-		routeRegexp := regexp.MustCompile(`^0\.0\.0\.0`)
 		for _, line := range strings.Split(string(out), "\n") {
-			// Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
-			// 0.0.0.0         10.0.3.1        0.0.0.0         UG    0      0        0 eth0
-			if routeRegexp.FindStringSubmatch(line) != nil {
-				routeResults := regexp.MustCompile(`[ \t]+`).Split(line, 8)
-				if len(routeResults) < 8 || interfaces[routeResults[7]] == nil {
-					continue
-				}
-				interfaces[routeResults[7]]["defaultGateway"] = routeResults[1]
+			name, defaultGateway := parseRouteLine(line)
+			if name == "" {
+				continue
 			}
+			interfaces.SetDefaultGateway(name, defaultGateway)
 		}
 	}
 
@@ -205,23 +220,41 @@ func (g *InterfaceGenerator) generateByIfconfigCommand() (map[string]map[string]
 			interfaceLogger.Errorf("Failed to run arp command (skip this spec): %s", err)
 			return interfaces, err
 		}
-
-		arpRegexp := regexp.MustCompile(`^\S+ \((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\) at ([a-fA-F0-9\:]+) \[(\w+)\] on ([0-9a-zA-Z\.\:\-]+)`)
 		for _, line := range strings.Split(string(out), "\n") {
-			// ex.) ? (10.0.3.2) at 01:23:45:67:89:ab [ether] on eth0
-			if matches := arpRegexp.FindStringSubmatch(line); matches != nil {
-				if interfaces[matches[4]] == nil {
-					continue
-				}
-				interfaces[matches[4]]["address"] = matches[1]
+			name, addr := parseArpLine(line)
+			if name == "" {
+				continue
 			}
+			interfaces.SetAddress(name, addr)
 		}
 	}
-
 	return interfaces, nil
 }
 
-func (g *InterfaceGenerator) translateEncap(encap string) string {
+// Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
+// 0.0.0.0         10.0.3.1        0.0.0.0         UG    0      0        0 eth0
+func parseRouteLine(line string) (name, defaultGateway string) {
+	if !strings.HasPrefix(line, "0.0.0.0") {
+		return
+	}
+	routeResults := strings.Fields(line)
+	if len(routeResults) < 8 {
+		return
+	}
+	return routeResults[7], routeResults[1]
+}
+
+// ex.) ? (10.0.3.2) at 01:23:45:67:89:ab [ether] on eth0
+var arpRegexp = regexp.MustCompile(`^\S+ \((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\) at ([a-fA-F0-9\:]+) \[(\w+)\] on ([0-9a-zA-Z\.\:\-]+)`)
+
+func parseArpLine(line string) (name, addr string) {
+	if matches := arpRegexp.FindStringSubmatch(line); matches != nil {
+		return matches[4], matches[1]
+	}
+	return
+}
+
+func translateEncap(encap string) string {
 	switch encap {
 	case "Local Loopback", "loopback":
 		return "Loopback"

--- a/spec/linux/interface_test.go
+++ b/spec/linux/interface_test.go
@@ -22,31 +22,26 @@ func TestInterfaceGenerate(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	interfaces, typeOk := value.([]map[string]interface{})
-	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
-	}
-
 	if os.Getenv("TRAVIS") != "" {
 		t.Skip("Skip in Travis for now")
 	}
 
-	if len(interfaces) == 0 {
+	if len(value) == 0 {
 		t.Error("should have at least 1 interface")
 		return
 	}
 
-	iface := interfaces[0]
-	if addrs, ok := iface["ipv4Addresses"]; !ok || len(addrs.([]string)) <= 0 {
+	iface := value[0]
+	if len(iface.IPv4Addresses) <= 0 {
 		t.Error("interface should have ipv4Addresses")
 	}
-	if _, ok := iface["macAddress"]; !ok {
+	if iface.MacAddress == "" {
 		t.Error("interface should have macAddress")
 	}
-	if _, ok := iface["address"]; !ok {
+	if iface.Address == "" {
 		t.Error("interface should have address")
 	}
-	if _, ok := iface["defaultGateway"]; !ok {
+	if iface.DefaultGateway == "" {
 		t.Error("interface should have defaultGateway")
 	}
 }
@@ -72,17 +67,17 @@ func TestGenerateByIpCommand(t *testing.T) {
 		return
 	}
 
-	iface := interfaces[name]
-	if len(iface) == 0 {
+	iface, ok := interfaces[name]
+	if !ok {
 		t.Error("should have item")
 	}
-	if addrs, ok := iface["ipv4Addresses"]; !ok || len(addrs.([]string)) <= 0 {
+	if len(iface.IPv4Addresses) <= 0 {
 		t.Error("interface should have ipv4Addresses")
 	}
-	if _, ok := iface["macAddress"]; !ok {
+	if iface.MacAddress == "" {
 		t.Error("interface should have macAddress")
 	}
-	if _, ok := iface["defaultGateway"]; !ok {
+	if iface.DefaultGateway == "" {
 		t.Error("interface should have defaultGateway")
 	}
 }
@@ -99,23 +94,17 @@ func TestGenerateByIfconfigCommand(t *testing.T) {
 		t.Log("Skip: should have interfaces")
 	}
 
-	iface := interfaces[name]
-	if len(iface) == 0 {
+	iface, ok := interfaces[name]
+	if !ok {
 		t.Log("Skip: should have item")
 	}
-	if addrs, ok := iface["ipv4Addresses"]; !ok || len(addrs.([]string)) <= 0 {
+	if len(iface.IPv4Addresses) <= 0 {
 		t.Log("Skip: interface should have ipv4Addresses")
 	}
-	if _, ok := iface["macAddress"]; !ok {
+	if iface.MacAddress == "" {
 		t.Log("Skip: interface should have macAddress")
 	}
-	if _, ok := iface["netmask"]; !ok {
-		t.Log("Skip: interface should have netmask")
-	}
-	if _, ok := iface["address"]; !ok {
-		t.Log("Skip: interface should have address")
-	}
-	if _, ok := iface["defaultGateway"]; !ok {
+	if iface.DefaultGateway == "" {
 		t.Log("Skip: interface should have defaultGateway")
 	}
 }

--- a/spec/net_interface.go
+++ b/spec/net_interface.go
@@ -1,0 +1,79 @@
+package spec
+
+// NetInterface represents network interface informations
+type NetInterface struct {
+	Name           string   `json:"name"`
+	Encap          string   `json:"encap,omitempty"`
+	IPv4Addresses  []string `json:"ipv4Addresses"`
+	IPv6Addresses  []string `json:"ipv6Addresses"`
+	Address        string   `json:"address,omitempty"`
+	V6Address      string   `json:"v6address,omitempty"`
+	MacAddress     string   `json:"macAddress,omitempty"`
+	DefaultGateway string   `json:"defaultGateway,omitempty"`
+}
+
+// NetInterfaces are map of network interfaces per name
+type NetInterfaces map[string]NetInterface
+
+func (ifs NetInterfaces) getOrNew(name string) NetInterface {
+	iface, ok := ifs[name]
+	if ok {
+		return iface
+	}
+	return NetInterface{Name: name}
+}
+
+// SetEncap sets the encap
+func (ifs NetInterfaces) SetEncap(name, encap string) {
+	iface := ifs.getOrNew(name)
+	iface.Encap = encap
+	ifs[name] = iface
+}
+
+// SetAddress sets the address
+func (ifs NetInterfaces) SetAddress(name, addr string) {
+	iface := ifs.getOrNew(name)
+	iface.Address = addr
+	ifs[name] = iface
+}
+
+// SetV6Address sets the v6address
+func (ifs NetInterfaces) SetV6Address(name, addr string) {
+	iface := ifs.getOrNew(name)
+	iface.V6Address = addr
+	ifs[name] = iface
+}
+
+// SetMacAddress sets the macaddress
+func (ifs NetInterfaces) SetMacAddress(name, addr string) {
+	iface := ifs.getOrNew(name)
+	iface.MacAddress = addr
+	ifs[name] = iface
+}
+
+// SetDefaultGateway sets the defaultGateway
+func (ifs NetInterfaces) SetDefaultGateway(name, gateway string) {
+	iface := ifs.getOrNew(name)
+	iface.DefaultGateway = gateway
+	ifs[name] = iface
+}
+
+// AppendIPv4Address appends ipv4address
+func (ifs NetInterfaces) AppendIPv4Address(name, addr string) {
+	iface := ifs.getOrNew(name)
+	iface.IPv4Addresses = append(iface.IPv4Addresses, addr)
+	ifs[name] = iface
+}
+
+// AppendIPv6Address appends ipv6address
+func (ifs NetInterfaces) AppendIPv6Address(name, addr string) {
+	iface := ifs.getOrNew(name)
+	iface.IPv6Addresses = append(iface.IPv6Addresses, addr)
+	ifs[name] = iface
+}
+
+// InterfaceGenerator retrieve network informations
+type InterfaceGenerator interface {
+	Key() string
+	Generate() ([]NetInterface, error)
+}

--- a/spec/netbsd/interface.go
+++ b/spec/netbsd/interface.go
@@ -2,6 +2,8 @@
 
 package netbsd
 
+import "github.com/mackerelio/mackerel-agent/spec"
+
 // InterfaceGenerator XXX
 type InterfaceGenerator struct {
 }
@@ -12,10 +14,7 @@ func (g *InterfaceGenerator) Key() string {
 }
 
 // Generate XXX
-func (g *InterfaceGenerator) Generate() (interface{}, error) {
-	var interfaces map[string]map[string]interface{}
-
+func (g *InterfaceGenerator) Generate() ([]spec.NetInterface, error) {
 	// TODO
-
-	return interfaces, nil
+	return []spec.NetInterface{}, nil
 }

--- a/spec/windows/interface.go
+++ b/spec/windows/interface.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/mackerel-agent/spec"
 	"github.com/mackerelio/mackerel-agent/util/windows"
 )
 
@@ -21,8 +22,8 @@ func (g *InterfaceGenerator) Key() string {
 var interfaceLogger = logging.GetLogger("spec.interface")
 
 // Generate XXX
-func (g *InterfaceGenerator) Generate() (interface{}, error) {
-	var results []map[string]interface{}
+func (g *InterfaceGenerator) Generate() ([]spec.NetInterface, error) {
+	var results []spec.NetInterface
 
 	ifs, err := net.Interfaces()
 	if err != nil {
@@ -35,10 +36,11 @@ func (g *InterfaceGenerator) Generate() (interface{}, error) {
 	}
 
 	for _, ifi := range ifs {
-		addr, err := ifi.Addrs()
-		if err != nil {
-			return nil, err
+		if ifi.Flags&net.FlagLoopback != 0 {
+			continue
 		}
+
+		// XXX occur mojibake when containing multi-byte strings
 		name := ifi.Name
 		for ; ai != nil; ai = ai.Next {
 			if ifi.Index == int(ai.Index) {
@@ -46,12 +48,38 @@ func (g *InterfaceGenerator) Generate() (interface{}, error) {
 			}
 		}
 
-		results = append(results, map[string]interface{}{
-			"name":       name,
-			"ipAddress":  addr[0].String(),
-			"macAddress": ifi.HardwareAddr.String(),
-		})
-	}
+		addrs, err := ifi.Addrs()
+		if err != nil {
+			return nil, err
+		}
+		ipv4Addresses := []string{}
+		ipv6Addresses := []string{}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			if ipv4 := ip.To4(); ipv4 != nil {
+				ipv4Addresses = append(ipv4Addresses, ipv4.String())
+				continue
+			}
+			if ipv6 := ip.To16(); ipv6 != nil {
+				ipv6Addresses = append(ipv6Addresses, ipv6.String())
+			}
+		}
 
+		if len(ipv4Addresses) > 0 || len(ipv6Addresses) > 0 {
+			results = append(results, spec.NetInterface{
+				Name:          name,
+				IPv4Addresses: ipv4Addresses,
+				IPv6Addresses: ipv6Addresses,
+				MacAddress:    ifi.HardwareAddr.String(),
+			})
+		}
+	}
 	return results, nil
 }

--- a/spec/windows/interface_test.go
+++ b/spec/windows/interface_test.go
@@ -16,27 +16,24 @@ func TestInterfaceKey(t *testing.T) {
 
 func TestInterfaceGenerate(t *testing.T) {
 	g := &InterfaceGenerator{}
-	value, err := g.Generate()
+	interfaces, err := g.Generate()
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	interfaces, typeOk := value.([]map[string]interface{})
-	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
-	}
 	if len(interfaces) == 0 {
-		t.Error("should have at least 1 interface")
+		t.Skipf("testing environment has no interface")
+		return
 	}
 
 	iface := interfaces[0]
-	if _, ok := iface["name"]; !ok {
+	if iface.Name == "" {
 		t.Error("interface should have name")
 	}
-	if _, ok := iface["ipAddress"]; !ok {
-		t.Error("interface should have ipAddress")
+	if len(iface.IPv4Addresses) == 0 {
+		t.Error("interface should have IPv4Addresses")
 	}
-	if _, ok := iface["macAddress"]; !ok {
+	if iface.MacAddress == "" {
 		t.Error("interface should have macAddress")
 	}
 }


### PR DESCRIPTION
- define spec.NetInterface
- define spec.InterfaceGenerator and change command/interfaceGenerator using it
- multiple ip support in windows and darwin
- distinguish ipv4 and ipv6 in spec/windows/interface