### PR TITLE
Add platform metadata for Darwin

### DIFF
--- a/spec/darwin/kernel.go
+++ b/spec/darwin/kernel.go
@@ -10,12 +10,6 @@ import (
 )
 
 // KernelGenerator Generates specs about the kernel.
-// Keys below are expected.
-// - name:    the operating system name ("Linux")
-// - release: the operating system release ("2.6.32-5-686")
-// - version: the operating system version ("#1 SMP Sun Sep 23 09:49:36 UTC 2012")
-// - machine: the machine hardware name ("i686")
-// - os:      the operating system name ("GNU/Linux")
 type KernelGenerator struct {
 }
 
@@ -26,7 +20,7 @@ func (g *KernelGenerator) Key() string {
 
 var kernelLogger = logging.GetLogger("spec.kernel")
 
-// Generate XXX
+// Generate collects specs from `uname` command and `sw_vers` command
 func (g *KernelGenerator) Generate() (interface{}, error) {
 	// foundamental information from `uname` command
 	unameArgs := map[string][]string{

--- a/spec/darwin/kernel_test.go
+++ b/spec/darwin/kernel_test.go
@@ -26,4 +26,9 @@ func TestKernelGenerator_Generate(t *testing.T) {
 	if !releaseExists {
 		t.Errorf("'release' must exit: %v", kernel)
 	}
+
+	_, platformNameExists := kernel["platform_name"]
+	if !platformNameExists {
+		t.Errorf("'platform_name' must exit: %v", kernel)
+	}
 }


### PR DESCRIPTION
In #274, `host.meta.kernel.platform_name` and `host.meta.kernel.platform_version` are introduced.
This p-r add Mac OS support for `platform_{name,version}`.

With my machine (Mac OS X 10.9.5), following specs are generated:
```
      "kernel": {
        "machine": "x86_64",
        "name": "Darwin",
        "os": "Darwin",
        "platform_name": "Mac OS X",
        "platform_version": "10.9.5",
        "release": "13.4.0",
        "version": "Darwin Kernel Version 13.4.0: Mon Jan 11 18:17:34 PST 2016; root:xnu-2422.115.15~1/RELEASE_X86_64"
      },
```