### PR TITLE
Improve darwin cpu spec

### DIFF
--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -68,7 +68,7 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 
 	wholeResults := make([]cpuSpec, 0, coreCount)
 	for i := 0; i < coreCount; i++ {
-		wholeResults = append(wholeResults, results)
+		wholeResults[i] = results
 	}
 	return wholeResults, nil
 }

--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -66,7 +66,7 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	wholeResults := make([]cpuSpec, 0, coreCount)
+	wholeResults := make([]cpuSpec, coreCount)
 	for i := 0; i < coreCount; i++ {
 		wholeResults[i] = results
 	}

--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -59,21 +59,21 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (cpuSpec, error) {
 	return results, nil
 }
 
-func (g *CPUGenerator) getCoreCount() (*int, error) {
-	coreCountBytes, err := exec.Command("sysctl", "-n", "hw.logicalcpu").Output()
+func (g *CPUGenerator) getCpuCount() (*int, error) {
+	countBytes, err := exec.Command("sysctl", "-n", "hw.logicalcpu").Output()
 	if err != nil {
 		cpuLogger.Errorf("Failed: %s", err)
 		return nil, err
 	}
-	coreCount, err := strconv.Atoi(strings.TrimSpace(string(coreCountBytes)))
+	count, err := strconv.Atoi(strings.TrimSpace(string(countBytes)))
 	if err != nil {
 		cpuLogger.Errorf("Failed to parse: %s", err)
 		return nil, err
 	}
-	return &coreCount, nil
+	return &count, nil
 }
 
-// MEMO: sysctl -a machdep.cpu.brand_string
+// MEMO: sysctl -a machdep.cpu
 
 // Generate collects CPU specs.
 // Returns an array of cpuSpec.
@@ -91,19 +91,19 @@ func (g *CPUGenerator) getCoreCount() (*int, error) {
 // - flags
 func (g *CPUGenerator) Generate() (interface{}, error) {
 	cpuInfoBytes, err := exec.Command("sysctl", "-a", "machdep.cpu").Output()
-	coreInfo, err := g.parseSysCtlBytes(cpuInfoBytes)
+	cpuInfo, err := g.parseSysCtlBytes(cpuInfoBytes)
 	if err != nil {
 		cpuLogger.Errorf("Failed: %s", err)
 		return nil, err
 	}
-	coreCount, err := g.getCoreCount()
+	cpuCount, err := g.getCpuCount()
 	if err != nil {
 		cpuLogger.Errorf("Failed: %s", err)
 		return nil, err
 	}
-	results := make([]cpuSpec, *coreCount)
-	for i := 0; i < *coreCount; i++ {
-		results[i] = coreInfo
+	results := make([]cpuSpec, *cpuCount)
+	for i := 0; i < *cpuCount; i++ {
+		results[i] = cpuInfo
 	}
 	return results, nil
 }

--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -36,7 +36,7 @@ var sysCtlKeyMap = map[string]string{
 func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 	scanner := bufio.NewScanner(bytes.NewBuffer(res))
 
-	results := map[string]interface{}{}
+	results := cpuSpec{}
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -55,7 +55,7 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	return results, nil
+	return []cpuSpec{results}, nil
 }
 
 // MEMO: sysctl -a machdep.cpu.brand_string

--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -59,7 +59,7 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (cpuSpec, error) {
 	return results, nil
 }
 
-func (g *CPUGenerator) getCpuCount() (*int, error) {
+func (g *CPUGenerator) getCPUCount() (*int, error) {
 	countBytes, err := exec.Command("sysctl", "-n", "hw.logicalcpu").Output()
 	if err != nil {
 		cpuLogger.Errorf("Failed: %s", err)
@@ -96,7 +96,7 @@ func (g *CPUGenerator) Generate() (interface{}, error) {
 		cpuLogger.Errorf("Failed: %s", err)
 		return nil, err
 	}
-	cpuCount, err := g.getCpuCount()
+	cpuCount, err := g.getCPUCount()
 	if err != nil {
 		cpuLogger.Errorf("Failed: %s", err)
 		return nil, err

--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -38,7 +38,7 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 	scanner := bufio.NewScanner(bytes.NewBuffer(res))
 
 	results := cpuSpec{}
-	var cores int64
+	var cores int
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -53,7 +53,7 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 		}
 		if key == "core_count" {
 			var err error
-			cores, err = strconv.ParseInt(val, 10, 32)
+			cores, err = strconv.Atoi(val)
 			if err != nil {
 				cpuLogger.Errorf("while parsing %q: %s", val, err)
 				return nil, err
@@ -67,7 +67,7 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 	}
 
 	wholeResults := []cpuSpec{}
-	for i := 0; int64(i) < cores; i++ {
+	for i := 0; i < cores; i++ {
 		wholeResults = append(wholeResults, results)
 	}
 	return wholeResults, nil

--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -38,7 +38,7 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 	scanner := bufio.NewScanner(bytes.NewBuffer(res))
 
 	results := cpuSpec{}
-	var cores int
+	var coreCount int
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -53,7 +53,7 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 		}
 		if key == "core_count" {
 			var err error
-			cores, err = strconv.Atoi(val)
+			coreCount, err = strconv.Atoi(val)
 			if err != nil {
 				cpuLogger.Errorf("while parsing %q: %s", val, err)
 				return nil, err
@@ -66,8 +66,8 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	wholeResults := make([]cpuSpec, 0, cores)
-	for i := 0; i < cores; i++ {
+	wholeResults := make([]cpuSpec, 0, coreCount)
+	for i := 0; i < coreCount; i++ {
 		wholeResults = append(wholeResults, results)
 	}
 	return wholeResults, nil

--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -27,6 +27,10 @@ type cpuSpec map[string]interface{}
 var sysCtlKeyMap = map[string]string{
 	"core_count":   "cores",
 	"brand_string": "model_name",
+	"model":        "model",
+	"vendor":       "vendor_id",
+	"family":       "family",
+	"stepping":     "stepping",
 }
 
 func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {

--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -66,7 +66,7 @@ func (g *CPUGenerator) parseSysCtlBytes(res []byte) (interface{}, error) {
 		return nil, err
 	}
 
-	wholeResults := []cpuSpec{}
+	wholeResults := make([]cpuSpec, 0, cores)
 	for i := 0; i < cores; i++ {
 		wholeResults = append(wholeResults, results)
 	}


### PR DESCRIPTION
Currently mackerel-agent in Darwin reports only 1 CPU core even if the host has many.
And, currently only `model_name` is collected.

With this patch, agent can report multiple CPU cores if the host has so, and it also reports `family`, `model`, `stepping`, `vendor_id` specs like linux does.

Demo
```json
      "cpu": [
        {
          "cores": "2",
          "family": "6",
          "model": "61",
          "model_name": "Intel(R) Core(TM) i5-5287U CPU @ 2.90GHz",
          "stepping": "4",
          "vendor_id": "GenuineIntel"
        },
        {
          "cores": "2",
          "family": "6",
          "model": "61",
          "model_name": "Intel(R) Core(TM) i5-5287U CPU @ 2.90GHz",
          "stepping": "4",
          "vendor_id": "GenuineIntel"
        }
      ],
```