### PR TITLE
Add `prevent_alert_auto_close` option for check plugins

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -402,8 +402,8 @@ func runChecker(checker *checks.Checker, checkReportCh chan *checks.Report, repo
 				// Do not report if nothing has changed
 				continue
 			}
-			if report.Status == checks.StatusOK && checker.Config.DisableAutoClose {
-				// Do not report `OK` if `DisableAutoClose`
+			if report.Status == checks.StatusOK && checker.Config.PreventAlertAutoClose {
+				// Do not report `OK` if `PreventAlertAutoClose`
 				lastStatus = report.Status
 				lastMessage = report.Message
 				continue

--- a/command/command.go
+++ b/command/command.go
@@ -402,6 +402,12 @@ func runChecker(checker *checks.Checker, checkReportCh chan *checks.Report, repo
 				// Do not report if nothing has changed
 				continue
 			}
+			if report.Status == checks.StatusOK && checker.Config.DisableAutoClose {
+				// Do not report `OK` if `DisableAutoClose`
+				lastStatus = report.Status
+				lastMessage = report.Message
+				continue
+			}
 			checkReportCh <- report
 
 			// If status has changed, send it immediately

--- a/config/config.go
+++ b/config/config.go
@@ -87,6 +87,7 @@ type PluginConfig struct {
 	ExecutionInterval    *int32  `toml:"execution_interval"`
 	MaxCheckAttempts     *int32  `toml:"max_check_attempts"`
 	CustomIdentifier     *string `toml:"custom_identifier"`
+	DisableAutoClose     *bool   `toml:"disable_auto_close"`
 }
 
 // MetricPlugin represents the configuration of a metric plugin
@@ -136,6 +137,7 @@ type CheckPlugin struct {
 	NotificationInterval *int32
 	CheckInterval        *int32
 	MaxCheckAttempts     *int32
+	DisableAutoClose     bool
 }
 
 func (pconf *PluginConfig) buildCheckPlugin() (*CheckPlugin, error) {
@@ -143,14 +145,20 @@ func (pconf *PluginConfig) buildCheckPlugin() (*CheckPlugin, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &CheckPlugin{
+	plugin := CheckPlugin{
 		Command:              pconf.Command,
 		CommandArgs:          pconf.CommandArgs,
 		User:                 pconf.User,
 		NotificationInterval: pconf.NotificationInterval,
 		CheckInterval:        pconf.CheckInterval,
 		MaxCheckAttempts:     pconf.MaxCheckAttempts,
-	}, nil
+	}
+	if pconf.DisableAutoClose == nil {
+		plugin.DisableAutoClose = false
+	} else {
+		plugin.DisableAutoClose = *pconf.DisableAutoClose
+	}
+	return &plugin, nil
 }
 
 // Run the check plugin.

--- a/config/config.go
+++ b/config/config.go
@@ -87,7 +87,7 @@ type PluginConfig struct {
 	ExecutionInterval    *int32  `toml:"execution_interval"`
 	MaxCheckAttempts     *int32  `toml:"max_check_attempts"`
 	CustomIdentifier     *string `toml:"custom_identifier"`
-	DisableAutoClose     *bool   `toml:"disable_auto_close"`
+	DisableAutoClose     bool   `toml:"disable_auto_close"`
 }
 
 // MetricPlugin represents the configuration of a metric plugin
@@ -152,11 +152,7 @@ func (pconf *PluginConfig) buildCheckPlugin() (*CheckPlugin, error) {
 		NotificationInterval: pconf.NotificationInterval,
 		CheckInterval:        pconf.CheckInterval,
 		MaxCheckAttempts:     pconf.MaxCheckAttempts,
-	}
-	if pconf.DisableAutoClose == nil {
-		plugin.DisableAutoClose = false
-	} else {
-		plugin.DisableAutoClose = *pconf.DisableAutoClose
+		DisableAutoClose:     pconf.DisableAutoClose,
 	}
 	return &plugin, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -78,16 +78,16 @@ type Config struct {
 
 // PluginConfig represents a plugin configuration.
 type PluginConfig struct {
-	CommandRaw           interface{} `toml:"command"`
-	Command              string
-	CommandArgs          []string
-	User                 string
-	NotificationInterval *int32  `toml:"notification_interval"`
-	CheckInterval        *int32  `toml:"check_interval"`
-	ExecutionInterval    *int32  `toml:"execution_interval"`
-	MaxCheckAttempts     *int32  `toml:"max_check_attempts"`
-	CustomIdentifier     *string `toml:"custom_identifier"`
-	DisableAutoClose     bool   `toml:"disable_auto_close"`
+	CommandRaw            interface{} `toml:"command"`
+	Command               string
+	CommandArgs           []string
+	User                  string
+	NotificationInterval  *int32  `toml:"notification_interval"`
+	CheckInterval         *int32  `toml:"check_interval"`
+	ExecutionInterval     *int32  `toml:"execution_interval"`
+	MaxCheckAttempts      *int32  `toml:"max_check_attempts"`
+	CustomIdentifier      *string `toml:"custom_identifier"`
+	PreventAlertAutoClose bool    `toml:"prevent_alert_auto_close"`
 }
 
 // MetricPlugin represents the configuration of a metric plugin
@@ -131,13 +131,13 @@ func (pconf *MetricPlugin) CommandString() string {
 // CheckPlugin represents the configuration of a check plugin
 // The User option is ignored on Windows
 type CheckPlugin struct {
-	Command              string
-	CommandArgs          []string
-	User                 string
-	NotificationInterval *int32
-	CheckInterval        *int32
-	MaxCheckAttempts     *int32
-	DisableAutoClose     bool
+	Command               string
+	CommandArgs           []string
+	User                  string
+	NotificationInterval  *int32
+	CheckInterval         *int32
+	MaxCheckAttempts      *int32
+	PreventAlertAutoClose bool
 }
 
 func (pconf *PluginConfig) buildCheckPlugin(name string) (*CheckPlugin, error) {
@@ -146,17 +146,17 @@ func (pconf *PluginConfig) buildCheckPlugin(name string) (*CheckPlugin, error) {
 		return nil, err
 	}
 	plugin := CheckPlugin{
-		Command:              pconf.Command,
-		CommandArgs:          pconf.CommandArgs,
-		User:                 pconf.User,
-		NotificationInterval: pconf.NotificationInterval,
-		CheckInterval:        pconf.CheckInterval,
-		MaxCheckAttempts:     pconf.MaxCheckAttempts,
-		DisableAutoClose:     pconf.DisableAutoClose,
+		Command:               pconf.Command,
+		CommandArgs:           pconf.CommandArgs,
+		User:                  pconf.User,
+		NotificationInterval:  pconf.NotificationInterval,
+		CheckInterval:         pconf.CheckInterval,
+		MaxCheckAttempts:      pconf.MaxCheckAttempts,
+		PreventAlertAutoClose: pconf.PreventAlertAutoClose,
 	}
-	if plugin.MaxCheckAttempts != nil && *plugin.MaxCheckAttempts > 1 && plugin.DisableAutoClose {
+	if plugin.MaxCheckAttempts != nil && *plugin.MaxCheckAttempts > 1 && plugin.PreventAlertAutoClose {
 		*plugin.MaxCheckAttempts = 1
-		configLogger.Warningf("'plugin.checks.%s.max_check_attempts' is set to 1 (Unavailable with 'disable_auto_close')", name)
+		configLogger.Warningf("'plugin.checks.%s.max_check_attempts' is set to 1 (Unavailable with 'prevent_alert_auto_close')", name)
 	}
 	return &plugin, nil
 }


### PR DESCRIPTION
If `disable_auto_close` option is true, alerts of the check plugin are no longer closed automatically.
This option make mackerel-agent not report `OK` status of the plugin to the server.

`disable_auto_close = true` option is not available in combination with `max_check_attempts > 1` option.