### PR TITLE
Release version 0.39.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.39.4 (2017-02-08)
+
+* prepare windows eventlog #319 (daiksy)
+* Refactor plugin configurations #322 (itchyny)
+* Execute less `go build`s on deploy #323 (astj)
+* treat xmlns #324 (mattn)
+* Fix xmlns #326 (mattn)
+
+
 ## 0.39.3 (2017-01-25)
 
 * Fix segfault when loading a bad config file #316 (hanazuki)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent (0.39.4-1) stable; urgency=low
+
+  * prepare windows eventlog (by daiksy)
+    <https://github.com/mackerelio/mackerel-agent/pull/319>
+  * Refactor plugin configurations (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/322>
+  * Execute less `go build`s on deploy (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/323>
+  * treat xmlns (by mattn)
+    <https://github.com/mackerelio/mackerel-agent/pull/324>
+  * Fix xmlns (by mattn)
+    <https://github.com/mackerelio/mackerel-agent/pull/326>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 08 Feb 2017 01:46:39 +0000
+
 mackerel-agent (0.39.3-1) stable; urgency=low
 
   * Fix segfault when loading a bad config file (by hanazuki)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,13 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Feb 08 2017 <mackerel-developers@hatena.ne.jp> - 0.39.4-1
+- prepare windows eventlog (by daiksy)
+- Refactor plugin configurations (by itchyny)
+- Execute less `go build`s on deploy (by astj)
+- treat xmlns (by mattn)
+- Fix xmlns (by mattn)
+
 * Wed Jan 25 2017 <mackerel-developers@hatena.ne.jp> - 0.39.3-1
 - Fix segfault when loading a bad config file (by hanazuki)
 - fix windows eventlog level when "verbose=true" (by daiksy)


### PR DESCRIPTION
- prepare windows eventlog #319
- Refactor plugin configurations #322
- Execute less `go build`s on deploy #323
- treat xmlns #324
- Fix xmlns #326