### PR TITLE
[EXPERIMENTAL] systemd support for CentOS 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ script:
 - test `gofmt -l . | wc -l` = 0
 - make crossbuild
 after_script:
-- docker pull astj/mackerel-rpm-builder:c7
-- make rpm-systemd
 - goveralls -coverprofile=.profile.cov
 before_deploy:
 - docker pull astj/mackerel-rpm-builder:c5

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ after_script:
 - goveralls -coverprofile=.profile.cov
 before_deploy:
 - docker pull astj/mackerel-rpm-builder:c6
+- docker pull astj/mackerel-rpm-builder:c7
 - make rpm deb rpm-kcps deb-kcps rpm-stage deb-stage tgz
 - go get github.com/aktau/github-release
 - mkdir -p ~/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
 - test `gofmt -l . | wc -l` = 0
 - make crossbuild
 after_script:
+- docker pull astj/mackerel-rpm-builder:c7
+- make rpm-systemd
 - goveralls -coverprofile=.profile.cov
 before_deploy:
 - docker pull astj/mackerel-rpm-builder:c6

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ rpm: crossbuild-package
 
 # TODO migrate to rpm
 rpm-systemd: crossbuild-package
-	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
+	BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
 	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build-linux-amd64" \
 			--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
-			-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME)-systemd.spec
+			-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
 
 deb: crossbuild-package
 	BUILD_DIRECTORY=build-linux-386 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ rpm: crossbuild-package
 # TODO migrate to rpm
 rpm-systemd: crossbuild-package
 	BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
-	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c7 \
+	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild -e NAME_POSTFIX=-c7 astj/mackerel-rpm-builder:c7 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-amd64" \
 	--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 	-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec

--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,9 @@ rpm: crossbuild-package
 			-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
 
 # TODO migrate to rpm
-rpm-systemd:
-	GOOS=linux GOARCH=amd64 make build
+rpm-systemd: crossbuild-package
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
-	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build" \
+	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build-linux-amd64" \
 			--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 			-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME)-systemd.spec
 

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,10 @@ rpm: crossbuild-package
 # TODO migrate to rpm
 rpm-systemd: crossbuild-package
 	BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
-	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build-linux-amd64" \
-			--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
-			-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
+	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c7 \
+	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-amd64" \
+	--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
+	-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
 
 deb: crossbuild-package
 	BUILD_DIRECTORY=build-linux-386 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,14 @@ rpm:
 			--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 			-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
 
+# TODO migrate to rpm
+rpm-systemd:
+	GOOS=linux GOARCH=amd64 make build
+	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
+	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build" \
+			--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
+			-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME)-systemd.spec
+
 deb:
 	GOOS=linux GOARCH=386 make build
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
@@ -118,4 +126,4 @@ clean:
 
 generate: commands_gen.go
 
-.PHONY: test build run deps clean lint crossbuild cover rpm deb tgz generate
+.PHONY: test build run deps clean lint crossbuild cover rpm deb tgz generate rpm-systemd

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ rpm: crossbuild-package
 # TODO migrate to rpm
 rpm-systemd: crossbuild-package
 	BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
-	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild -e NAME_POSTFIX=-c7 astj/mackerel-rpm-builder:c7 \
+	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c7 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-amd64" \
 	--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 	-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec

--- a/_tools/packaging/prepare-rpm-build.sh
+++ b/_tools/packaging/prepare-rpm-build.sh
@@ -6,12 +6,18 @@ pwd=`dirname $0`
 . "$pwd/common.sh"
 
 MACKEREL_AGENT_NAME=${MACKEREL_AGENT_NAME:-mackerel-agent}
+spec_filename="mackerel-agent.spec"
+if [ "$BUILD_SYSTEMD" != "" ]; then
+    spec_filename="mackerel-agent-systemd.spec"
+fi
 
 orig_dir="packaging/rpm"
 build_dir="packaging/rpm-build"
 
-cp mackerel-agent.sample.conf "$orig_dir/src/mackerel-agent.conf"
 rm -rf "$build_dir"
