### PR TITLE
Test wix/pluginlist.txt on AppVeyor ci

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ test_script:
 - go get -d -v -t ./...
 - go tool vet -all .
 - go test -short ./...
+- call wix\pluginlist_test.bat
 notifications:
   - provider: Slack
     auth_token:

--- a/wix/pluginlist.txt
+++ b/wix/pluginlist.txt
@@ -1,3 +1,4 @@
 github.com/mackerelio/go-check-plugins/check-log
 github.com/mackerelio/go-check-plugins/check-procs
 github.com/mackerelio/go-check-plugins/check-ntservice
+github.com/mackerelio/go-check-plugins/wrrrrrong

--- a/wix/pluginlist.txt
+++ b/wix/pluginlist.txt
@@ -1,4 +1,3 @@
 github.com/mackerelio/go-check-plugins/check-log
 github.com/mackerelio/go-check-plugins/check-procs
 github.com/mackerelio/go-check-plugins/check-ntservice
-github.com/mackerelio/go-check-plugins/wrrrrrong

--- a/wix/pluginlist_test.bat
+++ b/wix/pluginlist_test.bat
@@ -4,7 +4,7 @@ go get -d github.com/mackerelio/go-check-plugins/...
 go get -d github.com/mackerelio/mackerel-agent-plugins/...
 
 FOR /F %%w in (.\wix\pluginlist.txt) DO (
-  go list %%W
+  go list %%w
   if not "%ERRORLEVEL%" == "0" (
     exit /b 1
   )

--- a/wix/pluginlist_test.bat
+++ b/wix/pluginlist_test.bat
@@ -3,9 +3,10 @@ echo on
 go get -d github.com/mackerelio/go-check-plugins/...
 go get -d github.com/mackerelio/mackerel-agent-plugins/...
 
+setlocal enabledelayedexpansion
 FOR /F %%w in (.\wix\pluginlist.txt) DO (
   go list %%w
-  if not "%ERRORLEVEL%" == "0" (
+  if not "!ERRORLEVEL!" == "0" (
     exit /b 1
   )
 )

--- a/wix/pluginlist_test.bat
+++ b/wix/pluginlist_test.bat
@@ -1,0 +1,11 @@
+echo on
+
+go get -d github.com/mackerelio/go-check-plugins/...
+go get -d github.com/mackerelio/mackerel-agent-plugins/...
+
+FOR /F %%w in (.\wix\pluginlist.txt) DO (
+  go get -d %%W
+  if not "%ERRORLEVEL%" == "0" (
+    exit /b 1
+  )
+)

--- a/wix/pluginlist_test.bat
+++ b/wix/pluginlist_test.bat
@@ -4,7 +4,7 @@ go get -d github.com/mackerelio/go-check-plugins/...
 go get -d github.com/mackerelio/mackerel-agent-plugins/...
 
 FOR /F %%w in (.\wix\pluginlist.txt) DO (
-  go get -d %%W
+  go list %%W
   if not "%ERRORLEVEL%" == "0" (
     exit /b 1
   )


### PR DESCRIPTION
I know AppVeyor output is not easy to read...
related: #291 

https://github.com/mackerelio/mackerel-agent/pull/313/commits/4904d6904cd4ec0030414559d71a169b57244acf is for demonstration. https://github.com/mackerelio/mackerel-agent/pull/313/commits/4df1d7c9407f8be1e637bf9f680c4719da02fa0b failed because of the wrong pluginlist, and after reverted the commit on https://github.com/mackerelio/mackerel-agent/pull/313/commits/b6afb76d6f99c9b3d62ef0059ea26c4ae4c330d7, AppVeyor build recovered.