### PR TITLE
Execute less `go build`s on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ script:
 - make cover
 - test `gofmt -l . | wc -l` = 0
 - make crossbuild
-- make deb
 after_script:
 - goveralls -coverprofile=.profile.cov
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
 - make cover
 - test `gofmt -l . | wc -l` = 0
 - make crossbuild
+- make rpm
 after_script:
 - goveralls -coverprofile=.profile.cov
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ script:
 - make cover
 - test `gofmt -l . | wc -l` = 0
 - make crossbuild
-- make rpm
 after_script:
 - goveralls -coverprofile=.profile.cov
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
 - make cover
 - test `gofmt -l . | wc -l` = 0
 - make crossbuild
+- make deb
 after_script:
 - goveralls -coverprofile=.profile.cov
 before_deploy:

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,10 @@ crossbuild-package:
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-amd64/
 
 crossbuild-package-kcps:
-	make crossbuild MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16
+	make crossbuild-package MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16
 
 crossbuild-package-stage:
-	make crossbuild MACKEREL_AGENT_NAME=mackerel-agent-stage MACKEREL_API_BASE=http://0.0.0.0
+	make crossbuild-package MACKEREL_AGENT_NAME=mackerel-agent-stage MACKEREL_API_BASE=http://0.0.0.0
 
 rpm: crossbuild-package
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ crossbuild-package:
 	GOOS=linux GOARCH=amd64 make build
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-amd64/
 
+crossbuild-package-kcps:
+	make crossbuild MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16
+
 rpm: crossbuild-package
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
 	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build-linux-386" \
@@ -71,15 +74,13 @@ deb:
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
-rpm-kcps:
-	make build MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16 GOOS=linux GOARCH=386
+rpm-kcps: crossbuild-package-kcps
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps _tools/packaging/prepare-rpm-build.sh
-	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build" \
+	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build-linux-386" \
 			--define "_version ${CURRENT_VERSION}" --define "buildarch noarch" \
 			-bb packaging/rpm-build/mackerel-agent-kcps.spec
-	make build MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16 GOOS=linux GOARCH=amd64
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps _tools/packaging/prepare-rpm-build.sh
-	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build" \
+	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build-linux-amd64" \
 			--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 			-bb packaging/rpm-build/mackerel-agent-kcps.spec
 
@@ -123,4 +124,4 @@ clean:
 
 generate: commands_gen.go
 
-.PHONY: test build run deps clean lint crossbuild cover rpm deb tgz generate crossbuild-package
+.PHONY: test build run deps clean lint crossbuild cover rpm deb tgz generate crossbuild-package crossbuild-package-kcps

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,6 @@ rpm-kcps: crossbuild-package-kcps
 			-bb packaging/rpm-build/mackerel-agent-kcps.spec
 
 deb-kcps: crossbuild-package-kcps
-	make build MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16 GOOS=linux GOARCH=386
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps BUILD_DIRECTORY=build-linux-386 _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 

--- a/Makefile
+++ b/Makefile
@@ -56,15 +56,13 @@ crossbuild-package:
 	GOOS=linux GOARCH=amd64 make build
 	mv {build,build-linux-amd64}/$(MACKEREL_AGENT_NAME)
 
-rpm:
-	GOOS=linux GOARCH=386 make build
+rpm: crossbuild-package
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
-	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build" \
+	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build-linux-386" \
 	      --define "_version ${CURRENT_VERSION}" --define "buildarch noarch" \
 				-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
-	GOOS=linux GOARCH=amd64 make build
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
-	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build" \
+	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build-linux-amd64" \
 			--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 			-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
 
@@ -119,7 +117,7 @@ commands_gen.go: commands.go
 	go generate
 
 clean:
-	rm -f build/$(MACKEREL_AGENT_NAME)
+	rm -f {build,build-linux-386,build-linux-amd64}/$(MACKEREL_AGENT_NAME)
 	go clean
 	rm -f commands_gen.go
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ cover: deps
 crossbuild-package:
 	mkdir -p ./build-linux-386 ./build-linux-amd64
 	GOOS=linux GOARCH=386 make build
-	mv build/$(MACKEREL_AGENT_NAME) build-linux-i386/
+	mv build/$(MACKEREL_AGENT_NAME) build-linux-386/
 	GOOS=linux GOARCH=amd64 make build
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-amd64/
 

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,8 @@ rpm: crossbuild-package
 			--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 			-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
 
-deb:
-	GOOS=linux GOARCH=386 make build
-	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
+deb: crossbuild-package
+	BUILD_DIRECTORY=build-linux-386 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
 rpm-kcps: crossbuild-package-kcps
@@ -84,9 +83,9 @@ rpm-kcps: crossbuild-package-kcps
 			--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 			-bb packaging/rpm-build/mackerel-agent-kcps.spec
 
