### PR TITLE
Release version 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.36.0 (2016-10-18)
+
+* don't use HTTP_PROXY when requesting cloud instance metadata APIs #285 (Songmu)
+* Add an option to output filesystem-related metrics with key by mountpoint #286 (astj)
+
+
 ## 0.35.1 (2016-09-29)
 
 * support MACKEREL_PLUGIN_WORKDIR in init scripts #277 (Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.36.0-1) stable; urgency=low
+
+  * don't use HTTP_PROXY when requesting cloud instance metadata APIs (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/285>
+  * Add an option to output filesystem-related metrics with key by mountpoint (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/286>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 18 Oct 2016 08:15:17 +0000
+
 mackerel-agent (0.35.1-1) stable; urgency=low
 
   * support MACKEREL_PLUGIN_WORKDIR in init scripts (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,10 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Tue Oct 18 2016 <mackerel-developers@hatena.ne.jp> - 0.36.0-1
+- don't use HTTP_PROXY when requesting cloud instance metadata APIs (by Songmu)
+- Add an option to output filesystem-related metrics with key by mountpoint (by astj)
+
 * Thu Sep 29 2016 <mackerel-developers@hatena.ne.jp> - 0.35.1-1
 - support MACKEREL_PLUGIN_WORKDIR in init scripts (by Songmu)
 - Add platform metadata for Darwin (by astj)


### PR DESCRIPTION
- don't use HTTP_PROXY when requesting cloud instance metadata APIs #285
- Add an option to output filesystem-related metrics with key by mountpoint #286