### PR TITLE
Avoid time.Tick and use time.NewTicker instead

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -33,25 +33,31 @@ func (agent *Agent) CollectMetrics(collectedTime time.Time) *MetricsResult {
 }
 
 // Watch XXX
-func (agent *Agent) Watch() chan *MetricsResult {
+func (agent *Agent) Watch(quit chan struct{}) chan *MetricsResult {
 
 	metricsResult := make(chan *MetricsResult)
 	ticker := make(chan time.Time)
 	interval := config.PostMetricsInterval
 
 	go func() {
-		c := time.Tick(1 * time.Second)
+		t := time.NewTicker(1 * time.Second)
 
 		last := time.Now()
 		ticker <- last // sends tick once at first
 
-		for t := range c {
-			// Fire an event at 0 second per minute.
-			// Because ticks may not be accurate,
-			// fire an event if t - last is more than 1 minute
-			if t.Second()%int(interval.Seconds()) == 0 || t.After(last.Add(interval)) {
-				last = t
-				ticker <- t
+		for {
+			select {
+			case <-quit:
+				t.Stop()
+				return
+			case t := <-t.C:
+				// Fire an event at 0 second per minute.
+				// Because ticks may not be accurate,
+				// fire an event if t - last is more than 1 minute
+				if t.Second()%int(interval.Seconds()) == 0 || t.After(last.Add(interval)) {
+					last = t
+					ticker <- t
+				}
 			}
 		}
 	}()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -48,6 +48,7 @@ func (agent *Agent) Watch(quit chan struct{}) chan *MetricsResult {
 		for {
 			select {
 			case <-quit:
+				close(ticker)
 				t.Stop()
 				return
 			case t := <-t.C:

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,102 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mackerelio/mackerel-agent/config"
+	"github.com/mackerelio/mackerel-agent/mackerel"
+	"github.com/mackerelio/mackerel-agent/metrics"
+)
+
+type fakeGenerator struct {
+	metrics.Generator
+	FakeGenerate func() (metrics.Values, error)
+}
+
+func (f *fakeGenerator) Generate() (metrics.Values, error) {
+	return f.FakeGenerate()
+}
+
+type fakePluginGenerator struct {
+	metrics.PluginGenerator
+	FakeGenerate         func() (metrics.Values, error)
+	FakeCustomIdentifier *string
+}
+
+func (f *fakePluginGenerator) Generate() (metrics.Values, error) {
+	return f.FakeGenerate()
+}
+
+func (f *fakePluginGenerator) PrepareGraphDefs() ([]mackerel.CreateGraphDefsPayload, error) {
+	return nil, nil
+}
+
+func (f *fakePluginGenerator) CustomIdentifier() *string {
+	return f.FakeCustomIdentifier
+}
+
+func TestAgent_Watch(t *testing.T) {
+	g1Cnt := 0
+	g1 := &fakeGenerator{
+		FakeGenerate: func() (metrics.Values, error) {
+			g1Cnt++
+			return map[string]float64{"g1.a": float64(g1Cnt)}, nil
+		},
+	}
+	g2i := "g2"
+	g2 := &fakePluginGenerator{
+		FakeCustomIdentifier: &g2i,
+		FakeGenerate: func() (metrics.Values, error) {
+			return map[string]float64{"g2.a": float64(14), "g2.b": float64(42)}, nil
+		},
+	}
+
+	ag := &Agent{MetricsGenerators: []metrics.Generator{g1, g2}}
+
+	defer func(i time.Duration) { config.PostMetricsInterval = i }(config.PostMetricsInterval)
+	// we cannot set interval less than 1 second
+	config.PostMetricsInterval = 1 * time.Second
+
+	quit := make(chan struct{})
+	metricsResult := ag.Watch(quit)
+
+	cnt := 0
+	end := time.After(5 * time.Second)
+	for {
+		select {
+		case <-end:
+			t.Error("timeout")
+			return
+		case mr := <-metricsResult:
+			cnt++
+			if cnt > 3 {
+				return
+			}
+			v1, v2 := mr.Values[0], mr.Values[1]
+
+			if v1.CustomIdentifier != nil {
+				v1, v2 = v2, v1
+			}
+
+			if got, ok := v1.Values["g1.a"]; ok {
+				if want := float64(cnt); got != want {
+					t.Errorf("got %v, want %v", got, want)
+				}
+			} else {
+				t.Errorf("generator1: MetricResult should have 'g1.a': %v", v1)
+			}
+
+			if got, ok := v2.Values["g2.a"]; ok {
+				if want := float64(14); got != want {
+					t.Errorf("generator2: g2.a: got %v, want %v", got, want)
+				}
+			}
+			if got, ok := v2.Values["g2.b"]; ok {
+				if want := float64(42); got != want {
+					t.Errorf("generator2: g2.b: got %v, want %v", got, want)
+				}
+			}
+		}
+	}
+}

--- a/command/command.go
+++ b/command/command.go
@@ -332,7 +332,7 @@ func updateHostSpecsLoop(c *Context, quit chan struct{}) {
 }
 
 func enqueueLoop(c *Context, postQueue chan *postValue, quit chan struct{}) {
-	metricsResult := c.Agent.Watch()
+	metricsResult := c.Agent.Watch(quit)
 	for {
 		select {
 		case <-quit:


### PR DESCRIPTION
I ran https://github.com/dominikh/go-staticcheck for mackerel-agent and noticed that it uses time.Tick which is not safe to use in production code because underlying goroutine leaks.

```
$ staticcheck ./...
/home/haya14busa/src/github.com/mackerelio/mackerel-agent/agent/agent.go:43:8: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (SA1015)
```

There are no goroutine leaks caused by time.Tick in mackerel-agent because `Agent.Watch()` is called only once. However, just to be on the safe side, I think it's better to use `time.NewTicker()` and stop goroutine with quit.

godoc:
- https://golang.org/pkg/time/#Tick
- https://golang.org/pkg/time/#NewTicker

I also add a test for Agent.Watch().