-deb-kcps:
+deb-kcps: crossbuild-package-kcps
 	make build MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16 GOOS=linux GOARCH=386
-	MACKEREL_AGENT_NAME=mackerel-agent-kcps _tools/packaging/prepare-deb-build.sh
+	MACKEREL_AGENT_NAME=mackerel-agent-kcps BUILD_DIRECTORY=build-linux-386 _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
 rpm-stage:

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,13 @@ crossbuild: deps
 cover: deps
 	gotestcover -v -short -covermode=count -coverprofile=.profile.cov -parallelpackages=4 ./...
 
+crossbuild-package:
+	mkdir -p ./build-linux-386 ./build-linux-amd64
+	GOOS=linux GOARCH=386 make build
+	mv {build,build-linux-386}/$(MACKEREL_AGENT_NAME)
+	GOOS=linux GOARCH=amd64 make build
+	mv {build,build-linux-amd64}/$(MACKEREL_AGENT_NAME)
+
 rpm:
 	GOOS=linux GOARCH=386 make build
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
@@ -118,4 +125,4 @@ clean:
 
 generate: commands_gen.go
 
-.PHONY: test build run deps clean lint crossbuild cover rpm deb tgz generate
+.PHONY: test build run deps clean lint crossbuild cover rpm deb tgz generate crossbuild-package

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ crossbuild-package:
 crossbuild-package-kcps:
 	make crossbuild MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16
 
+crossbuild-package-stage:
+	make crossbuild MACKEREL_AGENT_NAME=mackerel-agent-stage MACKEREL_API_BASE=http://0.0.0.0
+
 rpm: crossbuild-package
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
 	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build-linux-386" \
@@ -88,16 +91,14 @@ deb-kcps: crossbuild-package-kcps
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps BUILD_DIRECTORY=build-linux-386 _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
-rpm-stage:
-	make build MACKEREL_AGENT_NAME=mackerel-agent-stage MACKEREL_API_BASE=http://0.0.0.0 GOOS=linux GOARCH=386
+rpm-stage: crossbuild-package-stage
 	MACKEREL_AGENT_NAME=mackerel-agent-stage _tools/packaging/prepare-rpm-build.sh
-	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build" \
+	rpmbuild --define "_sourcedir `pwd`/packaging/rpm-build/src" --define "_builddir `pwd`/build-linux-386" \
 	      --define "_version ${CURRENT_VERSION}" --define "buildarch noarch" \
 				-bb packaging/rpm-build/mackerel-agent-stage.spec
 
-deb-stage:
-	make build MACKEREL_AGENT_NAME=mackerel-agent-stage MACKEREL_API_BASE=http://0.0.0.0 GOOS=linux GOARCH=386
-	MACKEREL_AGENT_NAME=mackerel-agent-stage _tools/packaging/prepare-deb-build.sh
+deb-stage: crossbuild-package-stage
+	MACKEREL_AGENT_NAME=mackerel-agent-stage BUILD_DIRECTORY=build-linux-386 _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
 tgz_dir = "build/tgz/$(MACKEREL_AGENT_NAME)"
@@ -123,4 +124,4 @@ clean:
 
 generate: commands_gen.go
 
-.PHONY: test build run deps clean lint crossbuild cover rpm deb tgz generate crossbuild-package crossbuild-package-kcps
+.PHONY: test build run deps clean lint crossbuild cover rpm deb tgz generate crossbuild-package crossbuild-package-kcps crossbuild-package-stage

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ cover: deps
 crossbuild-package:
 	mkdir -p ./build-linux-386 ./build-linux-amd64
 	GOOS=linux GOARCH=386 make build
-	mv build/$(MACKEREL_AGENT_NAME) build-linux-i386/$(MACKEREL_AGENT_NAME)
+	mv build/$(MACKEREL_AGENT_NAME) build-linux-i386/
 	GOOS=linux GOARCH=amd64 make build
-	mv build/$(MACKEREL_AGENT_NAME) build-linux-amd64/$(MACKEREL_AGENT_NAME)
+	mv build/$(MACKEREL_AGENT_NAME) build-linux-amd64/
 
 rpm: crossbuild-package
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ commands_gen.go: commands.go
 	go generate
 
 clean:
-	rm -f build/$(MACKEREL_AGENT_NAME) build-linux-amd64/$(MACKEREL_AGENT_NAME) build-linux-i386/$(MACKEREL_AGENT_NAME)
+	rm -f build/$(MACKEREL_AGENT_NAME) build-linux-amd64/$(MACKEREL_AGENT_NAME) build-linux-386/$(MACKEREL_AGENT_NAME)
 	go clean
 	rm -f commands_gen.go
 

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ cover: deps
 crossbuild-package:
 	mkdir -p ./build-linux-386 ./build-linux-amd64
 	GOOS=linux GOARCH=386 make build
