### PR TITLE
Fixed error log output when Windows service stopped.

### DIFF
--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -101,11 +101,7 @@ func (h *handler) Execute(args []string, r <-chan svc.ChangeRequest, s chan<- sv
 
 	exit := make(chan struct{})
 	go func() {
-		err := h.cmd.Wait()
-		// enter when the child process exited
-		if err != nil {
-			h.elog.Error(stopEid, err.Error())
-		}
+		h.cmd.Wait()
 		exit <- struct{}{}
 	}()
 


### PR DESCRIPTION
When stopping Windows Service, error was output to the event log.
