### PR TITLE
Release version 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,9 @@
 ## 0.31.0 (2016-05-25)
 
 * Post the custom metrics to the hosts specified by custom identifiers #231 (itchyny)
-* Make appveyor build both versions of orginal and kcps #232 (stanaka)
 * refactor FilesystemGenerator #233 (Songmu)
 * Refactor metrics/linux/interface.go #234 (Songmu)
 * remove regexp from spec/linux/cpu #235 (Songmu)
-* Upload outputs of building master branch to GitHub Releases #236 (stanaka)
 * Fix missing printf args #237 (shogo82148)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.31.0 (2016-05-25)
+
+* Post the custom metrics to the hosts specified by custom identifiers #231 (itchyny)
+* Make appveyor build both versions of orginal and kcps #232 (stanaka)
+* refactor FilesystemGenerator #233 (Songmu)
+* Refactor metrics/linux/interface.go #234 (Songmu)
+* remove regexp from spec/linux/cpu #235 (Songmu)
+* Upload outputs of building master branch to GitHub Releases #236 (stanaka)
+* Fix missing printf args #237 (shogo82148)
+
+
 ## 0.30.4 (2016-05-10)
 
 * Recover from panic while processing generators #228 (stanaka)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,22 @@
+mackerel-agent (0.31.0-1) stable; urgency=low
+
+  * Post the custom metrics to the hosts specified by custom identifiers (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/231>
+  * Make appveyor build both versions of orginal and kcps (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent/pull/232>
+  * refactor FilesystemGenerator (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/233>
+  * Refactor metrics/linux/interface.go (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/234>
+  * remove regexp from spec/linux/cpu (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/235>
+  * Upload outputs of building master branch to GitHub Releases (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent/pull/236>
+  * Fix missing printf args (by shogo82148)
+    <https://github.com/mackerelio/mackerel-agent/pull/237>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 25 May 2016 04:13:19 +0000
+
 mackerel-agent (0.30.4-1) stable; urgency=low
 
   * Recover from panic while processing generators (by stanaka)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -2,16 +2,12 @@ mackerel-agent (0.31.0-1) stable; urgency=low
 
   * Post the custom metrics to the hosts specified by custom identifiers (by itchyny)
     <https://github.com/mackerelio/mackerel-agent/pull/231>
-  * Make appveyor build both versions of orginal and kcps (by stanaka)
-    <https://github.com/mackerelio/mackerel-agent/pull/232>
   * refactor FilesystemGenerator (by Songmu)
     <https://github.com/mackerelio/mackerel-agent/pull/233>
   * Refactor metrics/linux/interface.go (by Songmu)
     <https://github.com/mackerelio/mackerel-agent/pull/234>
   * remove regexp from spec/linux/cpu (by Songmu)
     <https://github.com/mackerelio/mackerel-agent/pull/235>
-  * Upload outputs of building master branch to GitHub Releases (by stanaka)
-    <https://github.com/mackerelio/mackerel-agent/pull/236>
   * Fix missing printf args (by shogo82148)
     <https://github.com/mackerelio/mackerel-agent/pull/237>
 

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,15 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed May 25 2016 <mackerel-developers@hatena.ne.jp> - 0.31.0-1
+- Post the custom metrics to the hosts specified by custom identifiers (by itchyny)
+- Make appveyor build both versions of orginal and kcps (by stanaka)
+- refactor FilesystemGenerator (by Songmu)
+- Refactor metrics/linux/interface.go (by Songmu)
+- remove regexp from spec/linux/cpu (by Songmu)
+- Upload outputs of building master branch to GitHub Releases (by stanaka)
+- Fix missing printf args (by shogo82148)
+
 * Tue May 10 2016 <mackerel-developers@hatena.ne.jp> - 0.30.4-1
 - Recover from panic while processing generators (by stanaka)
 - check length of cols just to be safe in metrics/linux/disk.go (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -64,11 +64,9 @@ fi
 %changelog
 * Wed May 25 2016 <mackerel-developers@hatena.ne.jp> - 0.31.0-1
 - Post the custom metrics to the hosts specified by custom identifiers (by itchyny)
-- Make appveyor build both versions of orginal and kcps (by stanaka)
 - refactor FilesystemGenerator (by Songmu)
 - Refactor metrics/linux/interface.go (by Songmu)
 - remove regexp from spec/linux/cpu (by Songmu)
-- Upload outputs of building master branch to GitHub Releases (by stanaka)
 - Fix missing printf args (by shogo82148)
 
 * Tue May 10 2016 <mackerel-developers@hatena.ne.jp> - 0.30.4-1


### PR DESCRIPTION
- Post the custom metrics to the hosts specified by custom identifiers #231
- Make appveyor build both versions of orginal and kcps #232
- refactor FilesystemGenerator #233
- Refactor metrics/linux/interface.go #234
- remove regexp from spec/linux/cpu #235
- Upload outputs of building master branch to GitHub Releases #236
- Fix missing printf args #237