### PR TITLE
Ignore docker mapper storage in spec as well

### DIFF
--- a/metrics/filesystem.go
+++ b/metrics/filesystem.go
@@ -25,9 +25,7 @@ func (g *FilesystemGenerator) Generate() (Values, error) {
 	ret := Values{}
 	for _, dfs := range filesystems {
 		name := dfs.Name
-		// https://github.com/docker/docker/blob/v1.5.0/daemon/graphdriver/devmapper/deviceset.go#L981
-		if strings.HasPrefix(name, "/dev/mapper/docker-") ||
-			(g.IgnoreRegexp != nil && g.IgnoreRegexp.MatchString(name)) {
+		if g.IgnoreRegexp != nil && g.IgnoreRegexp.MatchString(name) {
 			continue
 		}
 		if device := strings.TrimPrefix(name, "/dev/"); name != device {

--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -92,6 +92,10 @@ func parseDfLines(out string) []*DfStat {
 			logger.Warningf(err.Error())
 			continue
 		}
+		// https://github.com/docker/docker/blob/v1.5.0/daemon/graphdriver/devmapper/deviceset.go#L981
+		if strings.HasPrefix(dfstat.Name, "/dev/mapper/docker-") {
+			continue
+		}
 		filesystems = append(filesystems, dfstat)
 	}
 	return filesystems

--- a/util/filesystem_test.go
+++ b/util/filesystem_test.go
@@ -15,11 +15,12 @@ func TestCollectDfValues(t *testing.T) {
 }
 
 func TestParseDfLines(t *testing.T) {
-	dfout := `Filesystem     1024-blocks     Used Available Capacity Mounted on
-/dev/sda1           19734388 16868164 1863772  91% /
-tmpfs                 517224        0  517224   0% /lib/init/rw
-udev                  512780       96  512684   1% /dev
-tmpfs                 517224        4  517220   1% /dev/shm
+	dfout := `Filesystem                         1024-blocks     Used Available Capacity Mounted on
+/dev/sda1                             19734388 16868164 1863772        91% /
+tmpfs                                   517224        0  517224         0% /lib/init/rw
+udev                                    512780       96  512684         1% /dev
+tmpfs                                   517224        4  517220         1% /dev/shm
+/dev/mapper/docker-000:0-000-00000    10190136   168708 9480756         2% /var/lib/docker/devicemapper/mnt/00000
 `
 	expect := []*DfStat{
 		{


### PR DESCRIPTION
Docker mapper storages are ignored in collecting the metrics (ref: #58), but the specs are still collected. The information on docker mapper storages in the host page are not that useful. How about ignoring the docker storages?
