### PR TITLE
Build RPM files on CentOS5 on Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
 - test `gofmt -l . | wc -l` = 0
 - make crossbuild
 after_script:
+- docker pull astj/mackerel-rpm-builder:c5
+- make rpm rpm-kcps rpm-stage
 - goveralls -coverprofile=.profile.cov
 before_deploy:
 - docker pull astj/mackerel-rpm-builder:c5

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 after_script:
 - goveralls -coverprofile=.profile.cov
 before_deploy:
-- docker pull astj/mackerel-rpm-builder:c6
+- docker pull astj/mackerel-rpm-builder:c5
 - make rpm deb rpm-kcps deb-kcps rpm-stage deb-stage tgz
 - go get github.com/aktau/github-release
 - mkdir -p ~/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ script:
 - test `gofmt -l . | wc -l` = 0
 - make crossbuild
 after_script:
-- docker pull astj/mackerel-rpm-builder:c5
-- make rpm rpm-kcps rpm-stage
 - goveralls -coverprofile=.profile.cov
 before_deploy:
 - docker pull astj/mackerel-rpm-builder:c5

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ crossbuild-package-stage:
 	mv build/mackerel-agent-stage build-linux-386/
 
 rpm: crossbuild-package
-	mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+	mkdir -p rpmbuild/RPMS/{noarch,x86_64}
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \
@@ -82,7 +82,7 @@ deb: crossbuild-package
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
 rpm-kcps: crossbuild-package-kcps
-	mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+	mkdir -p rpmbuild/RPMS/{noarch,x86_64}
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \
@@ -99,7 +99,7 @@ deb-kcps: crossbuild-package-kcps
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
 rpm-stage: crossbuild-package-stage
-	mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+	mkdir -p rpmbuild/RPMS/{noarch,x86_64}
 	MACKEREL_AGENT_NAME=mackerel-agent-stage _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \

--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,12 @@ crossbuild-package-stage:
 rpm: crossbuild-package
 	mkdir -p rpmbuild
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
-	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c6 \
+	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \
 	--define "_version ${CURRENT_VERSION}" --define "buildarch noarch" \
 	-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
-	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c6 \
+	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-amd64" \
 	--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 	-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
@@ -84,12 +84,12 @@ deb: crossbuild-package
 rpm-kcps: crossbuild-package-kcps
 	mkdir -p rpmbuild
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps _tools/packaging/prepare-rpm-build.sh
-	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c6 \
+	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \
 	--define "_version ${CURRENT_VERSION}" --define "buildarch noarch" \
 	-bb packaging/rpm-build/mackerel-agent-kcps.spec
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps _tools/packaging/prepare-rpm-build.sh
-	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c6 \
+	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-amd64" \
 	--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 	-bb packaging/rpm-build/mackerel-agent-kcps.spec
@@ -101,7 +101,7 @@ deb-kcps: crossbuild-package-kcps
 rpm-stage: crossbuild-package-stage
 	mkdir -p rpmbuild
 	MACKEREL_AGENT_NAME=mackerel-agent-stage _tools/packaging/prepare-rpm-build.sh
-	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c6 \
+	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \
 	--define "_version ${CURRENT_VERSION}" --define "buildarch noarch" \
 	-bb packaging/rpm-build/mackerel-agent-stage.spec

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ crossbuild-package-stage:
 	mv build/mackerel-agent-stage build-linux-386/
 
 rpm: crossbuild-package
-	mkdir -p rpmbuild
+	mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \
@@ -82,7 +82,7 @@ deb: crossbuild-package
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
 rpm-kcps: crossbuild-package-kcps
-	mkdir -p rpmbuild
+	mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \
@@ -99,7 +99,7 @@ deb-kcps: crossbuild-package-kcps
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
 rpm-stage: crossbuild-package-stage
-	mkdir -p rpmbuild
+	mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 	MACKEREL_AGENT_NAME=mackerel-agent-stage _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \


### PR DESCRIPTION
ref: #330 

Sadly CentOS 5 cannot install RPMs built on CentOS 6.
Since CentOS 6/7 can install RPMs built on CentOS 5, we build RPMs on CentOS 5 docker image.