### PR TITLE
Fix format verb: use '%v'

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -91,7 +91,7 @@ func (agent *Agent) CollectGraphDefsOfPlugins() []mackerel.CreateGraphDefsPayloa
 	for _, g := range agent.PluginGenerators {
 		p, err := g.PrepareGraphDefs()
 		if err != nil {
-			logger.Debugf("Failed to fetch meta information from plugin %s (non critical); seems that this plugin does not have meta information: %s", g, err)
+			logger.Debugf("Failed to fetch meta information from plugin %v (non critical); seems that this plugin does not have meta information: %v", g, err)
 		}
 		if p != nil {
 			payloads = append(payloads, p...)


### PR DESCRIPTION
I found bad formatted log in test log output https://travis-ci.org/mackerelio/mackerel-agent/builds/203777712

Example:

2017/02/21 05:12:30 agent.go:110: DEBUG <agent> Failed to fetch meta information from plugin &{%!s(*config.MetricPlugin=&{../example/metrics-plugins/dice-with-meta.rb []  <nil>}) %!s(*metrics.pluginMeta=<nil>)} (non critical); seems that this plugin does not have meta information: while reading the first line of command ../example/metrics-plugins/dice-with-meta.rb: EOF