### PR TITLE
Logs that are not via the mackerel-agent's logger are also output to the eventlog

### DIFF
--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -170,6 +170,8 @@ func (h *handler) aggregate() error {
 						default:
 							h.elog.Error(defaultEid, line)
 						}
+					} else {
+						h.elog.Error(defaultEid, line)
 					}
 				}
 				select {

--- a/wix/wrapper/wrapper_windows_test.go
+++ b/wix/wrapper/wrapper_windows_test.go
@@ -85,6 +85,7 @@ func TestAggregate(t *testing.T) {
 				".go:1: INFO foo",
 			},
 			info: []item{{1, "2017/01/02 03:04:05 foo.go:1: INFO foo"}},
+			err:  []item{{1, strings.Repeat("=", 4097)}},
 		},
 		{
 			name: "concated log",

--- a/wix/wrapper/wrapper_windows_test.go
+++ b/wix/wrapper/wrapper_windows_test.go
@@ -125,7 +125,10 @@ func TestAggregate(t *testing.T) {
 			},
 			info: []item{{1, "2017/01/02 03:04:05 foo.go:1: INFO foo"}},
 			warn: []item{{1, "2017/01/02 03:04:05 foo.go:1: WARNING foo"}},
-			err:  []item{{1, "2017/01/02 03:04:05 foo.go:1: ERROR foo"}},
+			err: []item{
+				{1, strings.Repeat("=", 4097)},
+				{1, "2017/01/02 03:04:05 foo.go:1: ERROR foo"},
+			},
 		},
 	}
 


### PR DESCRIPTION
behavior is changed at https://github.com/mackerelio/mackerel-agent/pull/364, so fixed.