### PR TITLE
Release systemd RPMs to github releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
 - make crossbuild
 after_script:
 - goveralls -coverprofile=.profile.cov
+- docker pull astj/mackerel-rpm-builder:c5
 - docker pull astj/mackerel-rpm-builder:c7
 - make rpm rpm-kcps rpm-stage
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ script:
 - make crossbuild
 after_script:
 - goveralls -coverprofile=.profile.cov
+- docker pull astj/mackerel-rpm-builder:c7
+- make rpm rpm-kcps rpm-stage
 before_deploy:
 - docker pull astj/mackerel-rpm-builder:c5
 - docker pull astj/mackerel-rpm-builder:c7

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ script:
 - make crossbuild
 after_script:
 - goveralls -coverprofile=.profile.cov
-- docker pull astj/mackerel-rpm-builder:c7
-- make rpm rpm-kcps rpm-stage
 before_deploy:
 - docker pull astj/mackerel-rpm-builder:c5
 - docker pull astj/mackerel-rpm-builder:c7

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
 - make crossbuild
 after_script:
 - goveralls -coverprofile=.profile.cov
-- docker pull astj/mackerel-rpm-builder:c5
 - docker pull astj/mackerel-rpm-builder:c7
 - make rpm rpm-kcps rpm-stage
 before_deploy:

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,10 @@ crossbuild-package-kcps:
 	make crossbuild-package MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16
 
 crossbuild-package-stage:
-	mkdir -p ./build-linux-386
-	GOOS=linux GOARCH=386 make build MACKEREL_AGENT_NAME=mackerel-agent-stage MACKEREL_API_BASE=http://0.0.0.0
-	mv build/mackerel-agent-stage build-linux-386/
+	make crossbuild-package MACKEREL_AGENT_NAME=mackerel-agent-stage MACKEREL_API_BASE=http://0.0.0.0
 
-rpm: crossbuild-package
+rpm: rpm-v1 rpm-v2
+rpm-v1: crossbuild-package
 	mkdir -p rpmbuild/RPMS/{noarch,x86_64}
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
@@ -77,8 +76,7 @@ rpm: crossbuild-package
 	--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 	-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
 
-# TODO migrate to rpm
-rpm-systemd: crossbuild-package
+rpm-v2: crossbuild-package
 	BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c7 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-amd64" \
@@ -89,7 +87,8 @@ deb: crossbuild-package
 	BUILD_DIRECTORY=build-linux-386 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
-rpm-kcps: crossbuild-package-kcps
+rpm-kcps: rpm-kcps-v1 rpm-kcps-v2
+rpm-kcps-v1: crossbuild-package-kcps
 	mkdir -p rpmbuild/RPMS/{noarch,x86_64}
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
@@ -102,16 +101,31 @@ rpm-kcps: crossbuild-package-kcps
 	--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 	-bb packaging/rpm-build/mackerel-agent-kcps.spec
 
+rpm-kcps-v2: crossbuild-package-kcps
+	BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=mackerel-agent-kcps _tools/packaging/prepare-rpm-build.sh
+	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c7 \
+	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-amd64" \
+	--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
+	-bb packaging/rpm-build/mackerel-agent-kcps.spec
+
 deb-kcps: crossbuild-package-kcps
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps BUILD_DIRECTORY=build-linux-386 _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
 
-rpm-stage: crossbuild-package-stage
+rpm-stage: rpm-stage-v1 rpm-stage-v2
+rpm-stage-v1: crossbuild-package-stage
 	mkdir -p rpmbuild/RPMS/{noarch,x86_64}
 	MACKEREL_AGENT_NAME=mackerel-agent-stage _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \
 	--define "_version ${CURRENT_VERSION}" --define "buildarch noarch" \
+	-bb packaging/rpm-build/mackerel-agent-stage.spec
+
+rpm-stage-v2: crossbuild-package-stage
+	BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=mackerel-agent-stage _tools/packaging/prepare-rpm-build.sh
+	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c7 \
+	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-amd64" \
+	--define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" \
 	-bb packaging/rpm-build/mackerel-agent-stage.spec
 
 deb-stage: crossbuild-package-stage
@@ -141,4 +155,4 @@ clean:
 
 generate: commands_gen.go
 
-.PHONY: test build run deps clean lint crossbuild cover rpm deb tgz generate crossbuild-package crossbuild-package-kcps crossbuild-package-stage rpm-systemd
+.PHONY: test build run deps clean lint crossbuild cover rpm deb tgz generate crossbuild-package crossbuild-package-kcps crossbuild-package-stage rpm-v1 rpm-v2 rpm-stage rpm-stage-v1 rpm-stage-v2 rpm-kcps-v1 rpm-kcps-v2

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ crossbuild-package-stage:
 
 rpm: rpm-v1 rpm-v2
 rpm-v1: crossbuild-package
