### PR TITLE
remove `func (vs *Values) Merge(other Values)`

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -19,7 +19,7 @@ type Agent struct {
 // MetricsResult XXX
 type MetricsResult struct {
 	Created time.Time
-	Values  []metrics.ValuesCustomIdentifier
+	Values  []*metrics.ValuesCustomIdentifier
 }
 
 // CollectMetrics collects metrics with generators.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -28,8 +28,7 @@ func (agent *Agent) CollectMetrics(collectedTime time.Time) *MetricsResult {
 	for _, g := range agent.PluginGenerators {
 		generators = append(generators, g)
 	}
-	result := generateValues(generators)
-	values := <-result
+	values := generateValues(generators)
 	return &MetricsResult{Created: collectedTime, Values: values}
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -62,10 +62,10 @@ func (agent *Agent) Watch() chan *MetricsResult {
 	go func() {
 		// Start collectMetrics concurrently
 		// so that it does not prevent runnnig next collectMetrics.
-		sem := make(chan uint, collectMetricsWorkerMax)
+		sem := make(chan struct{}, collectMetricsWorkerMax)
 		for tickedTime := range ticker {
 			ti := tickedTime
-			sem <- 1
+			sem <- struct{}{}
 			go func() {
 				metricsResult <- agent.CollectMetrics(ti)
 				<-sem

--- a/agent/generator.go
+++ b/agent/generator.go
@@ -9,13 +9,13 @@ import (
 
 var logger = logging.GetLogger("agent")
 
-func generateValues(generators []metrics.Generator) []metrics.ValuesCustomIdentifier {
-	processed := make(chan metrics.ValuesCustomIdentifier)
+func generateValues(generators []metrics.Generator) []*metrics.ValuesCustomIdentifier {
+	processed := make(chan *metrics.ValuesCustomIdentifier)
 	finish := make(chan struct{})
-	result := make(chan []metrics.ValuesCustomIdentifier)
+	result := make(chan []*metrics.ValuesCustomIdentifier)
 
 	go func() {
-		allValues := []metrics.ValuesCustomIdentifier{}
+		allValues := []*metrics.ValuesCustomIdentifier{}
 		for {
 			select {
 			case values := <-processed:
@@ -48,7 +48,7 @@ func generateValues(generators []metrics.Generator) []metrics.ValuesCustomIdenti
 				if pluginGenerator, ok := g.(metrics.PluginGenerator); ok {
 					customIdentifier = pluginGenerator.CustomIdentifier()
 				}
-				processed <- metrics.ValuesCustomIdentifier{
+				processed <- &metrics.ValuesCustomIdentifier{
 					Values:           values,
 					CustomIdentifier: customIdentifier,
 				}

--- a/agent/generator.go
+++ b/agent/generator.go
@@ -9,7 +9,7 @@ import (
 
 var logger = logging.GetLogger("agent")
 
-func generateValues(generators []metrics.Generator) chan []metrics.ValuesCustomIdentifier {
+func generateValues(generators []metrics.Generator) []metrics.ValuesCustomIdentifier {
 	processed := make(chan metrics.ValuesCustomIdentifier)
 	finish := make(chan struct{})
 	result := make(chan []metrics.ValuesCustomIdentifier)
@@ -58,5 +58,5 @@ func generateValues(generators []metrics.Generator) chan []metrics.ValuesCustomI
 		finish <- struct{}{} // processed all jobs
 	}()
 
-	return result
+	return <-result
 }

--- a/agent/generator.go
+++ b/agent/generator.go
@@ -11,7 +11,7 @@ var logger = logging.GetLogger("agent")
 
 func generateValues(generators []metrics.Generator) chan []metrics.ValuesCustomIdentifier {
 	processed := make(chan metrics.ValuesCustomIdentifier)
-	finish := make(chan bool)
+	finish := make(chan struct{})
 	result := make(chan []metrics.ValuesCustomIdentifier)
 
 	go func() {
@@ -55,7 +55,7 @@ func generateValues(generators []metrics.Generator) chan []metrics.ValuesCustomI
 			}(g)
 		}
 		wg.Wait()
-		finish <- true // processed all jobs
+		finish <- struct{}{} // processed all jobs
 	}()
 
 	return result

--- a/agent/generator_test.go
+++ b/agent/generator_test.go
@@ -24,8 +24,7 @@ func TestGenerateValues(t *testing.T) {
 	tg := &testGenerator{}
 	tpg := &testPanicGenerator{}
 	generators := []metrics.Generator{tg, tpg}
-	result := generateValues(generators)
-	values := <-result
+	values := generateValues(generators)
 
 	if len(values) != 1 {
 		t.Errorf("Num of results should be 1, but %d", len(values))

--- a/command/command.go
+++ b/command/command.go
@@ -353,7 +353,7 @@ func enqueueLoop(c *Context, postQueue chan *postValue, quit chan struct{}) {
 						continue
 					}
 				}
-				for name, value := range (map[string]float64)(values.Values) {
+				for name, value := range values.Values {
 					if math.IsNaN(value) || math.IsInf(value, 0) {
 						logger.Warningf("Invalid value: hostID = %s, name = %s, value = %f\n is not sent.", hostID, name, value)
 						continue

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,7 +2,7 @@ package metrics
 
 import "github.com/mackerelio/mackerel-agent/mackerel"
 
-// Values XXX
+// Values represents metric values
 type Values map[string]float64
 
 func merge(v1, v2 Values) Values {
@@ -31,14 +31,14 @@ func MergeValuesCustomIdentifiers(values []*ValuesCustomIdentifier, newValue *Va
 	return append(values, newValue)
 }
 
-// Generator XXX
+// Generator generates metrics
 type Generator interface {
 	Generate() (Values, error)
 }
 
-// PluginGenerator XXX
+// PluginGenerator generates metrics of plugin
 type PluginGenerator interface {
-	Generate() (Values, error)
+	Generator
 	PrepareGraphDefs() ([]mackerel.CreateGraphDefsPayload, error)
 	CustomIdentifier() *string
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -5,11 +5,11 @@ import "github.com/mackerelio/mackerel-agent/mackerel"
 // Values XXX
 type Values map[string]float64
 
-// Merge XXX
-func (vs *Values) Merge(other Values) {
-	for k, v := range other {
-		(*vs)[k] = v
+func merge(v1, v2 Values) Values {
+	for k, v := range v2 {
+		v1[k] = v
 	}
+	return v1
 }
 
 // ValuesCustomIdentifier holds the metric values with the optional custom identifier
@@ -24,7 +24,7 @@ func MergeValuesCustomIdentifiers(values []*ValuesCustomIdentifier, newValue *Va
 		if value.CustomIdentifier == newValue.CustomIdentifier ||
 			(value.CustomIdentifier != nil && newValue.CustomIdentifier != nil &&
 				*value.CustomIdentifier == *newValue.CustomIdentifier) {
-			value.Values.Merge(newValue.Values)
+			value.Values = merge(value.Values, newValue.Values)
 			return values
 		}
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,7 +19,7 @@ type ValuesCustomIdentifier struct {
 }
 
 // MergeValuesCustomIdentifiers merges the metric values and custom identifiers
-func MergeValuesCustomIdentifiers(values []ValuesCustomIdentifier, newValue ValuesCustomIdentifier) []ValuesCustomIdentifier {
+func MergeValuesCustomIdentifiers(values []*ValuesCustomIdentifier, newValue *ValuesCustomIdentifier) []*ValuesCustomIdentifier {
 	for _, value := range values {
 		if value.CustomIdentifier == newValue.CustomIdentifier ||
 			(value.CustomIdentifier != nil && newValue.CustomIdentifier != nil &&

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -7,7 +7,7 @@ type Values map[string]float64
 
 // Merge XXX
 func (vs *Values) Merge(other Values) {
-	for k, v := range (map[string]float64)(other) {
+	for k, v := range other {
 		(*vs)[k] = v
 	}
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -42,11 +42,11 @@ func TestMergeValuesCustomIdentifiers(t *testing.T) {
 		"gg": 70,
 	}
 
-	v := MergeValuesCustomIdentifiers([]ValuesCustomIdentifier{
+	v := MergeValuesCustomIdentifiers([]*ValuesCustomIdentifier{
 		{Values: v0},
-	}, ValuesCustomIdentifier{Values: v1})
+	}, &ValuesCustomIdentifier{Values: v1})
 
-	if !reflect.DeepEqual(v, []ValuesCustomIdentifier{
+	if !reflect.DeepEqual(v, []*ValuesCustomIdentifier{
 		{
 			Values: Values{
 				"aa": 10,
@@ -59,9 +59,9 @@ func TestMergeValuesCustomIdentifiers(t *testing.T) {
 	}
 
 	customIdentifiers := "foo-bar"
-	v = MergeValuesCustomIdentifiers(v, ValuesCustomIdentifier{Values: v2, CustomIdentifier: &customIdentifiers})
+	v = MergeValuesCustomIdentifiers(v, &ValuesCustomIdentifier{Values: v2, CustomIdentifier: &customIdentifiers})
 
-	if !reflect.DeepEqual(v, []ValuesCustomIdentifier{
+	if !reflect.DeepEqual(v, []*ValuesCustomIdentifier{
 		{
 			Values: Values{
 				"aa": 10,
@@ -82,9 +82,9 @@ func TestMergeValuesCustomIdentifiers(t *testing.T) {
 	}
 
 	sameCustomIdentifiers := "foo-bar"
-	v = MergeValuesCustomIdentifiers(v, ValuesCustomIdentifier{Values: v3, CustomIdentifier: &sameCustomIdentifiers})
+	v = MergeValuesCustomIdentifiers(v, &ValuesCustomIdentifier{Values: v3, CustomIdentifier: &sameCustomIdentifiers})
 
-	if !reflect.DeepEqual(v, []ValuesCustomIdentifier{
+	if !reflect.DeepEqual(v, []*ValuesCustomIdentifier{
 		{
 			Values: Values{
 				"aa": 10,

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -5,26 +5,6 @@ import (
 	"testing"
 )
 
-func TestMerge(t *testing.T) {
-	var v = Values{
-		"aa": 10,
-	}
-	var vv = Values{
-		"bb": 20,
-		"cc": 30,
-	}
-
-	v.Merge(vv)
-
-	if !reflect.DeepEqual(v, Values{
-		"aa": 10,
-		"bb": 20,
-		"cc": 30,
-	}) {
-		t.Errorf("somthing went wrong")
-	}
-}
-
 func TestMergeValuesCustomIdentifiers(t *testing.T) {
 	var v0 = Values{
 		"aa": 10,


### PR DESCRIPTION
manipulating a pointer of map is dangerous, especially at the moment of reallocation.