-cp -r "$orig_dir" "$build_dir"
+mkdir -p "$build_dir"
+cp -r "$orig_dir/src" "$build_dir/src"
+cp mackerel-agent.sample.conf "$build_dir/src/mackerel-agent.conf"
+cp "$orig_dir/$spec_filename" "$build_dir/mackerel-agent.spec"
 
 convert_for_alternative $build_dir $MACKEREL_AGENT_NAME

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -10,8 +10,9 @@ License:   Commercial
 Summary:   mackerel.io agent
 URL:       https://mackerel.io
 Group:     Hatena
-Source0:   %{name}.system
-Source3:   %{name}.conf
+Source0:   %{name}.sysconfig
+Source1:   %{name}.conf
+Source2:   %{name}.service
 Packager:  Hatena
 BuildArch: %{buildarch}
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -39,6 +39,7 @@ mackerel.io agent
 
 %post
 %systemd_post %{name}.service
+systemctl enable %{name}.service
 
 %preun
 %systemd_preun %{name}.service

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -5,7 +5,7 @@
 
 Name:      mackerel-agent
 Version:   %{_version}
-Release:   1
+Release:   1%{?dist}
 License:   Commercial
 Summary:   mackerel.io agent
 URL:       https://mackerel.io

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -1,0 +1,55 @@
+# sudo yum -y install rpmdevtools go && rpmdev-setuptree
+# rpmbuild -ba ~/rpmbuild/SPECS/mackerel-agent.spec
+
+%define _binaries_in_noarch_packages_terminate_build   0
+
+Name:      mackerel-agent
+Version:   %{_version}
+Release:   1
+License:   Commercial
+Summary:   mackerel.io agent
+URL:       https://mackerel.io
+Group:     Hatena
+Source0:   %{name}.system
+Source3:   %{name}.conf
+Packager:  Hatena
+BuildArch: %{buildarch}
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+%{?systemd_requires}
+BuildRequires: systemd
+
+%description
+mackerel.io agent
+
+%prep
+
+%build
+
+%install
+%{__rm} -rf %{buildroot}
+%{__install} -Dp -m0755 %{_builddir}/%{name}             %{buildroot}%{_bindir}/%{name}
+%{__install} -Dp -m0644 %{_sourcedir}/%{name}.sysconfig  %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
+%{__install} -Dp -m0644 %{_sourcedir}/%{name}.conf       %{buildroot}/%{_sysconfdir}/%{name}/%{name}.conf
+%{__install} -Dp -m0644 %{_sourcedir}/%{name}.service    %{buildroot}%{_unitdir}/%{name}.service
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun %{name}.service
+
+%files
+%defattr(-,root,root)
+%{_unitdir}/%{name}.service
+%{_bindir}/%{name}
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
+
+%changelog

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -10,7 +10,7 @@ EnvironmentFile=-/etc/sysconfig/mackerel-agent
 PIDFile=/var/run/mackerel-agent.pid
 ExecStartPre=/usr/bin/mkdir -m 777 -p $MACKEREL_PLUGIN_WORKDIR
 ExecStart=/usr/bin/mackerel-agent --pidfile /var/run/mackerel-agent.pid --root $ROOT $OTHER_OPTS
-ExecStopPost=/bin/sh -c '[ "$AUTO_RETIREMENT" != "" ] && [ "$AUTO_RETIREMENT" != "0" ] && /usr/bin/mackerel-agent retire -force --root $ROOT $OTHER_OPTS'
+ExecStopPost=/bin/sh -c '[ "$AUTO_RETIREMENT" == "" ] || [ "$AUTO_RETIREMENT" == "0" ] && true || /usr/bin/mackerel-agent retire -force --root $ROOT $OTHER_OPTS'
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -13,6 +13,8 @@ ExecStartPre=/usr/bin/mkdir -m 777 -p $MACKEREL_PLUGIN_WORKDIR
 ExecStart=/usr/bin/mackerel-agent supervise --pidfile /var/run/mackerel-agent.pid --root $ROOT $OTHER_OPTS
 ExecStopPost=/bin/sh -c '[ "$AUTO_RETIREMENT" == "" ] || [ "$AUTO_RETIREMENT" == "0" ] && true || /usr/bin/mackerel-agent retire -force --root $ROOT $OTHER_OPTS'
 ExecReload=/bin/kill -HUP $MAINPID
