### PR TITLE
[incompatible] consider df  (used + available) as size of filesystem

### DIFF
--- a/metrics/filesystem.go
+++ b/metrics/filesystem.go
@@ -33,7 +33,7 @@ func (g *FilesystemGenerator) Generate() (Values, error) {
 		if device := strings.TrimPrefix(name, "/dev/"); name != device {
 			device = sanitizerReg.ReplaceAllString(device, "_")
 			// kilo bytes -> bytes
-			ret["filesystem."+device+".size"] = float64(dfs.Blocks) * 1024
+			ret["filesystem."+device+".size"] = float64(dfs.Used+dfs.Available) * 1024
 			ret["filesystem."+device+".used"] = float64(dfs.Used) * 1024
 		}
 	}


### PR DESCRIPTION
The ext2/3/4 filesystems have reserved blocks which may only be allocated by privileged processes. 
Normally, the default percentage of reserved blocks is 5%.

The `1k-blocks` output by `df` command contains this reserved blocks.
So, `Used + Available` is more suited for the total available size.

http://unix.stackexchange.com/questions/41125/ext2-3-4-reserved-blocks-percentage-purpose