### PR TITLE
Change package License to Apache 2.0

### DIFF
--- a/packaging/deb-systemd/debian/copyright
+++ b/packaging/deb-systemd/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    y_uuki <y_uuki@hatena.ne.jp> on Tue, 11 Mar 2014 11:27:51 +0900
+    astj <astj@hatena.ne.jp> on Tue, 28 Mar 2017 11:09:51 +0900
 
 It was downloaded from:
 
@@ -8,12 +8,12 @@ It was downloaded from:
 
 Copyright:
 
-    <Copyright (C) 2014 Hatena>
+    <Copyright (C) 2017 Hatena Co., Ltd.>
 
 License:
 
-    Commercial
+    Apache-2.0
 
 The Debian packaging is:
 
-    Copyright (C) 2014 Hatena <developers@mackerel.io>
+    Copyright (C) 2017 Hatena Co., Ltd. <developers@mackerel.io>

--- a/packaging/deb-systemd/debian/copyright
+++ b/packaging/deb-systemd/debian/copyright
@@ -8,7 +8,7 @@ It was downloaded from:
 
 Copyright:
 
-    <Copyright (C) 2017 Hatena Co., Ltd.>
+    <Copyright (C) 2014 Hatena Co., Ltd.>
 
 License:
 
@@ -16,4 +16,4 @@ License:
 
 The Debian packaging is:
 
-    Copyright (C) 2017 Hatena Co., Ltd. <developers@mackerel.io>
+    Copyright (C) 2014 Hatena Co., Ltd. <developers@mackerel.io>

--- a/packaging/deb/debian/copyright
+++ b/packaging/deb/debian/copyright
@@ -8,12 +8,12 @@ It was downloaded from:
 
 Copyright:
 
-    <Copyright (C) 2014 Hatena>
+    <Copyright (C) 2014 Hatena Co., Ltd.>
 
 License:
 
-    Commercial
+    Apache-2.0
 
 The Debian packaging is:
 
-    Copyright (C) 2014 Hatena <developers@mackerel.io>
+    Copyright (C) 2014 Hatena Co., Ltd. <developers@mackerel.io>

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -6,14 +6,14 @@
 Name:      mackerel-agent
 Version:   %{_version}
 Release:   1%{?dist}
-License:   Commercial
+License:   ASL 2.0
 Summary:   mackerel.io agent
 URL:       https://mackerel.io
-Group:     Hatena
+Group:     Hatena Co., Ltd.
 Source0:   %{name}.sysconfig
 Source1:   %{name}.conf
 Source2:   %{name}.service
-Packager:  Hatena
+Packager:  Hatena Co., Ltd.
 BuildArch: %{buildarch}
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -6,15 +6,15 @@
 Name:      mackerel-agent
 Version:   %{_version}
 Release:   1
-License:   Commercial
+License:   ASL 2.0
 Summary:   mackerel.io agent
 URL:       https://mackerel.io
-Group:     Hatena
+Group:     Hatena Co., Ltd.
 Source0:   %{name}.initd
 Source1:   %{name}.sysconfig
 Source2:   %{name}.logrotate
 Source3:   %{name}.conf
-Packager:  Hatena
+Packager:  Hatena Co., Ltd.
 BuildArch: %{buildarch}
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 Requires(post): /sbin/chkconfig


### PR DESCRIPTION
Discussed on #360.
https://github.com/mackerelio/mackerel-agent/pull/360#discussion_r107351282
https://github.com/mackerelio/mackerel-agent/pull/360#discussion_r107351307

Since mackerel-agent itself is published under Apache License 2.0 and we don't add copyrighted stuff to package releases, we can release the packages under Apache License 2.0 too.
Currently they're released under Commercial License, but it's maybe because at first we don't publish mackerel-agent's source codes.

And also I updated copyright terms in the packages. We, Hatena should be referred as `Hatena Co., Ltd`.