+LimitNOFILE=65536
+LimitNPROC=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=mackerel.io agent
-Documentation=https://mackerel.io
+Documentation=https://mackerel.io/
 After=network.target
 
 [Service]

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -3,7 +3,6 @@ Description=mackerel.io agent
 Documentation=https://mackerel.io
 # TODO fill dependencies?
 
-# TODO support auto_retirement
 [Service]
 Environment=MACKEREL_PLUGIN_WORKDIR=/var/tmp/mackerel-agent
 Environment=ROOT=/var/lib/mackerel-agent
@@ -11,6 +10,7 @@ EnvironmentFile=-/etc/sysconfig/mackerel-agent
 PIDFile=/var/run/mackerel-agent.pid
 ExecStartPre=/usr/bin/mkdir -m 777 -p $MACKEREL_PLUGIN_WORKDIR
 ExecStart=/usr/bin/mackerel-agent --pidfile /var/run/mackerel-agent.pid --root $ROOT $OTHER_OPTS
+ExecStopPost=/bin/sh -c '[ "$AUTO_RETIREMENT" != "" ] && [ "$AUTO_RETIREMENT" != "0" ] && /usr/bin/mackerel-agent retire -force --root $ROOT $OTHER_OPTS'
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=mackerel.io agent
 Documentation=https://mackerel.io/
-After=network-online.target
-After=nss-lookup.target
+After=network-online.target nss-lookup.target
 
 [Service]
 Environment=MACKEREL_PLUGIN_WORKDIR=/var/tmp/mackerel-agent

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -12,7 +12,7 @@ PIDFile=/var/run/mackerel-agent.pid
 ExecStartPre=/usr/bin/mkdir -m 777 -p $MACKEREL_PLUGIN_WORKDIR
 ExecStart=/usr/bin/mackerel-agent supervise --pidfile /var/run/mackerel-agent.pid --root $ROOT $OTHER_OPTS
 ExecStopPost=/bin/sh -c '[ "$AUTO_RETIREMENT" == "" ] || [ "$AUTO_RETIREMENT" == "0" ] && true || /usr/bin/mackerel-agent retire -force --root $ROOT $OTHER_OPTS'
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=/bin/sh -c '/usr/bin/mackerel-agent configtest && /bin/kill -HUP $MAINPID'
 LimitNOFILE=65536
 LimitNPROC=65536
 

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -2,6 +2,7 @@
 Description=mackerel.io agent
 Documentation=https://mackerel.io/
 After=network-online.target
+After=nss-lookup.target
 
 [Service]
 Environment=MACKEREL_PLUGIN_WORKDIR=/var/tmp/mackerel-agent

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -10,8 +10,9 @@ Environment=ROOT=/var/lib/mackerel-agent
 EnvironmentFile=-/etc/sysconfig/mackerel-agent
 PIDFile=/var/run/mackerel-agent.pid
 ExecStartPre=/usr/bin/mkdir -m 777 -p $MACKEREL_PLUGIN_WORKDIR
-ExecStart=/usr/bin/mackerel-agent --pidfile /var/run/mackerel-agent.pid --root $ROOT $OTHER_OPTS
+ExecStart=/usr/bin/mackerel-agent supervise --pidfile /var/run/mackerel-agent.pid --root $ROOT $OTHER_OPTS
 ExecStopPost=/bin/sh -c '[ "$AUTO_RETIREMENT" == "" ] || [ "$AUTO_RETIREMENT" == "0" ] && true || /usr/bin/mackerel-agent retire -force --root $ROOT $OTHER_OPTS'
+ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -8,9 +8,8 @@ After=nss-lookup.target
 Environment=MACKEREL_PLUGIN_WORKDIR=/var/tmp/mackerel-agent
 Environment=ROOT=/var/lib/mackerel-agent
 EnvironmentFile=-/etc/sysconfig/mackerel-agent
-PIDFile=/var/run/mackerel-agent.pid
 ExecStartPre=/usr/bin/mkdir -m 777 -p $MACKEREL_PLUGIN_WORKDIR
