### PR TITLE
fix comment of supervisor

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -32,7 +32,7 @@ type supervisor struct {
 
 // Supervise starts a child mackerel-agent process and supervises it.
 // 'c' can be nil and it's typically nil. When you pass signal channel to this
-// method, you have to close the channel to stop internal goroutine.
+// method, the channel will be closed internally.
 func Supervise(agentProg string, argv []string, c chan os.Signal) error {
 	return (&supervisor{
 		prog: agentProg,


### PR DESCRIPTION
The comment meant following code

	if c == nil {
		c = make(chan os.Signal, 1)
		defer close(c)
	}

but it actually looks like this

	if c == nil {
		c = make(chan os.Signal, 1)
	}
	defer close(c)

I think both are fine but comment should be true.

ref: https://github.com/mackerelio/mackerel-agent/pull/327#discussion_r102206365