### PR TITLE
Adjust isEC2 check 

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -87,7 +87,7 @@ func isEC2() bool {
 
 	res := false
 	cl := httpCli()
-	err := retry.Retry(3, 2*timeout, func() error {
+	err := retry.Retry(3, 2*time.Second, func() error {
 		// '/ami-id` is probably an AWS specific URL
 		resp, err := cl.Get(ec2BaseURL.String() + "/ami-id")
 		if err != nil {

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"runtime"
 	"strings"
 	"time"
 
@@ -67,17 +66,6 @@ func httpCli() *http.Client {
 			Proxy: nil,
 		},
 	}
-}
-
-func isEC2() bool {
-	// If the OS is Linux, check /sys/hypervisor/uuid file first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
-	// ref. http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
-	if runtime.GOOS == "linux" {
-		return isEC2ForLinux()
-	}
-
-	// For instances other than Linux, call Metadata API only once.
-	return isEC2ForNonLinux()
 }
 
 func isGCE() bool {

--- a/spec/isec2.go
+++ b/spec/isec2.go
@@ -13,5 +13,4 @@ func isEC2() bool {
 	defer resp.Body.Close()
 
 	return resp.StatusCode == 200
-
 }

--- a/spec/isec2.go
+++ b/spec/isec2.go
@@ -1,6 +1,9 @@
+// +build !linux
+
 package spec
 
-func isEC2ForNonLinux() bool {
+// For instances other than Linux, call Metadata API only once.
+func isEC2() bool {
 	cl := httpCli()
 	// '/ami-id` is probably an AWS specific URL
 	resp, err := cl.Get(ec2BaseURL.String() + "/ami-id")

--- a/spec/isec2.go
+++ b/spec/isec2.go
@@ -1,0 +1,14 @@
+package spec
+
+func isEC2ForNonLinux() bool {
+	cl := httpCli()
+	// '/ami-id` is probably an AWS specific URL
+	resp, err := cl.Get(ec2BaseURL.String() + "/ami-id")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == 200
+
+}

--- a/spec/isec2_linux.go
+++ b/spec/isec2_linux.go
@@ -8,7 +8,9 @@ import (
 	"github.com/Songmu/retry"
 )
 
-func isEC2ForLinux() bool {
+// If the OS is Linux, check /sys/hypervisor/uuid file first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
+// ref. http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
+func isEC2() bool {
 	data, err := ioutil.ReadFile("/sys/hypervisor/uuid")
 	if err != nil {
 		// Probably not EC2.

--- a/spec/isec2_linux.go
+++ b/spec/isec2_linux.go
@@ -13,10 +13,10 @@ import (
 func isEC2() bool {
 	data, err := ioutil.ReadFile("/sys/hypervisor/uuid")
 	if err != nil {
-		// Probably not EC2.
+		// Not EC2.
 		return false
 	}
-	// Probably not EC2.
+	// Not EC2.
 	if !strings.HasPrefix(string(data), "ec2") {
 		return false
 	}

--- a/spec/isec2linux.go
+++ b/spec/isec2linux.go
@@ -1,0 +1,39 @@
+package spec
+
+import (
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"github.com/Songmu/retry"
+)
+
+func isEC2ForLinux() bool {
+	data, err := ioutil.ReadFile("/sys/hypervisor/uuid")
+	if err != nil {
+		// Probably not EC2.
+		return false
+	}
+	// Probably not EC2.
+	if !strings.HasPrefix(string(data), "ec2") {
+		return false
+	}
+	res := false
+	cl := httpCli()
+	err = retry.Retry(3, 2*time.Second, func() error {
+		// '/ami-id` is probably an AWS specific URL
+		resp, err := cl.Get(ec2BaseURL.String() + "/ami-id")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		res = resp.StatusCode == 200
+		return nil
+	})
+
+	if err == nil {
+		return res
+	}
+	return false
+}


### PR DESCRIPTION
- Made the retry interval longer (from 200ms to 2000ms)
- Made it not retry calling the Metadata API for non Linux instances