### PR TITLE
Suppress ec2 metadata warnings

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -122,7 +122,6 @@ func (g *EC2Generator) Generate() (interface{}, error) {
 		"local-hostname",
 		"public-hostname",
 		"local-ipv4",
-		"public-keys",
 		"public-ipv4",
 		"reservation-id",
 	}

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -145,7 +145,7 @@ func (g *EC2Generator) Generate() (interface{}, error) {
 			metadata[key] = string(body)
 			cloudLogger.Debugf("results %s:%s", key, string(body))
 		} else {
-			cloudLogger.Warningf("Status code of the result of requesting metadata '%s' is '%d'", key, resp.StatusCode)
+			cloudLogger.Debugf("Status code of the result of requesting metadata '%s' is '%d'", key, resp.StatusCode)
 		}
 	}
 


### PR DESCRIPTION
The metadata public-hostname/public-ipv4 are unavailable on many environment. The warning is not that important worthing recording to the mackerel-agent.log.