### PR TITLE
hw.physmem is obsolete

### DIFF
--- a/spec/netbsd/memory.go
+++ b/spec/netbsd/memory.go
@@ -30,7 +30,7 @@ const bytesInKibibytes = 1024
 func (g *MemoryGenerator) Generate() (interface{}, error) {
 	spec := map[string]string{}
 
-	cmd := exec.Command("sysctl", "-n", "hw.physmem")
+	cmd := exec.Command("sysctl", "-n", "hw.physmem64")
 	outputBytes, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("sysctl -n hw.physmem: %s", err)


### PR DESCRIPTION
hw.physmem is singned 32bit. (less 2GB)
hw.physmem64 is singned 64bit.