### PR TITLE
Remove DigitalOcean related comment/definition from spec/cloud.go

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -13,10 +13,9 @@ import (
 )
 
 // This Generator collects metadata about cloud instances.
-// Currently metadata for DigitalOcean is not supported.
+// Currently EC2 and GCE are supported.
 // EC2: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
 // GCE: https://developers.google.com/compute/docs/metadata
-// DigitalOcean: https://developers.digitalocean.com/metadata/
 
 // CloudGenerator definition
 type CloudGenerator struct {
@@ -36,12 +35,11 @@ func (g *CloudGenerator) Key() string {
 
 var cloudLogger = logging.GetLogger("spec.cloud")
 
-var ec2BaseURL, gceMetaURL, digitalOceanBaseURL *url.URL
+var ec2BaseURL, gceMetaURL *url.URL
 
 func init() {
 	ec2BaseURL, _ = url.Parse("http://169.254.169.254/latest/meta-data")
 	gceMetaURL, _ = url.Parse("http://metadata.google.internal/computeMetadata/v1/?recursive=true")
-	digitalOceanBaseURL, _ = url.Parse("http://169.254.169.254/metadata/v1") // has not been yet used
 }
 
 var timeout = 100 * time.Millisecond

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This Generator collects metadata about cloud instances.
-// Currently only EC2 is supported.
+// Currently metadata for DigitalOcean is not supported.
 // EC2: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
 // GCE: https://developers.google.com/compute/docs/metadata
 // DigitalOcean: https://developers.digitalocean.com/metadata/


### PR DESCRIPTION
- Comments of `spec/cloud.go` says only EC2 is supported, but collecting metadata for GCE is already implemented
- `digitalOceanBaseURL` is defined but is not used, so removed it