### PR TITLE
Release version 0.31.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.31.2 (2016-06-23)
+
+* Refactor around metrics/linux/memory #242 (Songmu)
+* Don't stop mackerel-agent process on upgrading by debian package #243 (karupanerura)
+* add `silent` configuration key for suppressing log output #244 (Songmu)
+* change log level ERROR to WARNING in spec/spec.go #246 (Songmu)
+* remove /usr/local/bin from sample.conf #248 (Songmu)
+
+
 ## 0.31.0 (2016-05-25)
 
 * Post the custom metrics to the hosts specified by custom identifiers #231 (itchyny)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent (0.31.2-1) stable; urgency=low
+
+  * Refactor around metrics/linux/memory (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/242>
+  * Don't stop mackerel-agent process on upgrading by debian package (by karupanerura)
+    <https://github.com/mackerelio/mackerel-agent/pull/243>
+  * add `silent` configuration key for suppressing log output (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/244>
+  * change log level ERROR to WARNING in spec/spec.go (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/246>
+  * remove /usr/local/bin from sample.conf (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/248>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 23 Jun 2016 06:12:22 +0000
+
 mackerel-agent (0.31.1-1) stable; urgency=low
 
   * embed right version number

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,13 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Thu Jun 23 2016 <mackerel-developers@hatena.ne.jp> - 0.31.2-1
+- Refactor around metrics/linux/memory (by Songmu)
+- Don't stop mackerel-agent process on upgrading by debian package (by karupanerura)
+- add `silent` configuration key for suppressing log output (by Songmu)
+- change log level ERROR to WARNING in spec/spec.go (by Songmu)
+- remove /usr/local/bin from sample.conf (by Songmu)
+
 * Wed May 25 2016 <mackerel-developers@hatena.ne.jp> - 0.31.0-1
 - Post the custom metrics to the hosts specified by custom identifiers (by itchyny)
 - refactor FilesystemGenerator (by Songmu)


### PR DESCRIPTION
- Refactor around metrics/linux/memory #242
- Don't stop mackerel-agent process on upgrading by debian package #243
- add `silent` configuration key for suppressing log output #244
- change log level ERROR to WARNING in spec/spec.go #246
- remove /usr/local/bin from sample.conf #248