### PR TITLE
It need to read output from command continuously.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 language: go
 go:
-- 1.7
+- 1.8
 env:
   global:
   - PATH=/home/travis/gopath/bin:$PATH DEBIAN_FRONTEND=noninteractive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ install:
   - echo %Path%
   - choco install -y ruby
   - rd c:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.7.windows-386.zip
-  - 7z x go1.7.windows-386.zip -oC:\ >nul
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.8.windows-386.zip
+  - 7z x go1.8.windows-386.zip -oC:\ >nul
   - go version
   - go env
   - set CERT= & set CERTPASS= & set

--- a/wix/wrapper/wrapper_test.go
+++ b/wix/wrapper/wrapper_test.go
@@ -1,3 +1,5 @@
+// +build: windows
+
 package main
 
 import (

--- a/wix/wrapper/wrapper_test.go
+++ b/wix/wrapper/wrapper_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type item struct {
+	eid uint32
+	msg string
+}
+
+type testLogger struct {
+	info []item
+	warn []item
+	err  []item
+}
+
+func (l *testLogger) Info(eid uint32, msg string) error {
+	l.info = append(l.info, item{eid, msg})
+	return nil
+}
+
+func (l *testLogger) Warning(eid uint32, msg string) error {
+	l.warn = append(l.warn, item{eid, msg})
+	return nil
+}
+
+func (l *testLogger) Error(eid uint32, msg string) error {
+	l.err = append(l.err, item{eid, msg})
+	return nil
+}
+
+type testWriteCloser struct {
+}
+
+func (wc *testWriteCloser) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (wc *testWriteCloser) Close() error {
+	return nil
+}
+
+type testReader struct {
+	token []string
+	sr    *strings.Reader
+}
+
+func (tr *testReader) Read(b []byte) (int, error) {
+	if len(tr.token) == 0 {
+		return 0, io.EOF
+	}
+	total := len(b)
+	rest := total
+	for {
+		if tr.sr == nil || tr.sr.Len() == 0 {
+			if len(tr.token) == 0 {
+				return total - rest, nil
+			}
+			if len(tr.token[0]) == 0 {
+				time.Sleep(20 * time.Millisecond)
+				tr.token = tr.token[1:]
+			}
+			tr.sr = strings.NewReader(tr.token[0])
+			tr.token = tr.token[1:]
+		}
+		n, err := tr.sr.Read(b)
+		rest -= n
+		if err == nil && rest == 0 {
+			return total, err
+		}
+		b = b[n:]
+	}
+}
+
+func TestAggregate(t *testing.T) {
+	tests := []struct {
+		input []string
+		info  []item
+		warn  []item
+		err   []item
+	}{
+		{
+			input: []string{
+				"2017/01/02 03:04:05 foo.go:1: INFO foo",
+			},
+			info: []item{{1, "2017/01/02 03:04:05 foo.go:1: INFO foo"}},
+		},
+		{
+			input: []string{
+				strings.Repeat("=", 4097) + "\n2017/01/02 03:04:05 foo",
+				".go:1: INFO foo",
+			},
+			info: []item{{1, "2017/01/02 03:04:05 foo.go:1: INFO foo"}},
+		},
+	}
+
+	for _, test := range tests {
+		tl := &testLogger{}
+
+		h := &handler{
+			elog: tl,
+			w:    &testWriteCloser{},
+			r:    &testReader{test.input, nil},
+		}
+		h.aggregate()
+		h.wg.Wait()
+
+		if !reflect.DeepEqual(tl.info, test.info) {
+			t.Fatalf("info log: want: %v, got: %v", test.info, tl.info)
+		}
+		if !reflect.DeepEqual(tl.warn, test.warn) {
+			t.Fatalf("warn log: want: %v, got: %v", test.warn, tl.warn)
+		}
+		if !reflect.DeepEqual(tl.err, test.err) {
+			t.Fatalf("err log: want: %v, got: %v", test.err, tl.err)
+		}
+	}
+}

--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -117,12 +117,7 @@ func (h *handler) start() error {
 				}
 				continue
 			}
-			// Read size should be 4096 because default size of PIPE is 4096.
-			// We know this is not a limit size. This is workaround to avoid
-			// that plugin stop writing to pipe.
-			if body.Len() < 4096 {
-				body.WriteByte(b)
-			}
+			body.WriteByte(b)
 		}
 		if body.Len() > 0 {
 			lc <- body.String()

--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -90,14 +90,14 @@ func (h *handler) start() error {
 	r, w := io.Pipe()
 	cmd.Stderr = w
 
-	br := bufio.NewReader(r)
-	lc := make(chan string, 10)
-	done := make(chan struct{})
-
 	err := cmd.Start()
 	if err != nil {
 		return err
 	}
+
+	br := bufio.NewReader(r)
+	lc := make(chan string, 10)
+	done := make(chan struct{})
 
 	// It need to read data from pipe continuously. And it need to close handle
 	// when process finished.

--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -152,7 +152,7 @@ func (h *handler) start() error {
 						case "ERROR", "CRITICAL":
 							h.elog.Error(defaultEid, line)
 						default:
-							h.elog.Error(loggerEid, line)
+							h.elog.Error(defaultEid, line)
 						}
 					}
 					linebuf = nil

--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -62,14 +62,14 @@ func main() {
 	}
 }
 
-type Logger interface {
+type logger interface {
 	Info(eid uint32, msg string) error
 	Warning(eid uint32, msg string) error
 	Error(eid uint32, msg string) error
 }
 
 type handler struct {
-	elog Logger
+	elog logger
 	cmd  *exec.Cmd
 	r    io.Reader
 	w    io.WriteCloser
@@ -168,13 +168,17 @@ func (h *handler) aggregate() error {
 						default:
 							h.elog.Error(defaultEid, line)
 						}
+						linebuf = nil
+					} else {
+						linebuf = linebuf[1:]
 					}
-					linebuf = nil
 				}
-				select {
-				case <-done:
-					break loop
-				default:
+				if len(linebuf) == 0 {
+					select {
+					case <-done:
+						break loop
+					default:
+					}
 				}
 			}
 		}

--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -61,8 +61,14 @@ func main() {
 	}
 }
 
+type Logger interface {
+	Info(eid uint32, msg string) error
+	Warning(eid uint32, msg string) error
+	Error(eid uint32, msg string) error
+}
+
 type handler struct {
-	elog *eventlog.Log
+	elog Logger
 	cmd  *exec.Cmd
 }
 

--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -105,7 +105,7 @@ func (h *handler) start() error {
 		for {
 			b, err := br.ReadByte()
 			if err != nil {
-				if err != nil {
+				if err != io.EOF {
 					h.elog.Error(loggerEid, err.Error())
 				}
 				break

--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -79,7 +79,7 @@ type handler struct {
 // ex.
 // verbose log: 2017/01/21 22:21:08 command.go:434: DEBUG <command> received 'immediate' chan
 // normal log:  2017/01/24 14:14:27 INFO <main> Starting mackerel-agent version:0.36.0
-var logRe = regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} (?:.+\.go:\d+: )?([A-Z]+) `)
+var logRe = regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} (?:\S+\.go:\d+: )?([A-Z]+) `)
 
 func (h *handler) start() error {
 	procAllocConsole.Call()

--- a/wix/wrapper/wrapper_windows_test.go
+++ b/wix/wrapper/wrapper_windows_test.go
@@ -1,5 +1,3 @@
-// +build: windows
-
 package main
 
 import (


### PR DESCRIPTION
Fixes to read output from command continuously because plugin may hang when agent doesn't read. For example, reading too long lines using scanner.Scan() .