### PR TITLE
Uncapitalize error messages

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -76,7 +76,7 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 			})
 
 			if lastErr != nil {
-				return nil, fmt.Errorf("Failed to register this host: %s", lastErr.Error())
+				return nil, fmt.Errorf("failed to register this host: %s", lastErr.Error())
 			}
 
 			doRetry(func() error {
@@ -84,7 +84,7 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 				return filterErrorForRetry(lastErr)
 			})
 			if lastErr != nil {
-				return nil, fmt.Errorf("Failed to find this host on mackerel: %s", lastErr.Error())
+				return nil, fmt.Errorf("failed to find this host on mackerel: %s", lastErr.Error())
 			}
 		}
 	} else { // check the hostID is valid or not
@@ -94,9 +94,9 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 		})
 		if lastErr != nil {
 			if fsStorage, ok := conf.HostIDStorage.(*config.FileSystemHostIDStorage); ok {
-				return nil, fmt.Errorf("Failed to find this host on mackerel (You may want to delete file \"%s\" to register this host to an another organization): %s", fsStorage.HostIDFile(), lastErr.Error())
+				return nil, fmt.Errorf("failed to find this host on mackerel (You may want to delete file \"%s\" to register this host to an another organization): %s", fsStorage.HostIDFile(), lastErr.Error())
 			}
-			return nil, fmt.Errorf("Failed to find this host on mackerel: %s", lastErr.Error())
+			return nil, fmt.Errorf("failed to find this host on mackerel: %s", lastErr.Error())
 		}
 	}
 
@@ -107,13 +107,13 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 			return filterErrorForRetry(lastErr)
 		})
 		if lastErr != nil {
-			return nil, fmt.Errorf("Failed to set default host status: %s, %s", hostSt, lastErr.Error())
+			return nil, fmt.Errorf("failed to set default host status: %s, %s", hostSt, lastErr.Error())
 		}
 	}
 
 	lastErr = conf.SaveHostID(result.ID)
 	if lastErr != nil {
-		return nil, fmt.Errorf("Failed to save host ID: %s", lastErr.Error())
+		return nil, fmt.Errorf("failed to save host ID: %s", lastErr.Error())
 	}
 
 	return result, nil
@@ -529,12 +529,12 @@ func (c *Context) UpdateHostSpecs() {
 func Prepare(conf *config.Config) (*Context, error) {
 	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, conf.Verbose)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to prepare an api: %s", err.Error())
+		return nil, fmt.Errorf("failed to prepare an api: %s", err.Error())
 	}
 
 	host, err := prepareHost(conf, api)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to prepare host: %s", err.Error())
