### PR TITLE
Change the log level for failure of posting metric values

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -308,7 +308,7 @@ func loop(app *App, termCh chan struct{}) error {
 			}
 			err := app.API.PostMetricsValues(postValues)
 			if err != nil {
-				logger.Errorf("Failed to post metrics value (will retry): %s", err.Error())
+				logger.Warningf("Failed to post metrics value (will retry): %s", err.Error())
 				if lState != loopStateTerminating {
 					lState = loopStateHadError
 				}


### PR DESCRIPTION
The mackerel-agent retries posting metric values so we'll change the log level of its failure.