### PR TITLE
Release version 0.30.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ deploy:
   api_key:
     secure: NtpNjquqjnwpeVQQM1GTHTTU7YOo8fEIyoBtMf3Vf1ayZjuWVZxwNfM77E596TG52a8pnZtpapXyHT0M4e1zms7F5KVCrOEfOB0OrA4IDzoATelVqdONnN3lbRJeVJVdSmK8/FNKwjI24tQZTaTQcIOioNqh7ZRcrEYlatGCuAw=
   file:
-  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.29.2-1.noarch.rpm
-  - packaging/mackerel-agent_0.29.2-1_all.deb
+  - /home/travis/rpmbuild/RPMS/noarch/mackerel-agent-0.30.0-1.noarch.rpm
+  - packaging/mackerel-agent_0.30.0-1_all.deb
   - snapshot/mackerel-agent_darwin_386.zip
   - snapshot/mackerel-agent_darwin_amd64.zip
   - snapshot/mackerel-agent_freebsd_386.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.30.0 (2016-03-17)
+
+* remove uptime metrics generator #161 (Songmu)
+* Remove deprecated-sensu feature #202 (Songmu)
+* Send all IP addresses of each interface (linux only) #205 (mechairoi)
+* add `init` subcommand #207 (Songmu)
+* Refactor net interface (multi ip support and bugfix) #208 (Songmu)
+* Stop to fetch flags of cpu in spec/linux/cpu #209 (Songmu)
+
+
 ## 0.29.2 (2016-03-07)
 
 * Don't overwrite mackerel-agent.conf when updating deb package (Fix deb packaging) #199 (Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.30.0-1) stable; urgency=low
+
+  * remove uptime metrics generator (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/161>
+  * Remove deprecated-sensu feature (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/202>
+  * Send all IP addresses of each interface (linux only) (by mechairoi)
+    <https://github.com/mackerelio/mackerel-agent/pull/205>
+  * add `init` subcommand (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/207>
+  * Refactor net interface (multi ip support and bugfix) (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/208>
+  * Stop to fetch flags of cpu in spec/linux/cpu (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/209>
+
+ -- Songmu <y.songmu@gmail.com>  Thu, 17 Mar 2016 01:39:41 +0900
+
 mackerel-agent (0.29.2-1) stable; urgency=low
 
   * Don't overwrite mackerel-agent.conf when updating deb package (Fix deb packaging) (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mackerel-agent
-Version:   0.29.2
+Version:   0.30.0
 Release:   1
 License:   Commercial
 Summary:   mackerel.io agent

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -71,6 +71,14 @@ fi
 %{_sysconfdir}/logrotate.d/%{name}
 
 %changelog
+* Thu Mar 17 2016 <y.songmu@gmail.com> - 0.30.0-1
+- remove uptime metrics generator (by Songmu)
+- Remove deprecated-sensu feature (by Songmu)
+- Send all IP addresses of each interface (linux only) (by mechairoi)
+- add `init` subcommand (by Songmu)
+- Refactor net interface (multi ip support and bugfix) (by Songmu)
+- Stop to fetch flags of cpu in spec/linux/cpu (by Songmu)
+
 * Mon Mar 07 2016 <y.songmu@gmail.com> - 0.29.2-1
 - Don't overwrite mackerel-agent.conf when updating deb package (Fix deb packaging) (by Songmu)
 


### PR DESCRIPTION
- remove uptime metrics generator #161
- Remove deprecated-sensu feature #202
- Send all IP addresses of each interface (linux only) #205
- add `init` subcommand #207
- Refactor net interface (multi ip support and bugfix) #208
- Stop to fetch flags of cpu in spec/linux/cpu #209