### PR TITLE
Fix segfault when loading a bad config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -164,6 +164,9 @@ func (conf *Config) CheckNames() []string {
 // LoadConfig XXX
 func LoadConfig(conffile string) (*Config, error) {
 	config, err := loadConfigFile(conffile)
+	if err != nil {
+		return nil, err
+	}
 
 	// set default values if config does not have values
 	if config.Apibase == "" {

--- a/main.go
+++ b/main.go
@@ -105,10 +105,10 @@ func resolveConfig(fs *flag.FlagSet, argv []string) (*config.Config, error) {
 	fs.Parse(argv)
 
 	conf, confErr := config.LoadConfig(*conffile)
-	conf.Conffile = *conffile
 	if confErr != nil {
 		return nil, fmt.Errorf("failed to load the config file: %s", confErr)
 	}
+	conf.Conffile = *conffile
 
 	// overwrite config from file by config from args
 	fs.Visit(func(f *flag.Flag) {


### PR DESCRIPTION
This patch fixes a segfault when loading a bad config file (e.g. missing mandatory key)