### PR TITLE
Remove go get cmd/vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ run: build
 
 deps: generate
 	go get -d -v -t ./...
-	go get golang.org/x/tools/cmd/vet
 	go get github.com/golang/lint/golint
 	go get github.com/pierrre/gotestcover
 	go get github.com/laher/goxc


### PR DESCRIPTION
This pull request fixes the build error on Travis.
```
go get golang.org/x/tools/cmd/vet
package golang.org/x/tools/cmd/vet: cannot find package "golang.org/x/tools/cmd/vet" in any of:
	/home/travis/.gimme/versions/go1.5.linux.amd64/src/golang.org/x/tools/cmd/vet (from $GOROOT)
	/home/travis/gopath/src/golang.org/x/tools/cmd/vet (from $GOPATH)
make: *** [deps] Error 1
```