### PR TITLE
http_proxy configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	DisplayName string      `toml:"display_name"`
 	HostStatus  HostStatus  `toml:"host_status"`
 	Filesystems Filesystems `toml:"filesystems"`
+	HTTPProxy   string      `toml:"http_proxy"`
 
 	// Corresponds to the set of [plugin.<kind>.<name>] sections
 	// the key of the map is <kind>, which should be one of "metrics" or "checks".

--- a/main.go
+++ b/main.go
@@ -140,6 +140,10 @@ func resolveConfig(fs *flag.FlagSet, argv []string) (*config.Config, error) {
 	if conf.Apikey == "" {
 		return nil, fmt.Errorf("Apikey must be specified in the config file (or by the DEPRECATED command-line flag)")
 	}
+
+	if conf.HTTPProxy != "" {
+		os.Setenv("HTTP_PROXY", conf.HTTPProxy)
+	}
 	return conf, nil
 }
 

--- a/packaging/deb/debian/mackerel-agent.init
+++ b/packaging/deb/debian/mackerel-agent.init
@@ -20,6 +20,10 @@ LOGFILE=${LOGILE:="/var/log/$NAME.log"}
 PIDFILE=${PIDFILE:="/var/run/$NAME.pid"}
 ROOT=${ROOT:="/var/lib/$NAME"}
 
+if [ "$HTTP_PROXY" != "" ]; then
+    export HTTP_PROXY=$HTTP_PROXY
+fi
+
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0
 

--- a/packaging/rpm/src/mackerel-agent.initd
+++ b/packaging/rpm/src/mackerel-agent.initd
@@ -25,6 +25,10 @@ LOGFILE=${LOGILE:="/var/log/$prog.log"}
 PIDFILE=${PIDFILE:="/var/run/$prog.pid"}
 ROOT=${ROOT:="/var/lib/$prog"}
 
+if [ "$HTTP_PROXY" != "" ]; then
+    export HTTP_PROXY=$HTTP_PROXY
+fi
+
 lockfile=/var/lock/subsys/$prog
 
 # if matched return 0, else return 1


### PR DESCRIPTION
- we can write http_proxy setting in mackerel-agent.conf.
- needless to write `export` in `/etc/{default,sysconfig}/mackerel-agent` for `HTTP_PROXY` setting.
