### PR TITLE
Add linux distribution information to kernel spec

### DIFF
--- a/spec/linux/kernel.go
+++ b/spec/linux/kernel.go
@@ -109,7 +109,7 @@ func normalizePlatform(platform string) string {
 	case "coreos":
 		normalized = "CoreOS"
 	default:
-		normalized = ""
+		normalized = platform
 	}
 
 	return normalized

--- a/spec/linux/kernel.go
+++ b/spec/linux/kernel.go
@@ -76,6 +76,8 @@ func normalizePlatform(platform string) string {
 		normalized = "Fedora"
 	case "oracle":
 		normalized = "Oracle Linux"
+	case "enterpriseenterprise":
+		normalized = "Oracle Enterprise Linux"
 	case "centos":
 		normalized = "CentOS"
 	case "redhat":

--- a/spec/linux/kernel.go
+++ b/spec/linux/kernel.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/shirou/gopsutil/host"
 )
 
 // KernelGenerator XXX
@@ -42,5 +43,72 @@ func (g *KernelGenerator) Generate() (interface{}, error) {
 		results[key] = str
 	}
 
+	hostInfo, err := host.Info()
+	if err != nil {
+		kernelLogger.Errorf("Failed to get platform information: %s", err)
+	}
+
+	if np := normalizePlatform(hostInfo.Platform); np != "" {
+		platformInfo := np + " " + hostInfo.PlatformVersion
+
+		// when platform version is empty string
+		platformInfo = strings.TrimSpace(platformInfo)
+
+		results["platform"] = platformInfo
+	}
+
 	return results, nil
+}
+
+func normalizePlatform(platform string) string {
+	var normalized string
+
+	switch platform {
+	case "debian":
+		normalized = "Debian"
+	case "ubuntu":
+		normalized = "Ubuntu"
+	case "linuxmint":
+		normalized = "Linux Mint"
+	case "raspbian":
+		normalized = "Raspbian"
+	case "fedora":
+		normalized = "Fedora"
+	case "oracle":
+		normalized = "Oracle Linux"
+	case "centos":
+		normalized = "CentOS"
+	case "redhat":
+		normalized = "Red Hat Enterprise Linux"
+	case "scientific":
+		normalized = "Scientific Linux"
+	case "amazon":
+		normalized = "Amazon Linux"
+	case "xenserver":
+		normalized = "XenServer"
+	case "cloudlinux":
+		normalized = "CloudLinux"
+	case "ibm_powerkvm":
+		normalized = "IBM PowerKVM"
+	case "suse":
+		normalized = "SUSE Linux Enterprise Server"
+	case "opensuse":
+		normalized = "openSUSE"
+	case "gentoo":
+		normalized = "Gentoo Linux"
+	case "slackware":
+		normalized = "Slackware"
+	case "arch":
+		normalized = "Arch Linux"
+	case "exherbo":
+		normalized = "Exherbo"
+	case "alpine":
+		normalized = "Alpine Linux"
+	case "coreos":
+		normalized = "CoreOS"
+	default:
+		normalized = ""
+	}
+
+	return normalized
 }

--- a/spec/linux/kernel.go
+++ b/spec/linux/kernel.go
@@ -49,13 +49,12 @@ func (g *KernelGenerator) Generate() (interface{}, error) {
 		return results, nil
 	}
 
-	if np := normalizePlatform(hostInfo.Platform); np != "" {
-		platformInfo := np + " " + hostInfo.PlatformVersion
+	if platformName := normalizePlatform(hostInfo.Platform); platformName != "" {
+		results["platform_name"] = platformName
+	}
 
-		// when platform version is empty string
-		platformInfo = strings.TrimSpace(platformInfo)
-
-		results["platform"] = platformInfo
+	if platformVersion := hostInfo.PlatformVersion; platformVersion != "" {
+		results["platform_version"] = platformVersion
 	}
 
 	return results, nil

--- a/spec/linux/kernel.go
+++ b/spec/linux/kernel.go
@@ -46,6 +46,7 @@ func (g *KernelGenerator) Generate() (interface{}, error) {
 	hostInfo, err := host.Info()
 	if err != nil {
 		kernelLogger.Errorf("Failed to get platform information: %s", err)
+		return results, nil
 	}
 
 	if np := normalizePlatform(hostInfo.Platform); np != "" {


### PR DESCRIPTION
like this

```
{
  "name":     "Linux",
  "release":  "4.4.0-36-generic",
  "version":  "#55-Ubuntu SMP Thu Aug 11 18:01:55 UTC 2016",
  "machine":  "x86_64",
  "os":       "GNU/Linux",
  "platform": "Debian 8.5",
}
```


checked distributions are as follows:
- Ubuntu
- Debian
- CentOS
- AmazonLinux
- openSUSE
- Fedora
- AlpineLinux
- ArchLinux
- Gentoo
- Oracle Linux
- Red Hat Enterprise Linux
- Scientific Linux
