### PR TITLE
sh -c "exec ..."

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -21,7 +21,7 @@ var TimeoutKillAfter = 10 * time.Second
 
 // RunCommand runs command (in two string) and returns stdout, stderr strings and its exit code.
 func RunCommand(command, user string) (stdout, stderr string, exitCode int, err error) {
-	cmdArgs := []string{"/bin/sh", "-c", command}
+	cmdArgs := []string{"/bin/sh", "-c", fmt.Sprintf("exec %s", command)}
 	return RunCommandArgs(cmdArgs, user)
 }
 


### PR DESCRIPTION
If we don't use `exec` when calling external command, the plugin command is called as a child process of `sh -c`, so there is a possibility that an orphan process will occur at timeout.