### PR TITLE
Release version 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.34.0 (2016-08-18)
+
+* Reduce retry count on finding a host by the custom identifier #258 (itchyny)
+* suppress checker flooding when resuming from sleep mode #260 (Songmu)
+* truncate checker message up to 1024 characters #261 (Songmu)
+* commonalize spec.FilesystemGenerator around unix OSs #262 (Songmu)
+* define type DfStat,	remove dfColumnSpecs and refactor #263 (Songmu)
+
+
 ## 0.33.0 (2016-08-08)
 
 * Fill the customIdentifier in EC2 #255 (itchyny)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent (0.34.0-1) stable; urgency=low
+
+  * Reduce retry count on finding a host by the custom identifier (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/258>
+  * suppress checker flooding when resuming from sleep mode (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/260>
+  * truncate checker message up to 1024 characters (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/261>
+  * commonalize spec.FilesystemGenerator around unix OSs (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/262>
+  * define type DfStat,	remove dfColumnSpecs and refactor (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/263>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 18 Aug 2016 02:54:33 +0000
+
 mackerel-agent (0.33.0-1) stable; urgency=low
 
   * Fill the customIdentifier in EC2 (by itchyny)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,13 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Thu Aug 18 2016 <mackerel-developers@hatena.ne.jp> - 0.34.0-1
+- Reduce retry count on finding a host by the custom identifier (by itchyny)
+- suppress checker flooding when resuming from sleep mode (by Songmu)
+- truncate checker message up to 1024 characters (by Songmu)
+- commonalize spec.FilesystemGenerator around unix OSs (by Songmu)
+- define type DfStat,	remove dfColumnSpecs and refactor (by Songmu)
+
 * Mon Aug 08 2016 <mackerel-developers@hatena.ne.jp> - 0.33.0-1
 - Fill the customIdentifier in EC2 (by itchyny)
 


### PR DESCRIPTION
- Reduce retry count on finding a host by the custom identifier #258
- suppress checker flooding when resuming from sleep mode #260
- truncate checker message up to 1024 characters #261
- commonalize spec.FilesystemGenerator around unix OSs #262
- define type DfStat,	remove dfColumnSpecs and refactor #263