+		return nil, fmt.Errorf("failed to prepare host: %s", err.Error())
 	}
 
 	return &Context{

--- a/commands.go
+++ b/commands.go
@@ -96,7 +96,7 @@ func doRetire(fs *flag.FlagSet, argv []string) error {
 
 	hostID, err := conf.LoadHostID()
 	if err != nil {
-		return fmt.Errorf("HostID file is not found")
+		return fmt.Errorf("hostID file is not found")
 	}
 
 	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, conf.Verbose)
@@ -105,7 +105,7 @@ func doRetire(fs *flag.FlagSet, argv []string) error {
 	}
 
 	if !force && !prompter.YN(fmt.Sprintf("retire this host? (hostID: %s)", hostID), false) {
-		return fmt.Errorf("Retirement is canceled.")
+		return fmt.Errorf("retirement is canceled.")
 	}
 
 	err = retry.Retry(10, 3*time.Second, func() error {

--- a/commands.go
+++ b/commands.go
@@ -105,7 +105,7 @@ func doRetire(fs *flag.FlagSet, argv []string) error {
 	}
 
 	if !force && !prompter.YN(fmt.Sprintf("retire this host? (hostID: %s)", hostID), false) {
-		return fmt.Errorf("retirement is canceled.")
+		return fmt.Errorf("retirement is canceled")
 	}
 
 	err = retry.Retry(10, 3*time.Second, func() error {

--- a/do_init.go
+++ b/do_init.go
@@ -25,7 +25,7 @@ func doInitialize(fs *flag.FlagSet, argv []string) error {
 	if confExists {
 		conf, err := config.LoadConfig(*conffile)
 		if err != nil {
-			return fmt.Errorf("Failed to load the config file: %s", err)
+			return fmt.Errorf("failed to load the config file: %s", err)
 		}
 		if conf.Apikey != "" {
 			return apikeyAlreadySetError(*conffile)

--- a/do_init_test.go
+++ b/do_init_test.go
@@ -62,7 +62,7 @@ func TestDoInitialize(t *testing.T) {
 		conffile.Close()
 		err = doInit(&flag.FlagSet{}, []string{"-conf", f, "-apikey=hoge"})
 
-		if err == nil || !strings.HasPrefix(err.Error(), "Failed to load the config") {
+		if err == nil || !strings.HasPrefix(err.Error(), "failed to load the config") {
 			t.Errorf("should return load config error but: %s", err)
 		}
 	}

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -157,7 +157,7 @@ func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*Host, erro
 	}
 
 	if len(data.Hosts) == 0 {
-		return nil, fmt.Errorf("No host was found for the custom identifier: %s", customIdentifier)
+		return nil, fmt.Errorf("no host was found for the custom identifier: %s", customIdentifier)
 	}
 	return data.Hosts[0], err
 }

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func resolveConfig(fs *flag.FlagSet, argv []string) (*config.Config, error) {
 	conf, confErr := config.LoadConfig(*conffile)
 	conf.Conffile = *conffile
 	if confErr != nil {
-		return nil, fmt.Errorf("Failed to load the config file: %s", confErr)
+		return nil, fmt.Errorf("failed to load the config file: %s", confErr)
 	}
 
 	// overwrite config from file by config from args
@@ -145,7 +145,7 @@ func resolveConfig(fs *flag.FlagSet, argv []string) (*config.Config, error) {
 	}
 
 	if conf.Apikey == "" {
-		return nil, fmt.Errorf("Apikey must be specified in the config file (or by the DEPRECATED command-line flag)")
+		return nil, fmt.Errorf("apikey must be specified in the config file (or by the DEPRECATED command-line flag)")
 	}
 
 	if conf.HTTPProxy != "" {
@@ -158,7 +158,7 @@ func createPidFile(pidfile string) error {
 	if pidString, err := ioutil.ReadFile(pidfile); err == nil {
 		if pid, err := strconv.Atoi(string(pidString)); err == nil {
 			if existsPid(pid) {
-				return fmt.Errorf("Pidfile found, try stopping another running mackerel-agent or delete %s", pidfile)
+				return fmt.Errorf("pidfile found, try stopping another running mackerel-agent or delete %s", pidfile)
 			}
 			// Note mackerel-agent in windows can't remove pidfile during stoping the service
 			logger.Warningf("Pidfile found, but there seems no another process of mackerel-agent. Ignoring %s", pidfile)

--- a/main_test.go
+++ b/main_test.go
@@ -136,7 +136,7 @@ func TestCreateAndRemovePidFile(t *testing.T) {
 	}
 
 	if runtime.GOOS != "windows" {
-		if err := createPidFile(fpath); err == nil || !strings.HasPrefix(err.Error(), "Pidfile found, try stopping another running mackerel-agent or delete") {
+		if err := createPidFile(fpath); err == nil || !strings.HasPrefix(err.Error(), "pidfile found, try stopping another running mackerel-agent or delete") {
 			t.Errorf("creating pid file should be failed when the running process exists, %s", err)
 		}
 	}

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -162,19 +162,19 @@ func (g *EC2Generator) SuggestCustomIdentifier() (string, error) {
 	key := "instance-id"
 	resp, err := cl.Get(g.baseURL.String() + "/" + key)
 	if err != nil {
-		return "", fmt.Errorf("Error while retrieving instance-id.")
+		return "", fmt.Errorf("error while retrieving instance-id.")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("Failed to request instance-id. response code: %d", resp.StatusCode)
+		return "", fmt.Errorf("failed to request instance-id. response code: %d", resp.StatusCode)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("Results of requesting instance-id cannot be read: '%s'", err)
+		return "", fmt.Errorf("results of requesting instance-id cannot be read: '%s'", err)
 	}
 	instanceID := string(body)
 	if instanceID == "" {
-		return "", fmt.Errorf("Invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
 	return instanceID + ".ec2.amazonaws.com", nil
 }

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -162,7 +162,7 @@ func (g *EC2Generator) SuggestCustomIdentifier() (string, error) {
 	key := "instance-id"
 	resp, err := cl.Get(g.baseURL.String() + "/" + key)
 	if err != nil {
-		return "", fmt.Errorf("error while retrieving instance-id.")
+		return "", fmt.Errorf("error while retrieving instance-id")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {

--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -104,7 +104,7 @@ var dfColumnsPattern = regexp.MustCompile(`^(.+?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+
 func parseDfLine(line string) (*DfStat, error) {
 	matches := dfColumnsPattern.FindStringSubmatch(line)
 	if matches == nil {
-		return nil, fmt.Errorf("Failed to parse line: [%s]", line)
+		return nil, fmt.Errorf("failed to parse line: [%s]", line)
 	}
 	name := matches[1]
 	blocks, _ := strconv.ParseUint(matches[2], 0, 64)


### PR DESCRIPTION
We should not capitalize error strings, otherwise go vet will fail on Travis.
https://github.com/golang/go/wiki/CodeReviewComments#error-strings
