### PR TITLE
Post the custom metrics to the hosts specified by custom identifiers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -19,7 +19,7 @@ type Agent struct {
 // MetricsResult XXX
 type MetricsResult struct {
 	Created time.Time
-	Values  metrics.Values
+	Values  []metrics.ValuesCustomIdentifier
 }
 
 // CollectMetrics collects metrics with generators.

--- a/agent/generator.go
+++ b/agent/generator.go
@@ -48,7 +48,10 @@ func generateValues(generators []metrics.Generator) chan []metrics.ValuesCustomI
 				if pluginGenerator, ok := g.(metrics.PluginGenerator); ok {
 					customIdentifier = pluginGenerator.CustomIdentifier()
 				}
-				processed <- metrics.ValuesCustomIdentifier{values, customIdentifier}
+				processed <- metrics.ValuesCustomIdentifier{
+					Values:           values,
+					CustomIdentifier: customIdentifier,
+				}
 			}(g)
 		}
 		wg.Wait()

--- a/command/command.go
+++ b/command/command.go
@@ -318,21 +318,31 @@ func enqueueLoop(c *Context, postQueue chan *postValue, quit chan struct{}) {
 		case result := <-metricsResult:
 			created := float64(result.Created.Unix())
 			creatingValues := [](*mackerel.CreatingMetricsValue){}
-			for name, value := range (map[string]float64)(result.Values) {
-				if math.IsNaN(value) || math.IsInf(value, 0) {
-					logger.Warningf("Invalid value: hostID = %s, name = %s, value = %f\n is not sent.", c.Host.ID, name, value)
-					continue
+			for _, values := range result.Values {
+				hostID := c.Host.ID
+				if values.CustomIdentifier != nil {
+					if host, ok := c.CustomIdentifierHosts[*values.CustomIdentifier]; ok {
+						hostID = host.ID
+					} else {
+						continue
+					}
 				}
+				for name, value := range (map[string]float64)(values.Values) {
+					if math.IsNaN(value) || math.IsInf(value, 0) {
+						logger.Warningf("Invalid value: hostID = %s, name = %s, value = %f\n is not sent.", hostID, name, value)
+						continue
+					}
 
-				creatingValues = append(
-					creatingValues,
-					&mackerel.CreatingMetricsValue{
-						HostID: c.Host.ID,
-						Name:   name,
-						Time:   created,
-						Value:  value,
-					},
-				)
+					creatingValues = append(
+						creatingValues,
+						&mackerel.CreatingMetricsValue{
+							HostID: hostID,
+							Name:   name,
+							Time:   created,
+							Value:  value,
+						},
+					)
+				}
 			}
 			logger.Debugf("Enqueuing task to post metrics.")
 			postQueue <- newPostValue(creatingValues)

--- a/command/command.go
+++ b/command/command.go
@@ -114,10 +114,11 @@ func delayByHost(host *mackerel.Host) int {
 
 // Context context object
 type Context struct {
-	Agent  *agent.Agent
-	Config *config.Config
-	Host   *mackerel.Host
-	API    *mackerel.API
+	Agent                 *agent.Agent
+	Config                *config.Config
+	Host                  *mackerel.Host
+	API                   *mackerel.API
+	CustomIdentifierHosts map[string]*mackerel.Host
 }
 
 type postValue struct {

--- a/command/command_unix_test.go
+++ b/command/command_unix_test.go
@@ -102,7 +102,10 @@ func TestRunOncePayload(t *testing.T) {
 		t.Errorf("first check name should be check1")
 	}
 
-	if metrics.Values["custom.dice.d20"] == 0 {
+	if len(metrics.Values) != 1 {
+		t.Errorf("there must be some metric values")
+	}
+	if metrics.Values[0].Values["custom.dice.d20"] == 0 {
 		t.Errorf("custom.dice.d20 name should be set")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -67,8 +67,9 @@ type PluginConfigs map[string]PluginConfig
 // `MaxCheckAttempts` option is used with check monitoring plugins. Custom metrics plugins ignore this option.
 type PluginConfig struct {
 	Command              string
-	NotificationInterval *int32 `toml:"notification_interval"`
-	MaxCheckAttempts     *int32 `toml:"max_check_attempts"`
+	NotificationInterval *int32  `toml:"notification_interval"`
+	MaxCheckAttempts     *int32  `toml:"max_check_attempts"`
+	CustomIdentifier     *string `toml:"custom_identifier"`
 }
 
 const postMetricsDequeueDelaySecondsMax = 59   // max delay seconds for dequeuing from buffer queue

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -66,9 +66,10 @@ func NewAPI(rawurl string, apiKey string, verbose bool) (*API, error) {
 	return &API{u, apiKey, verbose}, nil
 }
 
-func (api *API) urlFor(path string) *url.URL {
+func (api *API) urlFor(path string, query string) *url.URL {
 	newURL, _ := url.Parse(api.BaseURL.String())
 	newURL.Path = path
+	newURL.RawQuery = query
 	return newURL
 }
 
@@ -110,7 +111,7 @@ func closeResp(resp *http.Response) {
 
 // FindHost find the host
 func (api *API) FindHost(id string) (*Host, error) {
-	resp, err := api.get(fmt.Sprintf("/api/v0/hosts/%s", id))
+	resp, err := api.get(fmt.Sprintf("/api/v0/hosts/%s", id), "")
 	defer closeResp(resp)
 	if err != nil {
 		return nil, err
@@ -236,8 +237,8 @@ func (api *API) RetireHost(hostID string) error {
 	return nil
 }
 
-func (api *API) get(path string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", api.urlFor(path).String(), nil)
+func (api *API) get(path string, query string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", api.urlFor(path, query).String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +254,7 @@ func (api *API) requestJSON(method, path string, payload interface{}) (*http.Res
 	}
 	logger.Debugf("%s %s %s", method, path, body.String())
 
-	req, err := http.NewRequest(method, api.urlFor(path).String(), &body)
+	req, err := http.NewRequest(method, api.urlFor(path, "").String(), &body)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -131,6 +131,34 @@ func (api *API) FindHost(id string) (*Host, error) {
 	return data.Host, err
 }
 
+// FindHostByCustomIdentifier find the host by the custom identifier
+func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*Host, error) {
+	v := url.Values{}
+	v.Set("customIdentifier", customIdentifier)
+	resp, err := api.get("/api/v0/hosts", v.Encode())
+	defer closeResp(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, apiError(resp.StatusCode, "status code is not 200")
+	}
+
+	var data struct {
+		Hosts []*Host `json:"hosts"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data.Hosts) == 0 {
+		return nil, fmt.Errorf("No host was found for the custom identifier: %s", customIdentifier)
+	}
+	return data.Hosts[0], err
+}
+
 // CreateHost register the host to mackerel
 func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces interface{}, roleFullnames []string, displayName string) (string, error) {
 	resp, err := api.postJSON("/api/v0/hosts", map[string]interface{}{

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -43,11 +43,11 @@ func TestUrlFor(t *testing.T) {
 		true,
 	)
 
-	if api.urlFor("/").String() != "http://example.com/" {
+	if api.urlFor("/", "").String() != "http://example.com/" {
 		t.Error("should return http://example.com/")
 	}
 
-	if api.urlFor("/path/to/api").String() != "http://example.com/path/to/api" {
+	if api.urlFor("/path/to/api", "").String() != "http://example.com/path/to/api" {
 		t.Error("should return http://example.com/path/to/api")
 	}
 }
@@ -87,7 +87,7 @@ func TestDo(t *testing.T) {
 		false,
 	)
 
-	req, _ := http.NewRequest("GET", api.urlFor("/").String(), nil)
+	req, _ := http.NewRequest("GET", api.urlFor("/", "").String(), nil)
 	api.do(req)
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -38,4 +38,5 @@ type Generator interface {
 type PluginGenerator interface {
 	Generate() (Values, error)
 	PrepareGraphDefs() ([]mackerel.CreateGraphDefsPayload, error)
+	CustomIdentifier() *string
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,6 +12,23 @@ func (vs *Values) Merge(other Values) {
 	}
 }
 
+// ValuesCustomIdentifier holds the metric values with the optional custom identifier
+type ValuesCustomIdentifier struct {
+	Values           Values
+	CustomIdentifier *string
+}
+
+// MergeValuesCustomIdentifiers merges the metric values and custom identifiers
+func MergeValuesCustomIdentifiers(values []ValuesCustomIdentifier, newValue ValuesCustomIdentifier) []ValuesCustomIdentifier {
+	for _, value := range values {
+		if value.CustomIdentifier == newValue.CustomIdentifier {
+			value.Values.Merge(newValue.Values)
+			return values
+		}
+	}
+	return append(values, newValue)
+}
+
 // Generator XXX
 type Generator interface {
 	Generate() (Values, error)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -21,7 +21,9 @@ type ValuesCustomIdentifier struct {
 // MergeValuesCustomIdentifiers merges the metric values and custom identifiers
 func MergeValuesCustomIdentifiers(values []ValuesCustomIdentifier, newValue ValuesCustomIdentifier) []ValuesCustomIdentifier {
 	for _, value := range values {
-		if value.CustomIdentifier == newValue.CustomIdentifier {
+		if value.CustomIdentifier == newValue.CustomIdentifier ||
+			(value.CustomIdentifier != nil && newValue.CustomIdentifier != nil &&
+				*value.CustomIdentifier == *newValue.CustomIdentifier) {
 			value.Values.Merge(newValue.Values)
 			return values
 		}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -24,3 +24,85 @@ func TestMerge(t *testing.T) {
 		t.Errorf("somthing went wrong")
 	}
 }
+
+func TestMergeValuesCustomIdentifiers(t *testing.T) {
+	var v0 = Values(map[string]float64{
+		"aa": 10,
+	})
+	var v1 = Values(map[string]float64{
+		"bb": 20,
+		"cc": 30,
+	})
+	var v2 = Values(map[string]float64{
+		"dd": 40,
+		"ee": 50,
+	})
+	var v3 = Values(map[string]float64{
+		"ff": 60,
+		"gg": 70,
+	})
+
+	v := MergeValuesCustomIdentifiers([]ValuesCustomIdentifier{
+		ValuesCustomIdentifier{Values: v0},
+	}, ValuesCustomIdentifier{Values: v1})
+
+	if !reflect.DeepEqual(v, []ValuesCustomIdentifier{
+		ValuesCustomIdentifier{
+			Values: Values(map[string]float64{
+				"aa": 10,
+				"bb": 20,
+				"cc": 30,
+			}),
+			CustomIdentifier: nil,
+		}}) {
+		t.Errorf("somthing went wrong")
+	}
+
+	customIdentifiers := "foo-bar"
+	v = MergeValuesCustomIdentifiers(v, ValuesCustomIdentifier{Values: v2, CustomIdentifier: &customIdentifiers})
+
+	if !reflect.DeepEqual(v, []ValuesCustomIdentifier{
+		ValuesCustomIdentifier{
+			Values: Values(map[string]float64{
+				"aa": 10,
+				"bb": 20,
+				"cc": 30,
+			}),
+			CustomIdentifier: nil,
+		},
+		ValuesCustomIdentifier{
+			Values: Values(map[string]float64{
+				"dd": 40,
+				"ee": 50,
+			}),
+			CustomIdentifier: &customIdentifiers,
+		},
+	}) {
+		t.Errorf("somthing went wrong")
+	}
+
+	sameCustomIdentifiers := "foo-bar"
+	v = MergeValuesCustomIdentifiers(v, ValuesCustomIdentifier{Values: v3, CustomIdentifier: &sameCustomIdentifiers})
+
+	if !reflect.DeepEqual(v, []ValuesCustomIdentifier{
+		ValuesCustomIdentifier{
+			Values: Values(map[string]float64{
+				"aa": 10,
+				"bb": 20,
+				"cc": 30,
+			}),
+			CustomIdentifier: nil,
+		},
+		ValuesCustomIdentifier{
+			Values: Values(map[string]float64{
+				"dd": 40,
+				"ee": 50,
+				"ff": 60,
+				"gg": 70,
+			}),
+			CustomIdentifier: &customIdentifiers,
+		},
+	}) {
+		t.Errorf("somthing went wrong")
+	}
+}

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -68,6 +68,10 @@ func (g *pluginGenerator) PrepareGraphDefs() ([]mackerel.CreateGraphDefsPayload,
 	return payload, nil
 }
 
+func (g *pluginGenerator) CustomIdentifier() *string {
+	return g.Config.CustomIdentifier
+}
+
 // loadPluginMeta obtains plugin information (e.g. graph visuals, metric
 // namespaces, etc) from the command specified.
 // mackerel-agent runs the command with MACKEREL_AGENT_PLUGIN_META


### PR DESCRIPTION
This pull request allows the users to configure the host which the agent sends the custom metrics to.