### PR TITLE
[nit] [plugin.checks.foo ] is valid toml now

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -231,8 +231,7 @@ func TestConfigTestInvalidFormat(t *testing.T) {
 		t.Fatalf("Could not create temprary config file for test")
 	}
 	confFile.WriteString(`apikey="DUMMYAPIKEY"
-[plugin.checks.foo ]
-command = "bar"
+invalid!!!
 `)
 	confFile.Sync()
 	confFile.Close()


### PR DESCRIPTION
changed at https://github.com/BurntSushi/toml/commit/18a79db433ce27022230837d2a399c60123d1b64