### PR TITLE
Keep environment variables when Agent runs commands with sudo

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -29,7 +29,7 @@ func RunCommand(command, user string) (stdout, stderr string, exitCode int, err 
 func RunCommandArgs(cmdArgs []string, user string) (stdout, stderr string, exitCode int, err error) {
 	args := append([]string{}, cmdArgs...)
 	if user != "" {
-		args = append([]string{"sudo", "-u", user}, args...)
+		args = append([]string{"sudo", "-Eu", user}, args...)
 	}
 	cmd := exec.Command(args[0], args[1:]...)
 	tio := &timeout.Timeout{


### PR DESCRIPTION
Especially when executing plugins with `user = ` option, currently some environment variables set by agent are dropped.
- `init_unix.go` does `setenv`
- `MACKEREL_AGENT_PLUGIN_META=1` on getting graph definitions

`sudo`ing with `-E` maybe solve those problem.
```
     -E, --preserve-env
                 Indicates to the security policy that the user wishes to preserve their existing environment variables.  The security policy may return an error if the user does not have permission
                 to preserve the environment.
```