### PR TITLE
FreeBSD: don't collect nullfs disk stat

### DIFF
--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -50,7 +50,7 @@ func init() {
 	case "darwin":
 		dfOpt = []string{"-Pkl"}
 	case "freebsd":
-		dfOpt = []string{"-Pkt", "noprocfs,devfs,fdescfs,nfs,cd9660"}
+		dfOpt = []string{"-Pkt", "noprocfs,devfs,fdescfs,nfs,nullfs,cd9660"}
 	case "netbsd":
 		dfOpt = []string{"-Pkl"}
 	default:


### PR DESCRIPTION
in FreeBSD, disk stats is weird for a long time.

I'm using Jail, a container virtualization implemented in FreeBSD.  It's commonly used mouting host directories from container as a nullfs.
In such a situation, duplicated disks having same capacity, used and available disk were acquired are acquired.

```sh
# df -Pkt noprocfs,devfs,fdescfs,nfs,cd9660                                                                                                                                                                     [/home/kyontan]
Filesystem                                           1024-blocks       Used      Avail Capacity  Mounted on
/dev/ada1p2                                            129990748  110079208    9512284    92%    /
/dev/ada1p4                                           2700123308 2426032016   58081428    98%    /home
tank                                                  1198986549         19 1198986530     0%    /tank
/usr/jails/basejail/base_amd64_amd64_11.0              129990748  110079208    9512284    92%    /usr/jails/jails/megu
/usr/ports                                             129990748  110079208    9512284    92%    /usr/jails/jails/megu/usr/ports
/usr/jails/jails-data/megu-data/var/cache/distfiles    129990748  110079208    9512284    92%    /usr/jails/jails/megu/usr/ports/distfiles
/usr/jails/tmp/usr/ports/packages                      129990748  110079208    9512284    92%    /usr/jails/jails/megu/usr/ports/packages
/usr/jails/jails-data/megu-data/etc                    129990748  110079208    9512284    92%    /usr/jails/jails/megu/etc
...
```

This PR changes the result below: (to filter nullfs from `df`)

```sh
# df -Pkt noprocfs,devfs,fdescfs,nfs,nullfs,cd9660                                                                                                                                                              [/home/kyontan]
Filesystem  1024-blocks       Used      Avail Capacity  Mounted on
/dev/ada1p2   129990748  110079208    9512284    92%    /
/dev/ada1p4  2700123308 2426032016   58081428    98%    /home
tank         1198986549         19 1198986530     0%    /tank
```