### PR TITLE
Fix missing printf args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ deps: generate
 	go get github.com/mattn/goveralls
 
 lint: deps
-	go tool vet -all .
+	go tool vet -all -printfuncs=Criticalf,Infof,Warningf,Debugf,Tracef .
 	_tools/go-linter $(BUILD_OS_TARGETS)
 
 crossbuild: deps

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -226,7 +226,7 @@ func (g *pluginGenerator) collectValues() (Values, error) {
 	stdout, stderr, _, err := util.RunCommand(command)
 
 	if stderr != "" {
-		pluginLogger.Infof("command %q outputted to STDERR: %q", stderr)
+		pluginLogger.Infof("command %q outputted to STDERR: %q", command, stderr)
 	}
 	if err != nil {
 		pluginLogger.Errorf("Failed to execute command %q (skip these metrics):\n", command)


### PR DESCRIPTION
I found `%!q(MISSING)` warnings in my `mackerel.log`.

```
2016/05/23 09:12:00 INFO <metrics.plugin> command "2016/05/23 09:12:00 OutputValues:  Counter seems to be reset.\n" outputted to STDERR: %!q(MISSING)
```
