### PR TITLE
Refactor plugin configurations

### DIFF
--- a/checks/checker.go
+++ b/checks/checker.go
@@ -37,12 +37,8 @@ var exitCodeToStatus = map[int]Status{
 // It invokes its given command and transforms the result to a Report
 // to be sent to Mackerel periodically.
 type Checker struct {
-	Name string
-	// NOTE(motemen): We make use of config.PluginConfig as it happens
-	// to have the Command field which was used by metrics.pluginGenerator.
-	// If the configuration of *checks.Checker and/or metrics.pluginGenerator changes,
-	// we should reconsider using config.PluginConfig.
-	Config *config.PluginConfig
+	Name   string
+	Config *config.CheckPlugin
 }
 
 // Report is what Checker produces by invoking its command.

--- a/checks/checker_test.go
+++ b/checks/checker_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestChecker_Check(t *testing.T) {
 	checkerOK := Checker{
-		Config: &config.PluginConfig{
+		Config: &config.CheckPlugin{
 			Command: "go run testdata/exit.go -code 0 -message OK",
 		},
 	}
 
 	checkerWarning := Checker{
-		Config: &config.PluginConfig{
+		Config: &config.CheckPlugin{
 			Command: "go run testdata/exit.go -code 1 -message something_is_going_wrong",
 		},
 	}

--- a/checks/checker_unix_test.go
+++ b/checks/checker_unix_test.go
@@ -18,7 +18,7 @@ func TestChecker_CheckTimeout(t *testing.T) {
 	util.TimeoutDuration = 1 * time.Second
 
 	checkerTimeout := Checker{
-		Config: &config.PluginConfig{
+		Config: &config.CheckPlugin{
 			Command: "sleep 2",
 		},
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -123,15 +123,7 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 // configuration of the custom_identifier fields.
 func prepareCustomIdentiferHosts(conf *config.Config, api *mackerel.API) map[string]*mackerel.Host {
 	customIdentifierHosts := make(map[string]*mackerel.Host)
-	customIdentifiers := make(map[string]bool) // use a map to make them unique
-	for _, pluginConfigs := range conf.Plugin {
-		for _, pluginConfig := range pluginConfigs {
-			if pluginConfig.CustomIdentifier != nil {
-				customIdentifiers[*pluginConfig.CustomIdentifier] = true
-			}
-		}
-	}
-	for customIdentifier := range customIdentifiers {
+	for _, customIdentifier := range conf.CustomIdentifiers() {
 		host, err := api.FindHostByCustomIdentifier(customIdentifier)
 		if err != nil {
 			logger.Warningf("Failed to retrieve the host of custom_identifier: %s, %s", customIdentifier, err)

--- a/command/command.go
+++ b/command/command.go
@@ -642,7 +642,7 @@ func prepareGenerators(conf *config.Config) []metrics.Generator {
 func pluginGenerators(conf *config.Config) []metrics.PluginGenerator {
 	generators := []metrics.PluginGenerator{}
 
-	for _, pluginConfig := range conf.Plugin["metrics"] {
+	for _, pluginConfig := range conf.MetricPlugins {
 		generators = append(generators, metrics.NewPluginGenerator(pluginConfig))
 	}
 

--- a/command/command.go
+++ b/command/command.go
@@ -123,7 +123,7 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 // configuration of the custom_identifier fields.
 func prepareCustomIdentiferHosts(conf *config.Config, api *mackerel.API) map[string]*mackerel.Host {
 	customIdentifierHosts := make(map[string]*mackerel.Host)
-	for _, customIdentifier := range conf.CustomIdentifiers() {
+	for _, customIdentifier := range conf.ListCustomIdentifiers() {
 		host, err := api.FindHostByCustomIdentifier(customIdentifier)
 		if err != nil {
 			logger.Warningf("Failed to retrieve the host of custom_identifier: %s, %s", customIdentifier, err)

--- a/command/command.go
+++ b/command/command.go
@@ -618,7 +618,7 @@ func Run(c *Context, termCh chan struct{}) error {
 func createCheckers(conf *config.Config) []*checks.Checker {
 	checkers := []*checks.Checker{}
 
-	for name, pluginConfig := range conf.Plugin["checks"] {
+	for name, pluginConfig := range conf.CheckPlugins {
 		checker := &checks.Checker{
 			Name:   name,
 			Config: pluginConfig,

--- a/command/command_unix_test.go
+++ b/command/command_unix_test.go
@@ -23,16 +23,14 @@ func TestRunOnce(t *testing.T) {
 	}
 
 	conf := &config.Config{
-		Plugin: map[string]config.PluginConfigs{
-			"metrics": map[string]*config.PluginConfig{
-				"metric1": {
-					Command: diceCommand,
-				},
+		MetricPlugins: map[string]*config.MetricPlugin{
+			"metric1": {
+				Command: diceCommand,
 			},
-			"checks": map[string]*config.PluginConfig{
-				"check1": {
-					Command: "echo 1",
-				},
+		},
+		CheckPlugins: map[string]*config.CheckPlugin{
+			"check1": {
+				Command: "echo 1",
 			},
 		},
 	}
@@ -52,16 +50,14 @@ func TestRunOncePayload(t *testing.T) {
 	}
 
 	conf := &config.Config{
-		Plugin: map[string]config.PluginConfigs{
-			"metrics": map[string]*config.PluginConfig{
-				"metric1": {
-					Command: diceCommand,
-				},
+		MetricPlugins: map[string]*config.MetricPlugin{
+			"metric1": {
+				Command: diceCommand,
 			},
-			"checks": map[string]*config.PluginConfig{
-				"check1": {
-					Command: "echo 1",
-				},
+		},
+		CheckPlugins: map[string]*config.CheckPlugin{
+			"check1": {
+				Command: "echo 1",
 			},
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -98,7 +98,7 @@ func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
 	}, nil
 }
 
-// Run the plugin
+// Run the metric plugin.
 func (pconf *MetricPlugin) Run() (string, string, int, error) {
 	if len(pconf.CommandArgs) > 0 {
 		return util.RunCommandArgs(pconf.CommandArgs, pconf.User)
@@ -140,7 +140,7 @@ func (pconf *PluginConfig) buildCheckPlugin() (*CheckPlugin, error) {
 	}, nil
 }
 
-// Run the plugin
+// Run the check plugin.
 func (pconf *CheckPlugin) Run() (string, string, int, error) {
 	if len(pconf.CommandArgs) > 0 {
 		return util.RunCommandArgs(pconf.CommandArgs, pconf.User)

--- a/config/config.go
+++ b/config/config.go
@@ -289,7 +289,6 @@ func LoadConfig(conffile string) (*Config, error) {
 }
 
 func (conf *Config) buildPlugins() error {
-	conf.MetricPlugins = make(map[string]*MetricPlugin)
 	if pconfs, ok := conf.Plugin["metrics"]; ok {
 		var err error
 		for name, pconf := range pconfs {
@@ -299,7 +298,6 @@ func (conf *Config) buildPlugins() error {
 			}
 		}
 	}
-	conf.CheckPlugins = make(map[string]*CheckPlugin)
 	if pconfs, ok := conf.Plugin["checks"]; ok {
 		var err error
 		for name, pconf := range pconfs {
@@ -321,6 +319,8 @@ func loadConfigFile(file string) (*Config, error) {
 		return config, err
 	}
 
+	config.MetricPlugins = make(map[string]*MetricPlugin)
+	config.CheckPlugins = make(map[string]*CheckPlugin)
 	if err := config.buildPlugins(); err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -105,7 +105,7 @@ func (pconf *PluginConfig) makeCheckPlugin() (*CheckPlugin, error) {
 }
 
 // MetricPlugin represents the configuration of a metric plugin
-// The `User` option is ignored in Windows
+// The User option is ignored on Windows
 type MetricPlugin struct {
 	Command          string
 	CommandArgs      []string
@@ -130,7 +130,7 @@ func (pconf *MetricPlugin) CommandString() string {
 }
 
 // CheckPlugin represents the configuration of a check plugin
-// The `User` option is ignored in Windows
+// The User option is ignored on Windows
 type CheckPlugin struct {
 	Command              string
 	CommandArgs          []string
@@ -212,7 +212,7 @@ func (r *Regexpwrapper) UnmarshalText(text []byte) error {
 	return err
 }
 
-// CheckNames returns a list of check plugins
+// CheckNames returns a list of name of the check plugins
 func (conf *Config) CheckNames() []string {
 	checks := []string{}
 	for name := range conf.CheckPlugins {

--- a/config/config.go
+++ b/config/config.go
@@ -52,8 +52,10 @@ type Config struct {
 	Filesystems Filesystems `toml:"filesystems"`
 	HTTPProxy   string      `toml:"http_proxy"`
 
-	// Corresponds to the set of [plugin.<kind>.<name>] sections
-	// the key of the map is <kind>, which should be one of "metrics" or "checks".
+	// This Plugin field is used to decode the toml file. After reading the
+	// configuration from file, this field is set to nil.
+	// Please use MetricPlugins and CheckPlugins.
+	// Corresponds to the set of [plugin.<kind>.<name>] sections.
 	Plugin map[string]map[string]*PluginConfig
 
 	Include string

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,8 @@ type Config struct {
 
 	// Cannot exist in configuration files
 	HostIDStorage HostIDStorage
+	MetricPlugins map[string]MetricPlugin
+	CheckPlugins  map[string]CheckPlugin
 }
 
 // PluginConfigs represents a set of [plugin.<kind>.<name>] sections in the configuration file

--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,7 @@ type Config struct {
 
 	// Corresponds to the set of [plugin.<kind>.<name>] sections
 	// the key of the map is <kind>, which should be one of "metrics" or "checks".
-	Plugin map[string]PluginConfigs
+	Plugin map[string]map[string]*PluginConfig
 
 	Include string
 
@@ -64,13 +64,7 @@ type Config struct {
 	CheckPlugins  map[string]*CheckPlugin
 }
 
-// PluginConfigs represents a set of [plugin.<kind>.<name>] sections in the configuration file
-// under a specific <kind>. The key of the map is <name>, for example "mysql" of "plugin.metrics.mysql".
-type PluginConfigs map[string]*PluginConfig
-
-// PluginConfig represents a section of [plugin.*].
-// `MaxCheckAttempts`, `NotificationInterval` and `CheckInterval` options are used with check monitoring plugins. Custom metrics plugins ignore these options.
-// `User` option is ignore in windows
+// PluginConfig represents a plugin configuration.
 type PluginConfig struct {
 	CommandRaw           interface{} `toml:"command"`
 	Command              string

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,7 @@ type PluginConfig struct {
 	CustomIdentifier     *string `toml:"custom_identifier"`
 }
 
-func makeMetricPlugin(pconf *PluginConfig) (*MetricPlugin, error) {
+func (pconf *PluginConfig) makeMetricPlugin() (*MetricPlugin, error) {
 	err := pconf.prepareCommand()
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func makeMetricPlugin(pconf *PluginConfig) (*MetricPlugin, error) {
 	}, nil
 }
 
-func makeCheckPlugin(pconf *PluginConfig) (*CheckPlugin, error) {
+func (pconf *PluginConfig) makeCheckPlugin() (*CheckPlugin, error) {
 	err := pconf.prepareCommand()
 	if err != nil {
 		return nil, err
@@ -299,7 +299,7 @@ func (conf *Config) makePlugins() error {
 	if pconfs, ok := conf.Plugin["metrics"]; ok {
 		var err error
 		for name, pconf := range pconfs {
-			conf.MetricPlugins[name], err = makeMetricPlugin(pconf)
+			conf.MetricPlugins[name], err = pconf.makeMetricPlugin()
 			if err != nil {
 				return err
 			}
@@ -309,7 +309,7 @@ func (conf *Config) makePlugins() error {
 	if pconfs, ok := conf.Plugin["checks"]; ok {
 		var err error
 		for name, pconf := range pconfs {
-			conf.CheckPlugins[name], err = makeCheckPlugin(pconf)
+			conf.CheckPlugins[name], err = pconf.makeCheckPlugin()
 			if err != nil {
 				return err
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -222,8 +222,8 @@ func (conf *Config) CheckNames() []string {
 	return checks
 }
 
-// CustomIdentifiers returns a list of customIdentifiers.
-func (conf *Config) CustomIdentifiers() []string {
+// ListCustomIdentifiers returns a list of customIdentifiers.
+func (conf *Config) ListCustomIdentifiers() []string {
 	var customIdentifiers []string
 	for _, pconf := range conf.MetricPlugins {
 		if pconf.CustomIdentifier != nil && index(customIdentifiers, *pconf.CustomIdentifier) == -1 {

--- a/config/config.go
+++ b/config/config.go
@@ -315,6 +315,9 @@ func (conf *Config) makePlugins() error {
 			}
 		}
 	}
+	// Make Plugins empty because we should not use this later.
+	// Use MetricPlugins and CheckPlugins.
+	conf.Plugin = nil
 	return nil
 }
 
@@ -333,11 +336,6 @@ func loadConfigFile(file string) (*Config, error) {
 			return config, err
 		}
 	}
-
-	// Make Plugins empty because we should not use this later
-	// (specifically when we include another configuration file).
-	// Use MetricPlugins and CheckPlugins.
-	config.Plugin = nil
 
 	return config, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -360,7 +360,7 @@ func includeConfigFile(config *Config, include string) error {
 			config.Roles = rolesSaved
 		}
 
-		// Overwrite plugin configurations.
+		// Add new plugin or overwrite a plugin with the same plugin name.
 		if err := config.buildPlugins(); err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -289,7 +289,7 @@ func LoadConfig(conffile string) (*Config, error) {
 	return config, err
 }
 
-func (conf *Config) buildPlugins() error {
+func (conf *Config) setMetricPluginsAndCheckPlugins() error {
 	if pconfs, ok := conf.Plugin["metrics"]; ok {
 		var err error
 		for name, pconf := range pconfs {
@@ -322,7 +322,7 @@ func loadConfigFile(file string) (*Config, error) {
 
 	config.MetricPlugins = make(map[string]*MetricPlugin)
 	config.CheckPlugins = make(map[string]*CheckPlugin)
-	if err := config.buildPlugins(); err != nil {
+	if err := config.setMetricPluginsAndCheckPlugins(); err != nil {
 		return nil, err
 	}
 
@@ -360,7 +360,7 @@ func includeConfigFile(config *Config, include string) error {
 		}
 
 		// Add new plugin or overwrite a plugin with the same plugin name.
-		if err := config.buildPlugins(); err != nil {
+		if err := config.setMetricPluginsAndCheckPlugins(); err != nil {
 			return err
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -127,6 +127,14 @@ func (pconf *MetricPlugin) Run() (string, string, int, error) {
 	return util.RunCommand(pconf.Command, pconf.User)
 }
 
+// CommandString returns the command string for log messages
+func (pconf *MetricPlugin) CommandString() string {
+	if len(pconf.CommandArgs) > 0 {
+		return strings.Join(pconf.CommandArgs, " ")
+	}
+	return pconf.Command
+}
+
 // CheckPlugin represents the configuration of a check plugin
 // The `User` option is ignored in Windows
 type CheckPlugin struct {

--- a/config/config.go
+++ b/config/config.go
@@ -227,6 +227,26 @@ func (conf *Config) CheckNames() []string {
 	return checks
 }
 
+// CustomIdentifiers returns a list of customIdentifiers.
+func (conf *Config) CustomIdentifiers() []string {
+	var customIdentifiers []string
+	for _, pconf := range conf.MetricPlugins {
+		if pconf.CustomIdentifier != nil && index(customIdentifiers, *pconf.CustomIdentifier) == -1 {
+			customIdentifiers = append(customIdentifiers, *pconf.CustomIdentifier)
+		}
+	}
+	return customIdentifiers
+}
+
+func index(xs []string, y string) int {
+	for i, x := range xs {
+		if x == y {
+			return i
+		}
+	}
+	return -1
+}
+
 // LoadConfig XXX
 func LoadConfig(conffile string) (*Config, error) {
 	config, err := loadConfigFile(conffile)

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,26 @@ type PluginConfig struct {
 	CustomIdentifier     *string `toml:"custom_identifier"`
 }
 
+// MetricPlugin represents the configuration of a metric plugin
+// The `User` option is ignored in Windows
+type MetricPlugin struct {
+	Command          string
+	CommandArgs      []string
+	User             string
+	CustomIdentifier *string
+}
+
+// CheckPlugin represents the configuration of a check plugin
+// The `User` option is ignored in Windows
+type CheckPlugin struct {
+	Command              string
+	CommandArgs          []string
+	User                 string
+	NotificationInterval *int32
+	CheckInterval        *int32
+	MaxCheckAttempts     *int32
+}
+
 func (pconf *PluginConfig) prepareCommand() error {
 	const errFmt = "failed to prepare plugin command. A configuration value of `command` should be string or string slice, but %T"
 	v := pconf.CommandRaw

--- a/config/config.go
+++ b/config/config.go
@@ -119,6 +119,14 @@ type MetricPlugin struct {
 	CustomIdentifier *string
 }
 
+// Run the plugin
+func (pconf *MetricPlugin) Run() (string, string, int, error) {
+	if len(pconf.CommandArgs) > 0 {
+		return util.RunCommandArgs(pconf.CommandArgs, pconf.User)
+	}
+	return util.RunCommand(pconf.Command, pconf.User)
+}
+
 // CheckPlugin represents the configuration of a check plugin
 // The `User` option is ignored in Windows
 type CheckPlugin struct {
@@ -128,6 +136,14 @@ type CheckPlugin struct {
 	NotificationInterval *int32
 	CheckInterval        *int32
 	MaxCheckAttempts     *int32
+}
+
+// Run the plugin
+func (pconf *CheckPlugin) Run() (string, string, int, error) {
+	if len(pconf.CommandArgs) > 0 {
+		return util.RunCommandArgs(pconf.CommandArgs, pconf.User)
+	}
+	return util.RunCommand(pconf.Command, pconf.User)
 }
 
 func (pconf *PluginConfig) prepareCommand() error {
@@ -154,14 +170,6 @@ func (pconf *PluginConfig) prepareCommand() error {
 		return fmt.Errorf(errFmt, v)
 	}
 	return nil
-}
-
-// Run the plugin
-func (pconf *PluginConfig) Run() (string, string, int, error) {
-	if len(pconf.CommandArgs) > 0 {
-		return util.RunCommandArgs(pconf.CommandArgs, pconf.User)
-	}
-	return util.RunCommand(pconf.Command, pconf.User)
 }
 
 const postMetricsDequeueDelaySecondsMax = 59   // max delay seconds for dequeuing from buffer queue

--- a/config/config.go
+++ b/config/config.go
@@ -54,8 +54,7 @@ type Config struct {
 
 	// This Plugin field is used to decode the toml file. After reading the
 	// configuration from file, this field is set to nil.
-	// Please use MetricPlugins and CheckPlugins.
-	// Corresponds to the set of [plugin.<kind>.<name>] sections.
+	// Please consider using MetricPlugins and CheckPlugins.
 	Plugin map[string]map[string]*PluginConfig
 
 	Include string

--- a/config/config.go
+++ b/config/config.go
@@ -221,7 +221,7 @@ func (r *Regexpwrapper) UnmarshalText(text []byte) error {
 // CheckNames return list of plugin.checks._name_
 func (conf *Config) CheckNames() []string {
 	checks := []string{}
-	for name := range conf.Plugin["checks"] {
+	for name := range conf.CheckPlugins {
 		checks = append(checks, name)
 	}
 	return checks

--- a/config/config.go
+++ b/config/config.go
@@ -241,7 +241,7 @@ func index(xs []string, y string) int {
 	return -1
 }
 
-// LoadConfig XXX
+// LoadConfig loads a Config from a file.
 func LoadConfig(conffile string) (*Config, error) {
 	config, err := loadConfigFile(conffile)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -218,7 +218,7 @@ func (r *Regexpwrapper) UnmarshalText(text []byte) error {
 	return err
 }
 
-// CheckNames return list of plugin.checks._name_
+// CheckNames returns a list of check plugins
 func (conf *Config) CheckNames() []string {
 	checks := []string{}
 	for name := range conf.CheckPlugins {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -204,7 +204,7 @@ func TestLoadConfigFile(t *testing.T) {
 	if *pluginConf.CustomIdentifier != "app1.example.com" {
 		t.Errorf("plugin custom_identifier should be 'app1.example.com' but got %v", *pluginConf.CustomIdentifier)
 	}
-	customIdentifiers := config.CustomIdentifiers()
+	customIdentifiers := config.ListCustomIdentifiers()
 	if len(customIdentifiers) != 1 {
 		t.Errorf("config should have 1 custom_identifier")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -228,6 +228,10 @@ func TestLoadConfigFile(t *testing.T) {
 	if *checks.MaxCheckAttempts != 3 {
 		t.Error("max_check_attempts should be 3")
 	}
+
+	if config.Plugins != nil {
+		t.Error("plugin config should be set nil, use MetricPlugins and CheckPlugins instead")
+	}
 }
 
 func assertNoError(t *testing.T, err error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,7 @@ post_metrics_retry_max = 5
 [plugin.metrics.mysql]
 command = "ruby /path/to/your/plugin/mysql.rb"
 user = "mysql"
+custom_identifier = "app1.example.com"
 
 [plugin.checks.heartbeat]
 command = "heartbeat.sh"
@@ -199,6 +200,16 @@ func TestLoadConfigFile(t *testing.T) {
 	}
 	if pluginConf.User != "mysql" {
 		t.Errorf("plugin user_name should be 'mysql'")
+	}
+	if *pluginConf.CustomIdentifier != "app1.example.com" {
+		t.Errorf("plugin custom_identifier should be 'app1.example.com'")
+	}
+	customIdentifiers := config.CustomIdentifiers()
+	if len(customIdentifiers) != 1 {
+		t.Errorf("config should have 1 custom_identifier")
+	}
+	if customIdentifiers[0] != "app1.example.com" {
+		t.Errorf("first custom_identifier should be 'app1.example.com'")
 	}
 
 	if config.CheckPlugins == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -190,10 +190,10 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Error("PostMetricsRetryMax should be 5")
 	}
 
-	if config.Plugin["metrics"] == nil {
+	if config.MetricPlugins == nil {
 		t.Error("plugin should have metrics")
 	}
-	pluginConf := config.Plugin["metrics"]["mysql"]
+	pluginConf := config.MetricPlugins["mysql"]
 	if pluginConf.Command != "ruby /path/to/your/plugin/mysql.rb" {
 		t.Errorf("plugin conf command should be 'ruby /path/to/your/plugin/mysql.rb' but %v", pluginConf.Command)
 	}
@@ -201,10 +201,10 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Errorf("plugin user_name should be 'mysql'")
 	}
 
-	if config.Plugin["checks"] == nil {
+	if config.CheckPlugins == nil {
 		t.Error("plugin should have checks")
 	}
-	checks := config.Plugin["checks"]["heartbeat"]
+	checks := config.CheckPlugins["heartbeat"]
 	if checks.Command != "heartbeat.sh" {
 		t.Error("check command should be 'heartbeat.sh'")
 	}
@@ -284,9 +284,9 @@ command = "bar"
 	assert(t, config.Apikey == "not overwritten", "apikey should not be overwritten")
 	assert(t, len(config.Roles) == 1, "roles should be overwritten")
 	assert(t, config.Roles[0] == "Service:role", "roles should be overwritten")
-	assert(t, config.Plugin["metrics"]["foo1"].Command == "foo1", "plugin.metrics.foo1 should exist")
-	assert(t, config.Plugin["metrics"]["foo2"].Command == "foo2", "plugin.metrics.foo2 should exist")
-	assert(t, config.Plugin["metrics"]["bar"].Command == "bar", "plugin.metrics.bar should be overwritten")
+	assert(t, config.MetricPlugins["foo1"].Command == "foo1", "plugin.metrics.foo1 should exist")
+	assert(t, config.MetricPlugins["foo2"].Command == "foo2", "plugin.metrics.foo2 should exist")
+	assert(t, config.MetricPlugins["bar"].Command == "bar", "plugin.metrics.bar should be overwritten")
 }
 
 func TestFileSystemHostIDStorage(t *testing.T) {
@@ -353,7 +353,7 @@ command = ["perl", "-E", "say 'Hello'"]
 	assertNoError(t, err)
 
 	expected := []string{"perl", "-E", "say 'Hello'"}
-	p := config.Plugin["metrics"]["hoge"]
+	p := config.MetricPlugins["hoge"]
 	output := p.CommandArgs
 
 	if !reflect.DeepEqual(expected, output) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -229,7 +229,7 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Error("max_check_attempts should be 3")
 	}
 
-	if config.Plugins != nil {
+	if config.Plugin != nil {
 		t.Error("plugin config should be set nil, use MetricPlugins and CheckPlugins instead")
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -199,10 +199,10 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Errorf("plugin conf command should be 'ruby /path/to/your/plugin/mysql.rb' but %v", pluginConf.Command)
 	}
 	if pluginConf.User != "mysql" {
-		t.Errorf("plugin user_name should be 'mysql'")
+		t.Error("plugin user_name should be 'mysql'")
 	}
 	if *pluginConf.CustomIdentifier != "app1.example.com" {
-		t.Errorf("plugin custom_identifier should be 'app1.example.com'")
+		t.Errorf("plugin custom_identifier should be 'app1.example.com' but got %v", *pluginConf.CustomIdentifier)
 	}
 	customIdentifiers := config.CustomIdentifiers()
 	if len(customIdentifiers) != 1 {

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -126,7 +126,7 @@ func (g *pluginGenerator) loadPluginMeta() error {
 
 	stdout, stderr, exitCode, err := g.Config.Run()
 	if err != nil {
-		return fmt.Errorf("running %T failed: %s, exit=%d stderr=%q", g.Config.CommandRaw, err, exitCode, stderr)
+		return fmt.Errorf("running %s failed: %s, exit=%d stderr=%q", g.Config.CommandString(), err, exitCode, stderr)
 	}
 
 	outBuffer := bufio.NewReader(strings.NewReader(stdout))
@@ -134,7 +134,7 @@ func (g *pluginGenerator) loadPluginMeta() error {
 
 	headerLine, err := outBuffer.ReadString('\n')
 	if err != nil {
-		return fmt.Errorf("while reading the first line of command %T: %s", g.Config.CommandRaw, err)
+		return fmt.Errorf("while reading the first line of command %s: %s", g.Config.CommandString(), err)
 	}
 
 	// Parse the header line of format:
@@ -219,10 +219,10 @@ func (g *pluginGenerator) collectValues() (Values, error) {
 	stdout, stderr, _, err := g.Config.Run()
 
 	if stderr != "" {
-		pluginLogger.Infof("command %T outputted to STDERR: %q", g.Config.CommandRaw, stderr)
+		pluginLogger.Infof("command %s outputted to STDERR: %q", g.Config.CommandString(), stderr)
 	}
 	if err != nil {
-		pluginLogger.Errorf("Failed to execute command %T (skip these metrics):\n", g.Config.CommandRaw)
+		pluginLogger.Errorf("Failed to execute command %s (skip these metrics):\n", g.Config.CommandString())
 		return nil, err
 	}
 

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -17,7 +17,7 @@ import (
 // pluginGenerator collects user-defined metrics.
 // mackerel-agent runs specified command and parses the result for the metric names and values.
 type pluginGenerator struct {
-	Config *config.PluginConfig
+	Config *config.MetricPlugin
 	Meta   *pluginMeta
 }
 
@@ -45,7 +45,7 @@ const pluginPrefix = "custom."
 var pluginConfigurationEnvName = "MACKEREL_AGENT_PLUGIN_META"
 
 // NewPluginGenerator XXX
-func NewPluginGenerator(conf *config.PluginConfig) PluginGenerator {
+func NewPluginGenerator(conf *config.MetricPlugin) PluginGenerator {
 	return &pluginGenerator{Config: conf}
 }
 

--- a/metrics/plugin_test.go
+++ b/metrics/plugin_test.go
@@ -18,7 +18,7 @@ func containsKeyRegexp(values Values, reg string) bool {
 }
 
 func TestPluginGenerate(t *testing.T) {
-	conf := &config.PluginConfig{
+	conf := &config.MetricPlugin{
 		Command: "ruby ../example/metrics-plugins/dice.rb",
 	}
 	g := &pluginGenerator{Config: conf}
@@ -33,7 +33,7 @@ func TestPluginGenerate(t *testing.T) {
 }
 
 func TestPluginCollectValues(t *testing.T) {
-	g := &pluginGenerator{Config: &config.PluginConfig{
+	g := &pluginGenerator{Config: &config.MetricPlugin{
 		Command: "ruby ../example/metrics-plugins/dice.rb",
 	},
 	}

--- a/metrics/plugin_unix_test.go
+++ b/metrics/plugin_unix_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestPluginCollectValuesCommand(t *testing.T) {
-	g := &pluginGenerator{Config: &config.PluginConfig{
+	g := &pluginGenerator{Config: &config.MetricPlugin{
 		Command: "echo \"just.echo.1\t1\t1397822016\"",
 	},
 	}
@@ -34,7 +34,7 @@ func TestPluginCollectValuesCommand(t *testing.T) {
 }
 
 func TestPluginCollectValuesCommandWithSpaces(t *testing.T) {
-	g := &pluginGenerator{Config: &config.PluginConfig{
+	g := &pluginGenerator{Config: &config.MetricPlugin{
 		Command: `echo "just.echo.2   2   1397822016"`,
 	}}
 
@@ -59,7 +59,7 @@ func TestPluginCollectValuesCommandWithSpaces(t *testing.T) {
 
 func TestPluginLoadPluginMeta(t *testing.T) {
 	g := &pluginGenerator{
-		Config: &config.PluginConfig{
+		Config: &config.MetricPlugin{
 			Command: `echo '# mackerel-agent-plugin version=1
 {
   "graphs": {
@@ -115,7 +115,7 @@ func TestPluginLoadPluginMeta(t *testing.T) {
 	}
 
 	generatorWithoutConf := &pluginGenerator{
-		Config: &config.PluginConfig{
+		Config: &config.MetricPlugin{
 			Command: "echo \"just.echo.1\t1\t1397822016\"",
 		},
 	}
@@ -126,7 +126,7 @@ func TestPluginLoadPluginMeta(t *testing.T) {
 	}
 
 	generatorWithBadVersion := &pluginGenerator{
-		Config: &config.PluginConfig{
+		Config: &config.MetricPlugin{
 			Command: `echo "# mackerel-agent-plugin version=666"`,
 		},
 	}

--- a/metrics/plugin_windows_test.go
+++ b/metrics/plugin_windows_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestPluginCollectValuesCommand(t *testing.T) {
-	g := &pluginGenerator{Config: &config.PluginConfig{
+	g := &pluginGenerator{Config: &config.MetricPlugin{
 		Command: "echo just.echo.1	1	1397822016",
 	},
 	}
@@ -34,7 +34,7 @@ func TestPluginCollectValuesCommand(t *testing.T) {
 }
 
 func TestPluginCollectValuesCommandWithSpaces(t *testing.T) {
-	g := &pluginGenerator{Config: &config.PluginConfig{
+	g := &pluginGenerator{Config: &config.MetricPlugin{
 		Command: `echo just.echo.2   2   1397822016`,
 	}}
 
@@ -59,7 +59,7 @@ func TestPluginCollectValuesCommandWithSpaces(t *testing.T) {
 
 func TestPluginLoadPluginMeta(t *testing.T) {
 	g := &pluginGenerator{
-		Config: &config.PluginConfig{
+		Config: &config.MetricPlugin{
 			Command: "ruby ../example/metrics-plugins/dice-with-meta.rb",
 		},
 	}
@@ -78,7 +78,7 @@ func TestPluginLoadPluginMeta(t *testing.T) {
 	}
 
 	generatorWithoutConf := &pluginGenerator{
-		Config: &config.PluginConfig{
+		Config: &config.MetricPlugin{
 			Command: "echo just.echo.1	1	1397822016",
 		},
 	}
@@ -89,7 +89,7 @@ func TestPluginLoadPluginMeta(t *testing.T) {
 	}
 
 	generatorWithBadVersion := &pluginGenerator{
-		Config: &config.PluginConfig{
+		Config: &config.MetricPlugin{
 			Command: `echo # mackerel-agent-plugin version=666`,
 		},
 	}


### PR DESCRIPTION
The configurations of metric plugins and check plugins are contained in Config.Plugin. It makes it easy to decode from the configuration file. But basically we should differentiate the struct of metric plugin and check plugin in my opinion. A check plugin config has `NotificationInterval` field but a metric plugin config does not.
This pull request introduces `MetricPlugin` and `CheckPlugin` and now a `Config` has `MetricPlugins` and `CheckPlugins`. The method `*Config.buildPlugins` builds these plugin configurations and clears the Plugin field to stop others use this field later. I think we should remove this field if possible and move the building phase on toml unmarshalization but I'm not sure how to do.