### PR TITLE
Improve the EC2 Instance check

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -97,7 +97,7 @@ func isEC2() bool {
 		return nil
 	})
 
-	if err != nil {
+	if err == nil {
 		return res
 	}
 	return false

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -196,31 +196,7 @@ func TestSuggestCloudGenerator(t *testing.T) {
 		}
 	}()
 
-	func() { // suggest EC2Generator
-		ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-			fmt.Fprint(res, "OK:ami-id")
-		}))
-		defer ts.Close()
-		u, _ := url.Parse(ts.URL)
-		ec2BaseURL = u
-
-		cGen = SuggestCloudGenerator()
-		if cGen == nil {
-			t.Errorf("cGen should not be nil.")
-		}
-
-		ec2gen, ok := cGen.CloudMetaGenerator.(*EC2Generator)
-
-		if !ok {
-			t.Errorf("cGen should be *EC2Generator")
-		}
-
-		if ec2gen.baseURL != ec2BaseURL {
-			t.Errorf("something went wrong")
-		}
-	}()
-
-	func() { // suggest EC2Generator
+	func() { // suggest GCEGenerator
 		ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 			fmt.Fprint(res, "GCE:OK")
 		}))


### PR DESCRIPTION
The isEC2 check always calls the metadata API, and does not retry. Instead, for EC2 linux instances we can first check the UUID and only call the API if the UUID starts with `ec2` . Also, perhaps retry when that is the case.

ref. http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html