### PR TITLE
Fix golint is not working on ci, and add some comment to pass golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ run: build
 
 deps: generate
 	go get -d -v -t ./...
-#	go get github.com/golang/lint/golint
+	go get github.com/golang/lint/golint
 	go get github.com/pierrre/gotestcover
 	go get github.com/laher/goxc
 	go get github.com/mattn/goveralls

--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -19,6 +19,8 @@ import (
 	"github.com/mackerelio/mackerel-agent/logging"
 )
 
+// DfStat is disk free statistics from df command.
+// Field names are taken from column names of `df -P`
 type DfStat struct {
 	Name      string
 	Blocks    uint64


### PR DESCRIPTION
Currently `go get`ing golint is disabled and linting on ci is not working.
Ref: https://travis-ci.org/mackerelio/mackerel-agent/builds/154671512#L270
> _tools/go-linter: 7: _tools/go-linter: golint: not found