### PR TITLE
Make `make deb` work in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
 - make crossbuild
 after_script:
 - goveralls -coverprofile=.profile.cov
+- make deb
 before_deploy:
 - docker pull astj/mackerel-rpm-builder:c5
 - docker pull astj/mackerel-rpm-builder:c7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - devscripts
       - debhelper
       - dh-systemd
+      - fakeroot
 install:
 - mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ script:
 - make crossbuild
 after_script:
 - goveralls -coverprofile=.profile.cov
-- make deb
 before_deploy:
 - docker pull astj/mackerel-rpm-builder:c5
 - docker pull astj/mackerel-rpm-builder:c7


### PR DESCRIPTION
I temporally changed .travis.yml to run `make deb` in this branch's build (and reverted).

Current master cannot build like this: https://travis-ci.org/mackerelio/mackerel-agent/builds/246108517#L1237
After adding missing `fakeroot` package, `make deb` recovered: https://travis-ci.org/mackerelio/mackerel-agent/builds/246111155#L1388

It seems this is due to Travis's runtime change. According to [travis's build-environment-updates](https://github.com/travis-ci/build-environment-updates/blob/master/2017Q2/gce/sugilite-trusty/dpkg-manifest.diff#L138), fakeroot is not installed anymore.