### PR TITLE
Don't stop mackerel-agent process on upgrading by debian package

### DIFF
--- a/packaging/deb/debian/mackerel-agent.prerm
+++ b/packaging/deb/debian/mackerel-agent.prerm
@@ -1,10 +1,21 @@
 #!/bin/sh
 set -e
 
-# This section is not automallically inserted by dh_installinit,
-# because `--no-start` option is specified in rules file.
-if [ -x "/etc/init.d/mackerel-agent" ]; then
-  invoke-rc.d mackerel-agent stop || exit $?
-fi
+case "$1" in
+remove)
+  # This section is not automallically inserted by dh_installinit,
+  # because `--no-start` option is specified in rules file.
+  if [ -x "/etc/init.d/mackerel-agent" ]; then
+    invoke-rc.d mackerel-agent stop || exit $?
+  fi
+;;
+upgrade|deconfigure|failed-upgrade)
+  exit 0
+;;
+*)
+  echo "postinst called with unknown argument \`$1'" >&2
+  exit 1
+;;
+esac
 
 #DEBHELPER#


### PR DESCRIPTION
Current `prerm` script stop mackerel-agent daemon. And this script is run on upgrading.
But, I don't happy to stop the mackerel-agent daemon on upgrading.
So I suggest to stop the mackerel-agent daemon on removing only.