### PR TITLE
Fix disk metrics on Windows

### DIFF
--- a/metrics/windows/disk.go
+++ b/metrics/windows/disk.go
@@ -23,7 +23,7 @@ func NewDiskGenerator(interval time.Duration) (*DiskGenerator, error) {
 	return &DiskGenerator{interval}, nil
 }
 
-type Win32_PerfFormattedData struct {
+type win32PerfFormattedData struct {
 	Name                 string
 	DiskReadBytesPersec  uint64
 	DiskWriteBytesPersec uint64
@@ -33,7 +33,7 @@ type Win32_PerfFormattedData struct {
 func (g *DiskGenerator) Generate() (metrics.Values, error) {
 	time.Sleep(g.Interval)
 
-	var records []Win32_PerfFormattedData
+	var records []win32PerfFormattedData
 	err := wmi.Query("SELECT * FROM Win32_PerfFormattedData_PerfDisk_LogicalDisk ", &records)
 	if err != nil {
 		return nil, err

--- a/metrics/windows/disk.go
+++ b/metrics/windows/disk.go
@@ -4,110 +4,52 @@ package windows
 
 import (
 	"fmt"
-	"syscall"
 	"time"
-	"unsafe"
 
+	"github.com/StackExchange/wmi"
 	"github.com/mackerelio/mackerel-agent/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
-	"github.com/mackerelio/mackerel-agent/util/windows"
 )
 
 // DiskGenerator XXX
 type DiskGenerator struct {
 	Interval time.Duration
-	query    syscall.Handle
-	counters []*windows.CounterInfo
 }
 
 var diskLogger = logging.GetLogger("metrics.disk")
 
 // NewDiskGenerator XXX
 func NewDiskGenerator(interval time.Duration) (*DiskGenerator, error) {
-	g := &DiskGenerator{interval, 0, nil}
+	return &DiskGenerator{interval}, nil
+}
 
-	var err error
-	g.query, err = windows.CreateQuery()
-	if err != nil {
-		diskLogger.Criticalf(err.Error())
-		return nil, err
-	}
-
-	drivebuf := make([]byte, 256)
-	r, _, err := windows.GetLogicalDriveStrings.Call(
-		uintptr(len(drivebuf)),
-		uintptr(unsafe.Pointer(&drivebuf[0])))
-
-	if r == 0 {
-		diskLogger.Criticalf(err.Error())
-		return nil, err
-	}
-
-	for _, v := range drivebuf {
-		if v >= 65 && v <= 90 {
-			drive := string(v)
-			r, _, err = windows.GetDriveType.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(drive + `:\`))))
-			if r != windows.DRIVE_FIXED {
-				continue
-			}
-			var counter *windows.CounterInfo
-
-			counter, err = windows.CreateCounter(
-				g.query,
-				fmt.Sprintf(`disk.%s.reads.delta`, drive),
-				fmt.Sprintf(`\PhysicalDisk(0 %s:)\Disk Reads/sec`, drive))
-			if err != nil {
-				diskLogger.Criticalf(err.Error())
-				return nil, err
-			}
-			g.counters = append(g.counters, counter)
-
-			counter, err = windows.CreateCounter(
-				g.query,
-				fmt.Sprintf(`disk.%s.writes.delta`, drive),
-				fmt.Sprintf(`\PhysicalDisk(0 %s:)\Disk Writes/sec`, drive))
-			if err != nil {
-				diskLogger.Criticalf(err.Error())
-				return nil, err
-			}
-			g.counters = append(g.counters, counter)
-		}
-	}
-
-	r, _, err = windows.PdhCollectQueryData.Call(uintptr(g.query))
-	if r != 0 && err != nil {
-		if r == windows.PDH_NO_DATA {
-			diskLogger.Infof("this metric has not data. ")
-			return nil, err
-		}
-		diskLogger.Criticalf(err.Error())
-		return nil, err
-	}
-
-	return g, nil
+type Win32_PerfFormattedData struct {
+	Name                 string
+	DiskReadBytesPersec  uint64
+	DiskWriteBytesPersec uint64
 }
 
 // Generate XXX
 func (g *DiskGenerator) Generate() (metrics.Values, error) {
 	time.Sleep(g.Interval)
 
-	r, _, err := windows.PdhCollectQueryData.Call(uintptr(g.query))
-	if r != 0 && err != nil {
-		if r == windows.PDH_NO_DATA {
-			diskLogger.Infof("this metric has not data. ")
-			return nil, err
-		}
+	var records []Win32_PerfFormattedData
+	err := wmi.Query("SELECT * FROM Win32_PerfFormattedData_PerfDisk_LogicalDisk ", &records)
+	if err != nil {
 		return nil, err
 	}
 
 	results := make(map[string]float64)
-	for _, v := range g.counters {
-		results[v.PostName], err = windows.GetCounterValue(v.Counter)
-		if err != nil {
-			return nil, err
+	for _, record := range records {
+		name := record.Name
+		// Collect metrics for only drives
+		if len(name) != 2 || name[1] != ':' {
+			continue
 		}
+		name = name[:1]
+		results[fmt.Sprintf(`disk.%s.reads.delta`, name)] = float64(record.DiskReadBytesPersec)
+		results[fmt.Sprintf(`disk.%s.writes.delta`, name)] = float64(record.DiskWriteBytesPersec)
 	}
-
 	diskLogger.Debugf("%q", results)
 	return results, nil
 }


### PR DESCRIPTION
Performance Counder doesn't provide counter for collecting IOPS per disks.
This change collect metrics using WMI.