### PR TITLE
Output error logs of mackerel-agent as warning log of windows event log

### DIFF
--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -163,9 +163,9 @@ func (h *handler) aggregate() error {
 						switch level {
 						case "TRACE", "DEBUG", "INFO":
 							h.elog.Info(defaultEid, line)
-						case "WARNING":
+						case "WARNING", "ERROR":
 							h.elog.Warning(defaultEid, line)
-						case "ERROR", "CRITICAL":
+						case "CRITICAL":
 							h.elog.Error(defaultEid, line)
 						default:
 							h.elog.Error(defaultEid, line)

--- a/wix/wrapper/wrapper_windows_test.go
+++ b/wix/wrapper/wrapper_windows_test.go
@@ -102,32 +102,36 @@ func TestAggregate(t *testing.T) {
 				"2017/01/02 03:04:05 foo.go:1: INFO foo\n",
 				"2017/01/02 03:04:05 foo.go:1: WARNING foo\n",
 				"2017/01/02 03:04:05 foo.go:1: ERROR foo\n",
+				"2017/01/02 03:04:05 foo.go:1: CRITICAL foo\n",
 			},
 			info: []item{{1, "2017/01/02 03:04:05 foo.go:1: INFO foo"}},
-			warn: []item{{1, "2017/01/02 03:04:05 foo.go:1: WARNING foo"}},
-			err:  []item{{1, "2017/01/02 03:04:05 foo.go:1: ERROR foo"}},
+			warn: []item{
+				{1, "2017/01/02 03:04:05 foo.go:1: WARNING foo"},
+				{1, "2017/01/02 03:04:05 foo.go:1: ERROR foo"},
+			},
+			err:  []item{{1, "2017/01/02 03:04:05 foo.go:1: CRITICAL foo"}},
 		},
 		{
 			name: "separated log, and sleep",
 			input: []string{
 				"2017/01/02 03:04:05 foo.go:1: INFO foo\n\n2017/01/02 03:04:05 foo.go:1: WARNING foo\n",
-				"2017/01/02 03:04:05 foo.go:1: ERROR foo\n",
+				"2017/01/02 03:04:05 foo.go:1: CRITICAL foo\n",
 			},
 			info: []item{{1, "2017/01/02 03:04:05 foo.go:1: INFO foo"}},
 			warn: []item{{1, "2017/01/02 03:04:05 foo.go:1: WARNING foo"}},
-			err:  []item{{1, "2017/01/02 03:04:05 foo.go:1: ERROR foo"}},
+			err:  []item{{1, "2017/01/02 03:04:05 foo.go:1: CRITICAL foo"}},
 		},
 		{
 			name: "separated log, and sleep",
 			input: []string{
 				strings.Repeat("=", 4097) + "\n2017/01/02 03:04:05 foo.go:1: INFO foo\n2017/01/02 03:04:05 foo.go:1: ",
-				"WARNING foo\n2017/01/02 03:04:05 foo.go:1: ERROR foo\n",
+				"WARNING foo\n2017/01/02 03:04:05 foo.go:1: CRITICAL foo\n",
 			},
 			info: []item{{1, "2017/01/02 03:04:05 foo.go:1: INFO foo"}},
 			warn: []item{{1, "2017/01/02 03:04:05 foo.go:1: WARNING foo"}},
 			err: []item{
 				{1, strings.Repeat("=", 4097)},
-				{1, "2017/01/02 03:04:05 foo.go:1: ERROR foo"},
+				{1, "2017/01/02 03:04:05 foo.go:1: CRITICAL foo"},
 			},
 		},
 	}

--- a/wix/wrapper/wrapper_windows_test.go
+++ b/wix/wrapper/wrapper_windows_test.go
@@ -109,7 +109,7 @@ func TestAggregate(t *testing.T) {
 				{1, "2017/01/02 03:04:05 foo.go:1: WARNING foo"},
 				{1, "2017/01/02 03:04:05 foo.go:1: ERROR foo"},
 			},
-			err:  []item{{1, "2017/01/02 03:04:05 foo.go:1: CRITICAL foo"}},
+			err: []item{{1, "2017/01/02 03:04:05 foo.go:1: CRITICAL foo"}},
 		},
 		{
 			name: "separated log, and sleep",


### PR DESCRIPTION
Since eventlog is a system-wide log, error logs of mackerel-agent are handled as warning level in the eventlog