### PR TITLE
Release version 0.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.40.1 (2017-03-07)
+
+* [EXPERIMENTAL] systemd support for CentOS 7 #317 (astj)
+* add `supervise` subcommand (supervisor mode) #327 (Songmu)
+* Build RPM packages with Docker #330 (astj)
+* run test with -race in CI #339 (haya14busa)
+* Use hw.physmem64 instead of hw.physmem in NetBSD #343 (astj)
+* Build RPM files on CentOS5 on Docker #344 (astj)
+* Keep environment variables when Agent runs commands with sudo #346 (astj)
+* Release systemd RPMs to github releases #347 (astj)
+* Fix disk metrics on Windows #348 (mattn)
+
+
 ## 0.40.0 (2017-02-22)
 
 * support metadata plugins in configuration #331 (itchyny)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,26 @@
+mackerel-agent (0.40.1-1) stable; urgency=low
+
+  * [EXPERIMENTAL] systemd support for CentOS 7 (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/317>
+  * add `supervise` subcommand (supervisor mode) (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/327>
+  * Build RPM packages with Docker (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/330>
+  * run test with -race in CI (by haya14busa)
+    <https://github.com/mackerelio/mackerel-agent/pull/339>
+  * Use hw.physmem64 instead of hw.physmem in NetBSD (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/343>
+  * Build RPM files on CentOS5 on Docker (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/344>
+  * Keep environment variables when Agent runs commands with sudo (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/346>
+  * Release systemd RPMs to github releases (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/347>
+  * Fix disk metrics on Windows (by mattn)
+    <https://github.com/mackerelio/mackerel-agent/pull/348>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 07 Mar 2017 04:10:01 +0000
+
 mackerel-agent (0.40.0-1) stable; urgency=low
 
   * support metadata plugins in configuration (by itchyny)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,3 +55,14 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Tue Mar 07 2017 <mackerel-developers@hatena.ne.jp> - 0.40.1-1
+- [EXPERIMENTAL] systemd support for CentOS 7 (by astj)
+- add `supervise` subcommand (supervisor mode) (by Songmu)
+- Build RPM packages with Docker (by astj)
+- run test with -race in CI (by haya14busa)
+- Use hw.physmem64 instead of hw.physmem in NetBSD (by astj)
+- Build RPM files on CentOS5 on Docker (by astj)
+- Keep environment variables when Agent runs commands with sudo (by astj)
+- Release systemd RPMs to github releases (by astj)
+- Fix disk metrics on Windows (by mattn)
+

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,17 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Tue Mar 07 2017 <mackerel-developers@hatena.ne.jp> - 0.40.1-1
+- [EXPERIMENTAL] systemd support for CentOS 7 (by astj)
+- add `supervise` subcommand (supervisor mode) (by Songmu)
+- Build RPM packages with Docker (by astj)
+- run test with -race in CI (by haya14busa)
+- Use hw.physmem64 instead of hw.physmem in NetBSD (by astj)
+- Build RPM files on CentOS5 on Docker (by astj)
+- Keep environment variables when Agent runs commands with sudo (by astj)
+- Release systemd RPMs to github releases (by astj)
+- Fix disk metrics on Windows (by mattn)
+
 * Wed Feb 22 2017 <mackerel-developers@hatena.ne.jp> - 0.40.0-1
 - support metadata plugins in configuration (by itchyny)
 - Add metadata plugin feature (by itchyny)


### PR DESCRIPTION
- [EXPERIMENTAL] systemd support for CentOS 7 #317
- add `supervise` subcommand (supervisor mode) #327
- Build RPM packages with Docker #330
- run test with -race in CI #339
- Use hw.physmem64 instead of hw.physmem in NetBSD #343
- Build RPM files on CentOS5 on Docker #344
- Keep environment variables when Agent runs commands with sudo #346
- Release systemd RPMs to github releases #347
- Fix disk metrics on Windows #348