### PR TITLE
Release version 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.38.0 (2016-12-21)
+
+* fix typo #12 (ts-3156)
+* Add Copyright #13 (yuuki)
+* Separate interfaceGenerator from specGenerators #14 (motemen)
+* Timout http reuquest in 30 sec (requries go 1.3) #17 (hakobe)
+* specify command arguments in mackerel-agent.conf #293 (Songmu)
+* several improvements for Windows #298 (daiksy)
+* Avoid time.Tick and use time.NewTicker instead #299 (haya14busa)
+
+
 ## 0.37.1 (2016-11-29)
 
 * fix pluginlist #291 (daiksy)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,22 @@
+mackerel-agent (0.38.0-1) stable; urgency=low
+
+  * fix typo (by ts-3156)
+    <https://github.com/mackerelio/mackerel-agent/pull/12>
+  * Add Copyright (by yuuki)
+    <https://github.com/mackerelio/mackerel-agent/pull/13>
+  * Separate interfaceGenerator from specGenerators (by motemen)
+    <https://github.com/mackerelio/mackerel-agent/pull/14>
+  * Timout http reuquest in 30 sec (requries go 1.3) (by hakobe)
+    <https://github.com/mackerelio/mackerel-agent/pull/17>
+  * specify command arguments in mackerel-agent.conf (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/293>
+  * several improvements for Windows (by daiksy)
+    <https://github.com/mackerelio/mackerel-agent/pull/298>
+  * Avoid time.Tick and use time.NewTicker instead (by haya14busa)
+    <https://github.com/mackerelio/mackerel-agent/pull/299>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 21 Dec 2016 02:22:17 +0000
+
 mackerel-agent (0.37.1-1) stable; urgency=low
 
   * fix pluginlist (by daiksy)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,15 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Dec 21 2016 <mackerel-developers@hatena.ne.jp> - 0.38.0-1
+- fix typo (by ts-3156)
+- Add Copyright (by yuuki)
+- Separate interfaceGenerator from specGenerators (by motemen)
+- Timout http reuquest in 30 sec (requries go 1.3) (by hakobe)
+- specify command arguments in mackerel-agent.conf (by Songmu)
+- several improvements for Windows (by daiksy)
+- Avoid time.Tick and use time.NewTicker instead (by haya14busa)
+
 * Tue Nov 29 2016 <mackerel-developers@hatena.ne.jp> - 0.37.1-1
 - fix pluginlist (by daiksy)
 - Suppress ec2 metadata warnings (by itchyny)


### PR DESCRIPTION
- fix typo #12
- Add Copyright #13
- Separate interfaceGenerator from specGenerators #14
- Timout http reuquest in 30 sec (requries go 1.3) #17
- specify command arguments in mackerel-agent.conf #293
- several improvements for Windows #298
- Avoid time.Tick and use time.NewTicker instead #299