-	mkdir -p rpmbuild/RPMS/{noarch,x86_64}
 	MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \
@@ -89,7 +88,6 @@ deb: crossbuild-package
 
 rpm-kcps: rpm-kcps-v1 rpm-kcps-v2
 rpm-kcps-v1: crossbuild-package-kcps
-	mkdir -p rpmbuild/RPMS/{noarch,x86_64}
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \
@@ -114,7 +112,6 @@ deb-kcps: crossbuild-package-kcps
 
 rpm-stage: rpm-stage-v1 rpm-stage-v2
 rpm-stage-v1: crossbuild-package-stage
-	mkdir -p rpmbuild/RPMS/{noarch,x86_64}
 	MACKEREL_AGENT_NAME=mackerel-agent-stage _tools/packaging/prepare-rpm-build.sh
 	docker run --rm -v "$(PWD)":/workspace -v "$(PWD)/rpmbuild":/rpmbuild astj/mackerel-rpm-builder:c5 \
 	--define "_sourcedir /workspace/packaging/rpm-build/src" --define "_builddir /workspace/build-linux-386" \

--- a/_tools/packaging/prepare-rpm-build.sh
+++ b/_tools/packaging/prepare-rpm-build.sh
@@ -14,6 +14,8 @@ fi
 orig_dir="packaging/rpm"
 build_dir="packaging/rpm-build"
 
+mkdir -p rpmbuild/RPMS/{noarch,x86_64}
+
 rm -rf "$build_dir"
 mkdir -p "$build_dir"
 cp -r "$orig_dir/src" "$build_dir/src"

--- a/_tools/releng
+++ b/_tools/releng
@@ -186,7 +186,7 @@ sub spew {
 sub replace {
     my ($file, $code) = @_;
     if(!-f $file){ errorf "File does not exist: %s\n", $file; }
-    my $content = $code->(slurp($file));
+    my $content = $code->(slurp($file), $file);
     spew($file, $content);
 }
 
@@ -333,31 +333,28 @@ sub update_changelog {
         }
     };
 
