### PR TITLE
remove /usr/local/bin from sample.conf

### DIFF
--- a/mackerel-agent.sample.conf
+++ b/mackerel-agent.sample.conf
@@ -18,98 +18,98 @@
 # Plugin for Apache2 mod_status
 #   By default, the plugin accesses to http://127.0.0.1/server-status?auto
 # [plugin.metrics.apache2]
-# command = "/usr/local/bin/mackerel-plugin-apache2"
+# command = "mackerel-plugin-apache2"
 
 # Plugin for EC2 CPU Credit
 # [plugin.metrics.aws-ec2_cpucredit]
-# command = "/usr/local/bin/mackerel-plugin-aws-ec2-cpucredit"
+# command = "mackerel-plugin-aws-ec2-cpucredit"
 
 # Plugin for AWS ELB
 # [plugin.metrics.aws-elb]
-# command = "/usr/local/bin/mackerel-plugin-aws-elb"
+# command = "mackerel-plugin-aws-elb"
 
 # Plugin for Amazon RDS
 # [plugin.metrics.aws-rds]
-# command = "/usr/local/bin/mackerel-plugin-aws-rds -identifier=<required>"
+# command = "mackerel-plugin-aws-rds -identifier=<required>"
 
 # Plugin for Elasticsearch
 #   By default, the plugin accesses Elasticsearch on localhost.
 # [plugin.metrics.elasticsearch]
-# command = "/usr/local/bin/mackerel-plugin-elasticsearch"
+# command = "mackerel-plugin-elasticsearch"
 
 # Plugin for HAProxy
 #   By default, the plugin accesses Elasticsearch on localhost.
 # [plugin.metrics.haproxy]
-# command = "/usr/local/bin/mackerel-plugin-haproxy"
+# command = "mackerel-plugin-haproxy"
 
 # Plugin for JVM
 #   Required javaname
 # [plugin.metrics.jvm]
-# command = "/usr/local/bin/mackerel-plugin-jvm -javaname=<required>"
+# command = "mackerel-plugin-jvm -javaname=<required>"
 
 # Plugin for Linux
 # [plugin.metrics.linux]
-# command = "/usr/local/bin/mackerel-plugin-linux"
+# command = "mackerel-plugin-linux"
 
 # Plugin for Memcached
 # [plugin.metrics.memcached]
-# command = "/usr/local/bin/mackerel-plugin-memcached"
+# command = "mackerel-plugin-memcached"
 
 # Plugin for MongoDB
 # [plugin.metrics.mongodb]
-# command = "/usr/local/bin/mackerel-plugin-mongodb"
+# command = "mackerel-plugin-mongodb"
 
 # Plugin for MySQL
 #   Appropriate previlege settings required.
 #   By default, the plugin accesses MySQL on localhost by 'root' with no password.
 # [plugin.metrics.mysql]
-# command = "/usr/local/bin/mackerel-plugin-mysql"
+# command = "mackerel-plugin-mysql"
 
 # Plugin for Nginx
 #   By default, the plugin accesses to http://localhost:8080/nginx_status
 # [plugin.metrics.nginx]
-# command = "/usr/local/bin/mackerel-plugin-nginx"
+# command = "mackerel-plugin-nginx"
 
 # Plugin for PHP APC
 # [plugin.metrics.php-apc]
-# command = "/usr/local/bin/mackerel-plugin-php-apc"
+# command = "mackerel-plugin-php-apc"
 
 # Plugin for Plack
 #   By default, the plugin accesses to http://localhost:5000/server-status?json
 # [plugin.metrics.plack]
-# command = "/usr/local/bin/mackerel-plugin-plack"
+# command = "mackerel-plugin-plack"
 
 # Plugin for PostgreSQL
 #   Appropriate previlege settings required.
 #   By default, the plugin accesses PostgreSQL on localhost.
 # [plugin.metrics.postgres]
-# command = "/usr/local/bin/mackerel-plugin-postgres"
+# command = "mackerel-plugin-postgres"
 
 # Plugin for Redis
 #   By default, the plugin accesses Redis on localhost.
 #   Currently AUTH password has not been supported yet.
 # [plugin.metrics.redis]
-# command = "/usr/local/bin/mackerel-plugin-redis"
+# command = "mackerel-plugin-redis"
 
 # Plugin for SNMP
 # [plugin.metrics.pps]
-# command = "/usr/local/bin/mackerel-plugin-snmp -name='pps' -community='private' '.1.3.6.1.2.1.31.1.1.1.7.2:eth01in:1:0' '.1.3.6.1.2.1.31.1.1.1.11.2:eth01out:1:0'"
+# command = "mackerel-plugin-snmp -name='pps' -community='private' '.1.3.6.1.2.1.31.1.1.1.7.2:eth01in:1:0' '.1.3.6.1.2.1.31.1.1.1.11.2:eth01out:1:0'"
 
 # Plugin for Squid
 # [plugin.metrics.squid]
-# command = "/usr/local/bin/mackerel-plugin-squid"
+# command = "mackerel-plugin-squid"
 
 # Plugin for Varnish
 # [plugin.metrics.varnish]
-# command = "/usr/local/bin/mackerel-plugin-varnish"
+# command = "mackerel-plugin-varnish"
 
 # Plugin for munin (wrapper)
 # [plugin.metrics.nfsd]
-# command = "/usr/local/bin/mackerel-plugin-munin -plugin=/usr/share/munin/plugins/nfsd"
+# command = "mackerel-plugin-munin -plugin=/usr/share/munin/plugins/nfsd"
 # [plugin.metrics.bind9]
-# command = "/usr/local/bin/mackerel-plugin-munin -plugin=/etc/munin/plugins/bind9 -plugin-conf-d=/etc/munin/plugin-conf.d"
+# command = "mackerel-plugin-munin -plugin=/etc/munin/plugins/bind9 -plugin-conf-d=/etc/munin/plugin-conf.d"
 # [plugin.metrics.postfix]
-# command = "MUNIN_LIBDIR=/usr/share/munin /usr/local/bin/mackerel-plugin-munin -plugin=/usr/share/munin/plugins/postfix_mailqueue -name=postfix.mailqueue"
+# command = "MUNIN_LIBDIR=/usr/share/munin mackerel-plugin-munin -plugin=/usr/share/munin/plugins/postfix_mailqueue -name=postfix.mailqueue"
 
 # followings are other samples
 # [plugin.metrics.vmstat]


### PR DESCRIPTION
mackerel-agent-plugins now installed into `/usr/bin`, not `/usr/local/bin`.