-ExecStart=/usr/bin/mackerel-agent supervise --pidfile /var/run/mackerel-agent.pid --root $ROOT $OTHER_OPTS
+ExecStart=/usr/bin/mackerel-agent supervise --root $ROOT $OTHER_OPTS
 ExecStopPost=/bin/sh -c '[ "$AUTO_RETIREMENT" == "" ] || [ "$AUTO_RETIREMENT" == "0" ] && true || /usr/bin/mackerel-agent retire -force --root $ROOT $OTHER_OPTS'
 ExecReload=/bin/kill -HUP $MAINPID
 LimitNOFILE=65536

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=mackerel.io agent
 Documentation=https://mackerel.io/
-After=network.target
+After=network-online.target
 
 [Service]
 Environment=MACKEREL_PLUGIN_WORKDIR=/var/tmp/mackerel-agent

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=mackerel.io agent
 Documentation=https://mackerel.io
-# TODO fill dependencies?
+After=network.target
 
 [Service]
 Environment=MACKEREL_PLUGIN_WORKDIR=/var/tmp/mackerel-agent

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -12,7 +12,7 @@ PIDFile=/var/run/mackerel-agent.pid
 ExecStartPre=/usr/bin/mkdir -m 777 -p $MACKEREL_PLUGIN_WORKDIR
 ExecStart=/usr/bin/mackerel-agent supervise --pidfile /var/run/mackerel-agent.pid --root $ROOT $OTHER_OPTS
 ExecStopPost=/bin/sh -c '[ "$AUTO_RETIREMENT" == "" ] || [ "$AUTO_RETIREMENT" == "0" ] && true || /usr/bin/mackerel-agent retire -force --root $ROOT $OTHER_OPTS'
-ExecReload=/bin/sh -c '/usr/bin/mackerel-agent configtest && /bin/kill -HUP $MAINPID'
+ExecReload=/bin/kill -HUP $MAINPID
 LimitNOFILE=65536
 LimitNPROC=65536
 

--- a/packaging/rpm/src/mackerel-agent.service
+++ b/packaging/rpm/src/mackerel-agent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=mackerel.io agent
+Documentation=https://mackerel.io
+# TODO fill dependencies?
+
+# TODO support auto_retirement
+[Service]
+Environment=MACKEREL_PLUGIN_WORKDIR=/var/tmp/mackerel-agent
+Environment=ROOT=/var/lib/mackerel-agent
+EnvironmentFile=-/etc/sysconfig/mackerel-agent
+PIDFile=/var/run/mackerel-agent.pid
+ExecStartPre=/usr/bin/mkdir -m 777 -p $MACKEREL_PLUGIN_WORKDIR
+ExecStart=/usr/bin/mackerel-agent --pidfile /var/run/mackerel-agent.pid --root $ROOT $OTHER_OPTS
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# What I do now

- Add experimental systemd service
- Add a new make task to build systemd-ready RPM for C7

# What I don't do now

- <del>Build systemd-supported RPM in travis CI</del>
  - Maybe Ubuntu 12 cannot build systemd-supported RPM, because of lacking systemd related rpm macros
  - <del>Somehow we have to do it, but not now</del>
  - building RPMs on Docker solved this!
- Staging and kcps support
  - Possible, but later.

# Differences between this systemd RPM and current init.d RPM

- systemd cannot change path PIDFile dynamically
- systemd outputs logs to systemd default logs, not to `/var/log/mackerel-agent.log`
  - For systemd maybe this is better, because we can view logs with `sudo systemctl status mackerel-agent` ?
- <del>(Maybe) `HTTP_PROXY` is not supported yet in systemd</del>
  - Thanks to EnvironmentFile
- <del>reload not supported yet in systemd</del>
  - <del>Maybe problem with `AUTO_RETIREMENT=1`</del>
  - Thanks to supervisor mode

# References

https://fedoraproject.org/wiki/Packaging:Scriptlets?rd=Packaging:ScriptletSnippets#Systemd
https://www.freedesktop.org/software/systemd/man/systemd.unit.html (and other systemd.* )