-    my $generate_rpm_changelog_replacer = sub {
-        my $spec = shift;
-        return sub {
-            my $content = shift;
+    my $rpm_changelog_replacer = sub {
+        my ($content, $filename) = @_;
 
-            my $update = sprintf "* %s <%s> - %s-1\n", $now->strftime('%a %b %d %Y'), $email, $next_version;
-            for my $rel (@releases) {
-                $update .= sprintf "- %s (by %s)\n", $rel->{title}, $rel->{user};
-            }
-            if (index($content, $update) == -1) {
-                infof "update '%s'\n", $spec;
-                $ret = 1;
-                $content =~ s/%changelog/%changelog\n$update/;
-            } else {
-                infof "skip to update '%s'\n", $spec;
-            }
-            $content;
-        };
+        my $update = sprintf "* %s <%s> - %s-1\n", $now->strftime('%a %b %d %Y'), $email, $next_version;
+        for my $rel (@releases) {
+            $update .= sprintf "- %s (by %s)\n", $rel->{title}, $rel->{user};
+        }
+        if (index($content, $update) == -1) {
+            infof "update '%s'\n", $filename;
+            $ret = 1;
+            $content =~ s/%changelog/%changelog\n$update/;
+        } else {
+            infof "skip to update '%s'\n", $filename;
+        }
+        $content;
     };
 
     my $rpm_spec = sprintf "packaging/rpm/%s.spec", $package_name;
-    replace $rpm_spec => $generate_rpm_changelog_replacer->($rpm_spec);
+    replace $rpm_spec => $rpm_changelog_replacer;
 
     my $rpm_systemd_spec = sprintf "packaging/rpm/%s-systemd.spec", $package_name;
-    replace $rpm_systemd_spec => $generate_rpm_changelog_replacer->($rpm_systemd_spec);
+    replace $rpm_systemd_spec => $rpm_changelog_replacer;
 
     replace 'CHANGELOG.md' => sub {
         my $content = shift;

--- a/_tools/releng
+++ b/_tools/releng
@@ -333,8 +333,7 @@ sub update_changelog {
         }
     };
 
-    my $spec = sprintf "packaging/rpm/%s.spec", $package_name;
-    replace $spec => sub {
+    my $rpm_changelog_replacer = sub {
         my $content = shift;
 
         my $update = sprintf "* %s <%s> - %s-1\n", $now->strftime('%a %b %d %Y'), $email, $next_version;
@@ -350,6 +349,12 @@ sub update_changelog {
         }
         $content;
     };
+
+    my $rpm_spec = sprintf "packaging/rpm/%s.spec", $package_name;
+    replace $rpm_spec => $rpm_changelog_replacer;
+
+    my $rpm_systemd_spec = sprintf "packaging/rpm/%s-systemd.spec", $package_name;
+    replace $rpm_systemd_spec => $rpm_changelog_replacer;
 
     replace 'CHANGELOG.md' => sub {
         my $content = shift;

--- a/_tools/releng
+++ b/_tools/releng
@@ -314,7 +314,7 @@ sub update_changelog {
     my $ret = 0;
 
     replace 'packaging/deb/debian/changelog' => sub {
-        my $content = shift;
+        my ($content, $filename) = @_;
 
         my $update = "$package_name ($next_version-1) stable; urgency=low\n\n";
         for my $rel (@releases) {
@@ -324,11 +324,11 @@ sub update_changelog {
 
         # '35' means a rough length to cut timestamp at the end of update.
         if(index($content, substr($update, 0, length($update) - 35)) == -1){
-            infof "update 'packaging/deb/debian/changelog'.\n";
+            infof "update '$filename'.\n";
             $ret = 1;
             $update . $content;
         } else {
-            infof "skip to update 'packaging/deb/debian/changelog'.\n";
+            infof "skip to update '$filename'.\n";
             $content;
         }
     };
@@ -357,18 +357,18 @@ sub update_changelog {
     replace $rpm_systemd_spec => $rpm_changelog_replacer;
 
     replace 'CHANGELOG.md' => sub {
-        my $content = shift;
+        my ($content, $filename) = @_;
 
         my $update = sprintf "\n\n## %s (%s)\n\n", $next_version, $now->strftime('%Y-%m-%d');
         for my $rel (@releases) {
             $update .= sprintf "* %s #%d (%s)\n", $rel->{title}, $rel->{num}, $rel->{user};
         }
         if(index($content, $update) == -1){
-            infof "update 'CHANGELOG.md'\n";
+            infof "update '$filename'\n";
             $ret = 1;
             $content =~ s/\A# Changelog/# Changelog$update/;
         } else {
-            infof "skip to update 'CHANGELOG.md'\n";
+            infof "skip to update '$filename'\n";
         }
         $content;
     };

--- a/_tools/releng
+++ b/_tools/releng
@@ -333,28 +333,31 @@ sub update_changelog {
         }
     };
 
-    my $rpm_changelog_replacer = sub {
-        my $content = shift;
+    my $generate_rpm_changelog_replacer = sub {
+        my $spec = shift;
+        return sub {
+            my $content = shift;
 
-        my $update = sprintf "* %s <%s> - %s-1\n", $now->strftime('%a %b %d %Y'), $email, $next_version;
-        for my $rel (@releases) {
-            $update .= sprintf "- %s (by %s)\n", $rel->{title}, $rel->{user};
-        }
-        if(index($content, $update) == -1){
-            infof "update '%s'\n", $spec;
-            $ret = 1;
-            $content =~ s/%changelog/%changelog\n$update/;
-        } else {
-            infof "skip to update '%s'\n", $spec;
-        }
-        $content;
+            my $update = sprintf "* %s <%s> - %s-1\n", $now->strftime('%a %b %d %Y'), $email, $next_version;
+            for my $rel (@releases) {
+                $update .= sprintf "- %s (by %s)\n", $rel->{title}, $rel->{user};
+            }
+            if (index($content, $update) == -1) {
+                infof "update '%s'\n", $spec;
+                $ret = 1;
+                $content =~ s/%changelog/%changelog\n$update/;
+            } else {
+                infof "skip to update '%s'\n", $spec;
+            }
+            $content;
+        };
     };
 
     my $rpm_spec = sprintf "packaging/rpm/%s.spec", $package_name;
-    replace $rpm_spec => $rpm_changelog_replacer;
+    replace $rpm_spec => $generate_rpm_changelog_replacer->($rpm_spec);
 
     my $rpm_systemd_spec = sprintf "packaging/rpm/%s-systemd.spec", $package_name;
-    replace $rpm_systemd_spec => $rpm_changelog_replacer;
+    replace $rpm_systemd_spec => $generate_rpm_changelog_replacer->($rpm_systemd_spec);
 
     replace 'CHANGELOG.md' => sub {
         my $content = shift;
@@ -546,6 +549,10 @@ sub main {
     } elsif($task && $task eq "upload-to-github-release"){
         infof "Upload files to GitHub Release.\n";
         upload_to_github_release();
+        return;
+    } elsif($task && $task eq "update-changelog"){
+        infof "Updating changelog.\n";
+        update_changelog(next_version);
         return;
     } elsif($task && $task eq "upload-master-to-github-release"){
         infof "Upload files on master branch to GitHub Release.\n";


### PR DESCRIPTION
- Make `make rpm{,-stage,-kcps}` to build systemd RPMs too
- Update changelog in systemd RPM in release process (same as original RPM)
- Some refactor

# Discussion

Currently mackerel-agent-systemd.spec has no changelogs before 0.40.1.  Should we add them?