### PR TITLE
Change systemd deb package architecture to amd64

### DIFF
--- a/packaging/deb-systemd/debian/control
+++ b/packaging/deb-systemd/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/mackerelio/mackerel-agent.git
 Homepage: https://mackerel.io
 
 Package: mackerel-agent
-Architecture: all
+Architecture: amd64
 Depends: ${misc:Depends}, systemd
 Description: mackerel.io agent
  Server monitoring agent for https://mackerel.io (Monitoring SaaS)


### PR DESCRIPTION
Currently systemd deb package released as `all` architecture, but it includes amd64 binary.
I'd like to change package architecture to amd64 so that package architecture will be the same as including binary.