### PR TITLE
Release version 0.43.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.43.3 (2017-06-28)
+
+* Make `make deb` work in Travis #396 (astj)
+* Migrate to mackerelio/golib/logging #395 (astj)
+
+
 ## 0.43.2 (2017-06-14)
 
 * Revert "Enable HTTP/2" #393 (Songmu)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://mackerel.io"
-VERSION = 0.43.2
+VERSION = 0.43.3
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.43.3-1.systemd) stable; urgency=low
+
+  * Make `make deb` work in Travis (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/396>
+  * Migrate to mackerelio/golib/logging (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/395>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 28 Jun 2017 13:56:36 +0900
+
 mackerel-agent (0.43.2-1.systemd) stable; urgency=low
 
   * Revert "Enable HTTP/2" (by Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.43.3-1) stable; urgency=low
+
+  * Make `make deb` work in Travis (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/396>
+  * Migrate to mackerelio/golib/logging (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/395>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 28 Jun 2017 13:56:36 +0900
+
 mackerel-agent (0.43.2-1) stable; urgency=low
 
   * Revert "Enable HTTP/2" (by Songmu)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,10 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Wed Jun 28 2017 <mackerel-developers@hatena.ne.jp> - 0.43.3
+- Make `make deb` work in Travis (by astj)
+- Migrate to mackerelio/golib/logging (by astj)
+
 * Wed Jun 14 2017 <mackerel-developers@hatena.ne.jp> - 0.43.2
 - Revert "Enable HTTP/2" (by Songmu)
 - [refactoring] remove version package and adjust internal dependencies (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,10 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Jun 28 2017 <mackerel-developers@hatena.ne.jp> - 0.43.3
+- Make `make deb` work in Travis (by astj)
+- Migrate to mackerelio/golib/logging (by astj)
+
 * Wed Jun 14 2017 <mackerel-developers@hatena.ne.jp> - 0.43.2
 - Revert "Enable HTTP/2" (by Songmu)
 - [refactoring] remove version package and adjust internal dependencies (by Songmu)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.43.2"
+const version = "0.43.3"
 
 var gitcommit string


### PR DESCRIPTION
- Make `make deb` work in Travis #396
- Migrate to mackerelio/golib/logging #395