### PR TITLE
Stop to fetch flags of cpu in spec/linux/cpu

### DIFF
--- a/spec/linux/cpu.go
+++ b/spec/linux/cpu.go
@@ -60,8 +60,6 @@ func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
 			cur["mhz"] = matches[1]
 		} else if matches := regexp.MustCompile(`^cache size\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
 			cur["cache_size"] = matches[1]
-		} else if matches := regexp.MustCompile(`^flags\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["flags"] = regexp.MustCompile(` `).Split(matches[1], -1)
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/spec/linux/cpu.go
+++ b/spec/linux/cpu.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/mackerelio/mackerel-agent/logging"
 )
@@ -15,12 +16,13 @@ import (
 type CPUGenerator struct {
 }
 
-// Key XXX
+// Key return "cpu"
 func (g *CPUGenerator) Key() string {
 	return "cpu"
 }
 
 var cpuLogger = logging.GetLogger("spec.cpu")
+var cpuinfoLineReg = regexp.MustCompile(`^([^:]+?)\s+:\s+(.*)$`)
 
 func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
 	scanner := bufio.NewScanner(file)
@@ -31,35 +33,27 @@ func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-
-		if matches := regexp.MustCompile(`^processor\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur = make(map[string]interface{})
-			if modelName != "" {
-				cur["model_name"] = modelName
+		if matches := cpuinfoLineReg.FindStringSubmatch(line); matches != nil {
+			key := matches[1]
+			val := matches[2]
+			switch key {
+			case "processor":
+				cur = make(map[string]interface{})
+				if modelName != "" {
+					cur["model_name"] = modelName
+				}
+				results = append(results, cur)
+			case "Processor":
+				modelName = val
+			case "vendor_id", "model", "stepping", "physical id", "core id", "model name", "cache size":
+				cur[strings.Replace(key, " ", "_", -1)] = val
+			case "cpu family":
+				cur["family"] = val
+			case "cpu cores":
+				cur["cores"] = val
+			case "cpu MHz":
+				cur["mhz"] = val
 			}
-			results = append(results, cur)
-		} else if matches := regexp.MustCompile(`^Processor\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			modelName = matches[1]
-		} else if matches := regexp.MustCompile(`^vendor_id\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["vendor_id"] = matches[1]
-		} else if matches := regexp.MustCompile(`^cpu family\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["family"] = matches[1]
-		} else if matches := regexp.MustCompile(`^model\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["model"] = matches[1]
-		} else if matches := regexp.MustCompile(`^stepping\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["stepping"] = matches[1]
-		} else if matches := regexp.MustCompile(`^physical id\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["physical_id"] = matches[1]
-		} else if matches := regexp.MustCompile(`^core id\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["core_id"] = matches[1]
-		} else if matches := regexp.MustCompile(`^cpu cores\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["cores"] = matches[1]
-		} else if matches := regexp.MustCompile(`^model name\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["model_name"] = matches[1]
-		} else if matches := regexp.MustCompile(`^cpu MHz\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["mhz"] = matches[1]
-		} else if matches := regexp.MustCompile(`^cache size\s+:\s+(.*)$`).FindStringSubmatch(line); matches != nil {
-			cur["cache_size"] = matches[1]
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -77,7 +71,7 @@ func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
 	return results, nil
 }
 
-// Generate XXX
+// Generate cpu specs
 func (g *CPUGenerator) Generate() (interface{}, error) {
 	file, err := os.Open("/proc/cpuinfo")
 	if err != nil {

--- a/spec/linux/cpu_test.go
+++ b/spec/linux/cpu_test.go
@@ -65,12 +65,6 @@ func TestCPUGenerate(t *testing.T) {
 	if _, ok := cpu1["cache_size"]; !ok {
 		t.Error("cpu should have cache_size")
 	}
-	if _, ok := cpu1["flags"]; !ok {
-		t.Error("cpu should have flags")
-	}
-	if _, ok := cpu1["flags"].([]string); !ok {
-		t.Error("cpu.flags should be slice of string")
-	}
 }
 
 func TestCPUgenerate_linux4_0_amd64(t *testing.T) {


### PR DESCRIPTION
Stop to fetch flags of cpu in spec/linux/cpu. It's too noisy