### PR TITLE
[nit] Add pointer for full license text to debian package license information

### DIFF
--- a/packaging/deb-systemd/debian/copyright
+++ b/packaging/deb-systemd/debian/copyright
@@ -13,6 +13,7 @@ Copyright:
 License:
 
     Apache-2.0
+    To obtain full license text, see /usr/share/common-licenses/Apache-2.0
 
 The Debian packaging is:
 

--- a/packaging/deb/debian/copyright
+++ b/packaging/deb/debian/copyright
@@ -13,6 +13,7 @@ Copyright:
 License:
 
     Apache-2.0
+    To obtain full license text, see /usr/share/common-licenses/Apache-2.0
 
 The Debian packaging is:
 


### PR DESCRIPTION
related: #368 
This will reduce lintian errors on building deb packages: `E: mackerel-agent: copyright-should-refer-to-common-license-file-for-apache-2`.
In fact there're still many errors and warnings, but reducing error is better than doing nothing...

Ref: https://lintian.debian.org/tags/copyright-should-refer-to-common-license-file-for-apache-2.html