### PR TITLE
Add workaround for docker0 interface in docker-enabled Travis

### DIFF
--- a/spec/linux/interface_test.go
+++ b/spec/linux/interface_test.go
@@ -32,6 +32,11 @@ func TestInterfaceGenerate(t *testing.T) {
 	}
 
 	iface := value[0]
+	// In Docker enabled Travis environment, there's "docker0" interface
+	// which does not have defaultGateway..
+	if iface.Name == "docker0" && os.Getenv("TRAVIS") != "" {
+		iface = value[1]
+	}
 	if len(iface.IPv4Addresses) <= 0 {
 		t.Error("interface should have ipv4Addresses")
 	}


### PR DESCRIPTION
This patch fixes occasional ci failure due to try to get `iface.defaultGateway` on `docker0` interface, which does not have default gateway.
ref: https://travis-ci.org/mackerelio/mackerel-agent/builds/213299895