### PR TITLE
Release version 0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.35.0 (2016-09-07)
+
+* built with Go 1.7 #266 (Songmu)
+* remove `func (vs *Values) Merge(other Values)` #268 (Songmu)
+* [incompatible] consider df  (used + available) as size of filesystem #271 (Songmu)
+* Remove DigitalOcean related comment/definition from spec/cloud.go #272 (astj)
+* Fix golint is not working on ci, and add some comment to pass golint #273 (astj)
+* Add linux distribution information to kernel spec #274 (ak1t0)
+* http_proxy configuration #275 (Songmu)
+* set PATH and LANG only in unix environment #276 (Songmu)
+* Ignore docker mapper storage in spec as well #278 (itchyny)
+
+
 ## 0.34.0 (2016-08-18)
 
 * Reduce retry count on finding a host by the custom identifier #258 (itchyny)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,26 @@
+mackerel-agent (0.35.0-1) stable; urgency=low
+
+  * built with Go 1.7 (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/266>
+  * remove `func (vs *Values) Merge(other Values)` (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/268>
+  * [incompatible] consider df  (used + available) as size of filesystem (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/271>
+  * Remove DigitalOcean related comment/definition from spec/cloud.go (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/272>
+  * Fix golint is not working on ci, and add some comment to pass golint (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/273>
+  * Add linux distribution information to kernel spec (by ak1t0)
+    <https://github.com/mackerelio/mackerel-agent/pull/274>
+  * http_proxy configuration (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/275>
+  * set PATH and LANG only in unix environment (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/276>
+  * Ignore docker mapper storage in spec as well (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/278>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 07 Sep 2016 02:42:39 +0000
+
 mackerel-agent (0.34.0-1) stable; urgency=low
 
   * Reduce retry count on finding a host by the custom identifier (by itchyny)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,17 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Sep 07 2016 <mackerel-developers@hatena.ne.jp> - 0.35.0-1
+- built with Go 1.7 (by Songmu)
+- remove `func (vs *Values) Merge(other Values)` (by Songmu)
+- [incompatible] consider df  (used + available) as size of filesystem (by Songmu)
+- Remove DigitalOcean related comment/definition from spec/cloud.go (by astj)
+- Fix golint is not working on ci, and add some comment to pass golint (by astj)
+- Add linux distribution information to kernel spec (by ak1t0)
+- http_proxy configuration (by Songmu)
+- set PATH and LANG only in unix environment (by Songmu)
+- Ignore docker mapper storage in spec as well (by itchyny)
+
 * Thu Aug 18 2016 <mackerel-developers@hatena.ne.jp> - 0.34.0-1
 - Reduce retry count on finding a host by the custom identifier (by itchyny)
 - suppress checker flooding when resuming from sleep mode (by Songmu)


### PR DESCRIPTION
* built with Go 1.7 #266 (Songmu)
* remove `func (vs *Values) Merge(other Values)` #268 (Songmu)
* [incompatible] consider df  (used + available) as size of filesystem #271 (Songmu)
* Remove DigitalOcean related comment/definition from spec/cloud.go #272 (astj)
* Fix golint is not working on ci, and add some comment to pass golint #273 (astj)
* Add linux distribution information to kernel spec #274 (ak1t0)
* http_proxy configuration #275 (Songmu)
* set PATH and LANG only in unix environment #276 (Songmu)
* Ignore docker mapper storage in spec as well #278 (itchyny)