### PR TITLE
[nit] Fix slice formatter

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -558,7 +558,7 @@ func RunOnce(conf *config.Config) error {
 		"metrics": metrics,
 	})
 	if err != nil {
-		logger.Warningf("Error while marshaling graphdefs: err = %s, graphdefs = %s.", err.Error(), graphdefs)
+		logger.Warningf("Error while marshaling graphdefs: err = %s, graphdefs = %v.", err.Error(), graphdefs)
 		return err
 	}
 	fmt.Println(string(json))


### PR DESCRIPTION
Slices should be formatted by `%v`.

```
[github.com/mackerelio/mackerel-agent]$ go version
go version go1.7.4 darwin/amd64
[github.com/mackerelio/mackerel-agent]$ make lint
go get -d -v -t ./...
go get github.com/golang/lint/golint
go get github.com/pierrre/gotestcover
go get github.com/laher/goxc
go get github.com/mattn/goveralls
go tool vet -all -printfuncs=Criticalf,Infof,Warningf,Debugf,Tracef .
command/command.go:561: arg graphdefs for printf verb %s of wrong type: []github.com/mackerelio/mackerel-agent/mackerel.CreateGraphDefsPayload
make: *** [lint] Error 1
```