### PR TITLE
Fix the Azure VM check

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -54,6 +54,9 @@ func SuggestCloudGenerator() *CloudGenerator {
 	if isGCE() {
 		return &CloudGenerator{&GCEGenerator{gceMetaURL}}
 	}
+	if isAzure() {
+		return &CloudGenerator{&AzureVMGenerator{azureVMBaseURL}}
+	}
 
 	return nil
 }


### PR DESCRIPTION
It seems like I only defined the Azure VM metadata related methods, but never called isAzure..