### PR TITLE
Show CPU/SoC model name on Linux/MIPS

### DIFF
--- a/spec/linux/cpu.go
+++ b/spec/linux/cpu.go
@@ -44,7 +44,7 @@ func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
 				cur["model_name"] = modelName
 			}
 			results = append(results, cur)
-		case "Processor":
+		case "Processor", "system type":
 			modelName = val
 		case "vendor_id", "model", "stepping", "physical id", "core id", "model name", "cache size":
 			cur[strings.Replace(key, " ", "_", -1)] = val


### PR DESCRIPTION
When using mackerel-agent on Linux/MIPS, the CPU/SoC model name is "undefined" in the Mackerel console. 

![image](https://user-images.githubusercontent.com/27699/29714783-913a6bf8-89df-11e7-9a0e-636b71549a1d.png)

On Linux/MIPS, the output of `/proc/cpuinfo` is as follows:

```
# cat /proc/cpuinfo
system type		: Atheros AR7242 rev 1
machine			: Buffalo BHR-4GRV
processor		: 0
cpu model		: MIPS 24Kc V7.4
BogoMIPS		: 265.42
wait instruction	: yes
microsecond timers	: yes
tlb_entries		: 16
extra interrupt vector	: yes
hardware watchpoint	: yes, count: 4, address/irw mask: [0x0ffc, 0x0ffc, 0x0ffb, 0x0ffb]
isa			: mips1 mips2 mips32r1 mips32r2
ASEs implemented	: mips16
shadow register sets	: 1
kscratch registers	: 0
package			: 0
core			: 0
VCED exceptions		: not available
VCEI exceptions		: not available
```

This is a slightly different result than the Linux/x86_64 architecture. The CPU/SoC model name is displayed as "system type", however mackerel-agent doesn't support it. 

This behavior can also be confirmed by checking the linux source code: [arch/mips/kernel/proc.c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/mips/kernel/proc.c?h=v4.13-rc6#n53) .
