### PR TITLE
Exclude _tools from package

### DIFF
--- a/.goxc.json
+++ b/.goxc.json
@@ -3,6 +3,6 @@
     "TasksExclude": [
         "go-test"
     ],
-    "MainDirsExclude": "wix,checks/testdata,metadata/testdata,supervisor/testdata",
+    "MainDirsExclude": "_tools,wix,checks/testdata,metadata/testdata,supervisor/testdata",
     "ResourcesInclude": "README*,mackerel-agent.conf"
 }


### PR DESCRIPTION
Currently the packages include `_tools` file. The file looks like an executable of `gen_commands.go` and is unintentionally included in the packages. This pull request fixes the problem.