### PR TITLE
Revert "Enable HTTP/2"

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,13 @@ func main() {
 	if os.Getenv("GOMAXPROCS") == "" {
 		runtime.GOMAXPROCS(1)
 	}
+	// force disabling http2 for now
+	godebug := os.Getenv("GODEBUG")
+	if godebug != "" {
+		godebug += ","
+	}
+	godebug += "http2client=0"
+	os.Setenv("GODEBUG", godebug)
 	cli.Run(os.Args[1:])
 }
 

--- a/main.go
+++ b/main.go
@@ -42,7 +42,8 @@ func main() {
 	if os.Getenv("GOMAXPROCS") == "" {
 		runtime.GOMAXPROCS(1)
 	}
-	// force disabling http2 for now
+	// force disabling http2, because the http/2 connection sometimes unstable
+	// at a certain data center equipped with particular network switches.
 	godebug := os.Getenv("GODEBUG")
 	if godebug != "" {
 		godebug += ","


### PR DESCRIPTION
Reverts mackerelio/mackerel-agent#383

The http/2 connection sometimes unstable at a certain data center equipped with particular network switches.