-	mv build/$(MACKEREL_AGENT_NAME) build-linux-i386/
+	mv build/$(MACKEREL_AGENT_NAME) build-linux-i386/$(MACKEREL_AGENT_NAME)
 	GOOS=linux GOARCH=amd64 make build
-	mv build/$(MACKEREL_AGENT_NAME) build-linux-amd64/
+	mv build/$(MACKEREL_AGENT_NAME) build-linux-amd64/$(MACKEREL_AGENT_NAME)
 
 rpm: crossbuild-package
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,9 @@ crossbuild-package-kcps:
 	make crossbuild-package MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16
 
 crossbuild-package-stage:
-	make crossbuild-package MACKEREL_AGENT_NAME=mackerel-agent-stage MACKEREL_API_BASE=http://0.0.0.0
+	mkdir -p ./build-linux-386
+	GOOS=linux GOARCH=386 make build MACKEREL_AGENT_NAME=mackerel-agent-stage MACKEREL_API_BASE=http://0.0.0.0
+	mv build/mackerel-agent-stage build-linux-386/
 
 rpm: crossbuild-package
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ cover: deps
 crossbuild-package:
 	mkdir -p ./build-linux-386 ./build-linux-amd64
 	GOOS=linux GOARCH=386 make build
-	mv {build,build-linux-386}/$(MACKEREL_AGENT_NAME)
+	mv build/$(MACKEREL_AGENT_NAME) build-linux-i386/
 	GOOS=linux GOARCH=amd64 make build
-	mv {build,build-linux-amd64}/$(MACKEREL_AGENT_NAME)
+	mv build/$(MACKEREL_AGENT_NAME) build-linux-amd64/
 
 rpm: crossbuild-package
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
@@ -117,7 +117,7 @@ commands_gen.go: commands.go
 	go generate
 
 clean:
-	rm -f {build,build-linux-386,build-linux-amd64}/$(MACKEREL_AGENT_NAME)
+	rm -f build/$(MACKEREL_AGENT_NAME) build-linux-amd64/$(MACKEREL_AGENT_NAME) build-linux-i386/$(MACKEREL_AGENT_NAME)
 	go clean
 	rm -f commands_gen.go
 

--- a/_tools/packaging/prepare-deb-build.sh
+++ b/_tools/packaging/prepare-deb-build.sh
@@ -7,7 +7,7 @@ pwd=`dirname $0`
 
 MACKEREL_AGENT_NAME=${MACKEREL_AGENT_NAME:-mackerel-agent}
 MACKEREL_AGENT_VERSION=$(grep -o -e "[0-9]\+.[0-9]\+.[0-9]\+-[0-9]" packaging/deb/debian/changelog | head -1 | sed 's/-.*$//')
-BUILD_DIRECTORY=${BUILD_DIRECTORY:-build/}
+BUILD_DIRECTORY=${BUILD_DIRECTORY:-build}
 
 orig_dir="packaging/deb"
 build_dir="packaging/deb-build"

--- a/_tools/packaging/prepare-deb-build.sh
+++ b/_tools/packaging/prepare-deb-build.sh
@@ -7,6 +7,7 @@ pwd=`dirname $0`
 
 MACKEREL_AGENT_NAME=${MACKEREL_AGENT_NAME:-mackerel-agent}
 MACKEREL_AGENT_VERSION=$(grep -o -e "[0-9]\+.[0-9]\+.[0-9]\+-[0-9]" packaging/deb/debian/changelog | head -1 | sed 's/-.*$//')
+BUILD_DIRECTORY=${BUILD_DIRECTORY:-build/}
 
 orig_dir="packaging/deb"
 build_dir="packaging/deb-build"
@@ -16,5 +17,5 @@ rm -rf "$build_dir"
 cp -r "$orig_dir" "$build_dir"
 
 convert_for_alternative $build_dir $MACKEREL_AGENT_NAME
-cp "build/$MACKEREL_AGENT_NAME" "$build_dir/debian/$MACKEREL_AGENT_NAME.bin"
+cp "${BUILD_DIRECTORY}/$MACKEREL_AGENT_NAME" "$build_dir/debian/$MACKEREL_AGENT_NAME.bin"
 cp packaging/dummy-empty.tar.gz "packaging/${MACKEREL_AGENT_NAME}_$MACKEREL_AGENT_VERSION.orig.tar.gz"


### PR DESCRIPTION
Currently we execute `go build` 9 times per 1 deploy, with various build parameters. With this change, `go build` is executed 6 times per 1 deploy.

```
make rpm deb rpm-kcps deb-kcps rpm-stage deb-stage tgz
```

# Before

2 for rpm, 1 for deb, 2 for rpm-kcps, 1 for deb-kcps, 1 for rpm-stage, 1 for deb-stage, and 1 for tgz

# After

2 for rpm and deb, 2 for rpm-kcps and deb-kcps, 1 for rpm-stage and deb-stage, and 1 for tgz
