### PR TITLE
Set large number of file descriptors for the safety sake in init scripts

### DIFF
--- a/packaging/deb/debian/mackerel-agent.init
+++ b/packaging/deb/debian/mackerel-agent.init
@@ -37,6 +37,8 @@ fi
 #
 do_start()
 {
+    # Set large number of file descriptors for the safety sake
+    ulimit -n 65536 1>/dev/null 2>&1 || true
     mkdir -m 777 -p $MACKEREL_PLUGIN_WORKDIR
     MACKEREL_PLUGIN_WORKDIR=$MACKEREL_PLUGIN_WORKDIR $DAEMON ${APIBASE:+--apibase=$APIBASE} ${APIKEY:+--apikey=$APIKEY} --pidfile=$PIDFILE --root=$ROOT $OTHER_OPTS >>$LOGFILE 2>&1 &
     sleep 3

--- a/packaging/rpm/src/mackerel-agent.initd
+++ b/packaging/rpm/src/mackerel-agent.initd
@@ -41,6 +41,8 @@ prefix_match() {
 start() {
     [ -x $exec ] || exit 5
 
+    # Set large number of file descriptors for the safety sake
+    ulimit -n 65536 1>/dev/null 2>&1 || true
     echo -n $"Starting $prog:"
     mkdir -m 777 -p $MACKEREL_PLUGIN_WORKDIR
     MACKEREL_PLUGIN_WORKDIR=$MACKEREL_PLUGIN_WORKDIR $BIN ${APIBASE:+--apibase=$APIBASE} ${APIKEY:+--apikey=$APIKEY} --pidfile=$PIDFILE --root=$ROOT $OTHER_OPTS >>$LOGFILE 2>&1 &


### PR DESCRIPTION
avoid "too many open files"