### PR TITLE
Fill the customIdentifier in EC2

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -509,12 +509,13 @@ func (c *Context) UpdateHostSpecs() {
 	}
 
 	err = c.API.UpdateHost(c.Host.ID, mackerel.HostSpec{
-		Name:          hostname,
-		Meta:          meta,
-		Interfaces:    interfaces,
-		RoleFullnames: c.Config.Roles,
-		Checks:        c.Config.CheckNames(),
-		DisplayName:   c.Config.DisplayName,
+		Name:             hostname,
+		Meta:             meta,
+		Interfaces:       interfaces,
+		RoleFullnames:    c.Config.Roles,
+		Checks:           c.Config.CheckNames(),
+		DisplayName:      c.Config.DisplayName,
+		CustomIdentifier: customIdentifier,
 	})
 
 	if err != nil {
@@ -581,12 +582,13 @@ func runOncePayload(conf *config.Config) ([]mackerel.CreateGraphDefsPayload, *ma
 	graphdefs := ag.CollectGraphDefsOfPlugins()
 	metrics := ag.CollectMetrics(time.Now())
 	return graphdefs, &mackerel.HostSpec{
-		Name:          hostname,
-		Meta:          meta,
-		Interfaces:    interfaces,
-		RoleFullnames: conf.Roles,
-		Checks:        conf.CheckNames(),
-		DisplayName:   conf.DisplayName,
+		Name:             hostname,
+		Meta:             meta,
+		Interfaces:       interfaces,
+		RoleFullnames:    conf.Roles,
+		Checks:           conf.CheckNames(),
+		DisplayName:      conf.DisplayName,
+		CustomIdentifier: customIdentifier,
 	}, metrics, nil
 }
 

--- a/command/command.go
+++ b/command/command.go
@@ -54,7 +54,6 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 
 	var result *mackerel.Host
 	if hostID, err := conf.LoadHostID(); err != nil { // create
-		logger.Debugf("Registering new host on mackerel...")
 
 		if customIdentifier != "" {
 			doRetry(func() error {
@@ -67,6 +66,8 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 		}
 
 		if result == nil {
+			logger.Debugf("Registering new host on mackerel...")
+
 			doRetry(func() error {
 				hostID, lastErr = api.CreateHost(mackerel.HostSpec{
 					Name:             hostname,

--- a/command/command.go
+++ b/command/command.go
@@ -82,14 +82,14 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 			if lastErr != nil {
 				return nil, fmt.Errorf("Failed to register this host: %s", lastErr.Error())
 			}
-		}
 
-		doRetry(func() error {
-			result, lastErr = api.FindHost(hostID)
-			return filterErrorForRetry(lastErr)
-		})
-		if lastErr != nil {
-			return nil, fmt.Errorf("Failed to find this host on mackerel: %s", lastErr.Error())
+			doRetry(func() error {
+				result, lastErr = api.FindHost(hostID)
+				return filterErrorForRetry(lastErr)
+			})
+			if lastErr != nil {
+				return nil, fmt.Errorf("Failed to find this host on mackerel: %s", lastErr.Error())
+			}
 		}
 	} else { // check the hostID is valid or not
 		doRetry(func() error {

--- a/command/command.go
+++ b/command/command.go
@@ -56,9 +56,9 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 	if hostID, err := conf.LoadHostID(); err != nil { // create
 		logger.Debugf("Registering new host on mackerel...")
 
-		if customIdentifier != nil {
+		if customIdentifier != "" {
 			doRetry(func() error {
-				result, lastErr = api.FindHostByCustomIdentifier(*customIdentifier)
+				result, lastErr = api.FindHostByCustomIdentifier(customIdentifier)
 				return filterErrorForRetry(lastErr)
 			})
 			if result != nil {
@@ -477,10 +477,10 @@ func runCheckersLoop(c *Context, termCheckerCh <-chan struct{}, quit <-chan stru
 }
 
 // collectHostSpecs collects host specs (correspond to "name", "meta", "interfaces" and "customIdentifier" fields in API v0)
-func collectHostSpecs() (string, map[string]interface{}, []spec.NetInterface, *string, error) {
+func collectHostSpecs() (string, map[string]interface{}, []spec.NetInterface, string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		return "", nil, nil, nil, fmt.Errorf("failed to obtain hostname: %s", err.Error())
+		return "", nil, nil, "", fmt.Errorf("failed to obtain hostname: %s", err.Error())
 	}
 
 	specGens := specGenerators()
@@ -490,7 +490,7 @@ func collectHostSpecs() (string, map[string]interface{}, []spec.NetInterface, *s
 	}
 	meta := spec.Collect(specGens)
 
-	var customIdentifier *string
+	var customIdentifier string
 	if cGen != nil {
 		customIdentifier, err = cGen.SuggestCustomIdentifier()
 		if err != nil {
@@ -500,7 +500,7 @@ func collectHostSpecs() (string, map[string]interface{}, []spec.NetInterface, *s
 
 	interfaces, err := interfaceGenerator().Generate()
 	if err != nil {
-		return "", nil, nil, nil, fmt.Errorf("failed to collect interfaces: %s", err.Error())
+		return "", nil, nil, "", fmt.Errorf("failed to collect interfaces: %s", err.Error())
 	}
 	return hostname, meta, interfaces, customIdentifier, nil
 }

--- a/command/command.go
+++ b/command/command.go
@@ -68,7 +68,14 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 
 		if result == nil {
 			doRetry(func() error {
-				hostID, lastErr = api.CreateHost(hostname, meta, interfaces, conf.Roles, conf.DisplayName, customIdentifier)
+				hostID, lastErr = api.CreateHost(mackerel.HostSpec{
+					Name:             hostname,
+					Meta:             meta,
+					Interfaces:       interfaces,
+					RoleFullnames:    conf.Roles,
+					DisplayName:      conf.DisplayName,
+					CustomIdentifier: customIdentifier,
+				})
 				return filterErrorForRetry(lastErr)
 			})
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -188,7 +188,7 @@ func TestPrepareWithUpdate(t *testing.T) {
 }
 
 func TestCollectHostSpecs(t *testing.T) {
-	hostname, meta, _ /*interfaces*/, err := collectHostSpecs()
+	hostname, meta, _ /*interfaces*/, _ /*customIdentifier*/, err := collectHostSpecs()
 
 	if err != nil {
 		t.Errorf("collectHostSpecs should not fail: %s", err)

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -163,15 +163,16 @@ func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*Host, erro
 }
 
 // CreateHost register the host to mackerel
-func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces interface{}, roleFullnames []string, displayName string) (string, error) {
+func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces interface{}, roleFullnames []string, displayName string, customIdentifier *string) (string, error) {
 	resp, err := api.postJSON("/api/v0/hosts", map[string]interface{}{
-		"name":          name,
-		"type":          "unknown",
-		"status":        "working",
-		"meta":          meta,
-		"interfaces":    interfaces,
-		"roleFullnames": roleFullnames,
-		"displayName":   displayName,
+		"name":             name,
+		"type":             "unknown",
+		"status":           "working",
+		"meta":             meta,
+		"interfaces":       interfaces,
+		"roleFullnames":    roleFullnames,
+		"displayName":      displayName,
+		"customIdentifier": customIdentifier,
 	})
 	defer closeResp(resp)
 	if err != nil {

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -135,6 +135,9 @@ func (api *API) FindHost(id string) (*Host, error) {
 func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*Host, error) {
 	v := url.Values{}
 	v.Set("customIdentifier", customIdentifier)
+	for _, status := range []string{"working", "standby", "maintenance", "poweroff"} {
+		v.Add("status", status)
+	}
 	resp, err := api.get("/api/v0/hosts", v.Encode())
 	defer closeResp(resp)
 	if err != nil {

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -163,17 +163,8 @@ func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*Host, erro
 }
 
 // CreateHost register the host to mackerel
-func (api *API) CreateHost(name string, meta map[string]interface{}, interfaces interface{}, roleFullnames []string, displayName string, customIdentifier *string) (string, error) {
-	resp, err := api.postJSON("/api/v0/hosts", map[string]interface{}{
-		"name":             name,
-		"type":             "unknown",
-		"status":           "working",
-		"meta":             meta,
-		"interfaces":       interfaces,
-		"roleFullnames":    roleFullnames,
-		"displayName":      displayName,
-		"customIdentifier": customIdentifier,
-	})
+func (api *API) CreateHost(hostSpec HostSpec) (string, error) {
+	resp, err := api.postJSON("/api/v0/hosts", hostSpec)
 	defer closeResp(resp)
 	if err != nil {
 		return "", err

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -158,9 +158,17 @@ func TestCreateHost(t *testing.T) {
 		"macAddress": "01:23:45:67:89:ab",
 		"encap":      "Ethernet",
 	})
-	hostID, err := api.CreateHost("dummy", map[string]interface{}{
-		"memo": "hello",
-	}, interfaces, []string{"My-Service:app-default"}, "label")
+	hostSpec := HostSpec{
+		Name: "dummy",
+		Meta: map[string]interface{}{
+			"memo": "hello",
+		},
+		Interfaces:       interfaces,
+		RoleFullnames:    []string{"My-Service:app-default"},
+		DisplayName:      "my-display-name",
+		CustomIdentifier: nil,
+	}
+	hostID, err := api.CreateHost(hostSpec)
 
 	if err != nil {
 		t.Error("should not raise error: ", err)
@@ -214,7 +222,10 @@ func TestCreateHostWithNilArgs(t *testing.T) {
 	api, _ := NewAPI(ts.URL, "dummy-key", false)
 
 	// with nil args
-	hostID, err := api.CreateHost("nilsome", nil, nil, nil, "")
+	hostSpec := HostSpec{
+		Name: "nilsome",
+	}
+	hostID, err := api.CreateHost(hostSpec)
 	if err != nil {
 		t.Error("should not return error but got: ", err)
 	}
@@ -291,8 +302,6 @@ func TestUpdateHost(t *testing.T) {
 		"encap":      "Ethernet",
 	})
 
-	var checkNames = []string{}
-
 	hostSpec := HostSpec{
 		Name: "dummy",
 		Meta: map[string]interface{}{
@@ -300,7 +309,7 @@ func TestUpdateHost(t *testing.T) {
 		},
 		Interfaces:    interfaces,
 		RoleFullnames: []string{"My-Service:app-default"},
-		Checks:        checkNames,
+		Checks:        []string{},
 	}
 
 	err := api.UpdateHost("ABCD123", hostSpec)

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -166,7 +166,7 @@ func TestCreateHost(t *testing.T) {
 		Interfaces:       interfaces,
 		RoleFullnames:    []string{"My-Service:app-default"},
 		DisplayName:      "my-display-name",
-		CustomIdentifier: nil,
+		CustomIdentifier: "",
 	}
 	hostID, err := api.CreateHost(hostSpec)
 

--- a/mackerel/host.go
+++ b/mackerel/host.go
@@ -10,10 +10,11 @@ type Host struct {
 
 // HostSpec is host specifications sent Mackerel server per hour
 type HostSpec struct {
-	Name          string                 `json:"name"`
-	Meta          map[string]interface{} `json:"meta"`
-	Interfaces    interface{}            `json:"interfaces"`
-	RoleFullnames []string               `json:"roleFullnames"`
-	Checks        []string               `json:"checks"`
-	DisplayName   string                 `json:"displayName,omitempty"`
+	Name             string                 `json:"name"`
+	Meta             map[string]interface{} `json:"meta"`
+	Interfaces       interface{}            `json:"interfaces"`
+	RoleFullnames    []string               `json:"roleFullnames"`
+	Checks           []string               `json:"checks"`
+	DisplayName      string                 `json:"displayName,omitempty"`
+	CustomIdentifier *string                `json:"customIdentifier,omitempty"`
 }

--- a/mackerel/host.go
+++ b/mackerel/host.go
@@ -16,5 +16,5 @@ type HostSpec struct {
 	RoleFullnames    []string               `json:"roleFullnames"`
 	Checks           []string               `json:"checks"`
 	DisplayName      string                 `json:"displayName,omitempty"`
-	CustomIdentifier *string                `json:"customIdentifier,omitempty"`
+	CustomIdentifier string                 `json:"customIdentifier,omitempty"`
 }

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -26,6 +26,7 @@ type CloudGenerator struct {
 // CloudMetaGenerator interface of metadata generator for each cloud platform
 type CloudMetaGenerator interface {
 	Generate() (interface{}, error)
+	SuggestCustomIdentifier() (*string, error)
 }
 
 // Key is a root key for the generator.
@@ -153,6 +154,30 @@ func (g *EC2Generator) Generate() (interface{}, error) {
 	return results, nil
 }
 
+// SuggestCustomIdentifier suggests the identifier of the EC2 instance
+func (g *EC2Generator) SuggestCustomIdentifier() (*string, error) {
+	client := http.Client{Timeout: timeout}
+	key := "instance-id"
+	resp, err := client.Get(g.baseURL.String() + "/" + key)
+	if err != nil {
+		return nil, fmt.Errorf("Error while retrieving instance-id.")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Failed to request instance-id. response code: %d", resp.StatusCode)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Results of requesting instance-id cannot be read: '%s'", err)
+	}
+	instanceID := string(body)
+	if instanceID == "" {
+		return nil, fmt.Errorf("Invalid instance id")
+	}
+	customIdentifier := instanceID + ".ec2.amazonaws.com"
+	return &customIdentifier, nil
+}
+
 // GCEGenerator generate for GCE
 type GCEGenerator struct {
 	metaURL *url.URL
@@ -214,4 +239,9 @@ func (g gceMeta) toGeneratorResults() interface{} {
 	results["metadata"] = g.toGeneratorMeta()
 
 	return results
+}
+
+// SuggestCustomIdentifier for GCE is not implemented yet
+func (g *GCEGenerator) SuggestCustomIdentifier() (*string, error) {
+	return nil, nil
 }

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -26,7 +26,7 @@ type CloudGenerator struct {
 // CloudMetaGenerator interface of metadata generator for each cloud platform
 type CloudMetaGenerator interface {
 	Generate() (interface{}, error)
-	SuggestCustomIdentifier() (*string, error)
+	SuggestCustomIdentifier() (string, error)
 }
 
 // Key is a root key for the generator.
@@ -155,27 +155,26 @@ func (g *EC2Generator) Generate() (interface{}, error) {
 }
 
 // SuggestCustomIdentifier suggests the identifier of the EC2 instance
-func (g *EC2Generator) SuggestCustomIdentifier() (*string, error) {
+func (g *EC2Generator) SuggestCustomIdentifier() (string, error) {
 	client := http.Client{Timeout: timeout}
 	key := "instance-id"
 	resp, err := client.Get(g.baseURL.String() + "/" + key)
 	if err != nil {
-		return nil, fmt.Errorf("Error while retrieving instance-id.")
+		return "", fmt.Errorf("Error while retrieving instance-id.")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Failed to request instance-id. response code: %d", resp.StatusCode)
+		return "", fmt.Errorf("Failed to request instance-id. response code: %d", resp.StatusCode)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Results of requesting instance-id cannot be read: '%s'", err)
+		return "", fmt.Errorf("Results of requesting instance-id cannot be read: '%s'", err)
 	}
 	instanceID := string(body)
 	if instanceID == "" {
-		return nil, fmt.Errorf("Invalid instance id")
+		return "", fmt.Errorf("Invalid instance id")
 	}
-	customIdentifier := instanceID + ".ec2.amazonaws.com"
-	return &customIdentifier, nil
+	return instanceID + ".ec2.amazonaws.com", nil
 }
 
 // GCEGenerator generate for GCE
@@ -242,6 +241,6 @@ func (g gceMeta) toGeneratorResults() interface{} {
 }
 
 // SuggestCustomIdentifier for GCE is not implemented yet
-func (g *GCEGenerator) SuggestCustomIdentifier() (*string, error) {
-	return nil, nil
+func (g *GCEGenerator) SuggestCustomIdentifier() (string, error) {
+	return "", nil
 }

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -56,6 +56,15 @@ func TestCloudGenerate(t *testing.T) {
 	if len(metadata["instance-id"]) == 0 {
 		t.Error("instance-id should be filled")
 	}
+
+	customIdentifier, err := g.SuggestCustomIdentifier()
+	if err != nil {
+		t.Errorf("should not raise error: %s", err)
+	}
+
+	if len(customIdentifier) == 0 {
+		t.Error("customIdentifier should be retrieved")
+	}
 }
 
 func TestGCEGenerate(t *testing.T) {


### PR DESCRIPTION
With this pull request, mackerel-agent on cloud platforms can identify the host by customIdentifier. Currently, EC2 is only supported.

Firstly, the agent on EC2 decides the customIdentifier based on the instance-id. Before creating a new host, the agent tries to find a host by the customIdentifier (if found, the host is possibly created by the AWS integration). On upgrading the version of mackerel-agent, it updates the host information with customIdentifier filled.