### PR TITLE
Recover from panic while processing generators

### DIFF
--- a/agent/generator.go
+++ b/agent/generator.go
@@ -32,7 +32,12 @@ func generateValues(generators []metrics.Generator) chan metrics.Values {
 		for _, g := range generators {
 			wg.Add(1)
 			go func(g metrics.Generator) {
-				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						logger.Errorf("Panic: generating value in %T (skip this metric): %s", g, r)
+					}
+					wg.Done()
+				}()
 
 				values, err := g.Generate()
 				if err != nil {

--- a/agent/generator_test.go
+++ b/agent/generator_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/mackerelio/mackerel-agent/metrics"
+)
+
+type testGenerator struct{}
+
+func (g *testGenerator) Generate() (metrics.Values, error) {
+	values := make(map[string]float64)
+	values["test"] = 10
+	return values, nil
+}
+
+type testPanicGenerator struct{}
+
+func (g *testPanicGenerator) Generate() (metrics.Values, error) {
+	panic("sudden panic!!")
+}
+
+func TestGenerateValues(t *testing.T) {
+	tg := &testGenerator{}
+	tpg := &testPanicGenerator{}
+	generators := []metrics.Generator{tg, tpg}
+	result := generateValues(generators)
+	values := <-result
+
+	if len(values) != 1 {
+		t.Errorf("Num of results should be 1, but %d", len(values))
+	}
+}


### PR DESCRIPTION
Generator may panic in some case, such as running mackerel-agent in new/old/modified environments.
With this patch, mackerel-agent recovers from panic of processing generators and continues to work.
