### PR TITLE
Release version 0.44.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.44.2 (2017-08-30)
+
+* Change the log level for failure of posting metric values #409 (itchyny)
+* Show CPU/SoC model name on Linux/MIPS #408 (hnw)
+
+
 ## 0.44.1 (2017-08-23)
 
 * Fail to start when custom identifiers are mismatched #405 (mechairoi)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://mackerel.io"
-VERSION = 0.44.1
+VERSION = 0.44.2
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.44.2-1.systemd) stable; urgency=low
+
+  * Change the log level for failure of posting metric values (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/409>
+  * Show CPU/SoC model name on Linux/MIPS (by hnw)
+    <https://github.com/mackerelio/mackerel-agent/pull/408>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 30 Aug 2017 15:17:58 +0900
+
 mackerel-agent (0.44.1-1.systemd) stable; urgency=low
 
   * Fail to start when custom identifiers are mismatched (by mechairoi)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.44.2-1) stable; urgency=low
+
+  * Change the log level for failure of posting metric values (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/409>
+  * Show CPU/SoC model name on Linux/MIPS (by hnw)
+    <https://github.com/mackerelio/mackerel-agent/pull/408>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 30 Aug 2017 15:17:58 +0900
+
 mackerel-agent (0.44.1-1) stable; urgency=low
 
   * Fail to start when custom identifiers are mismatched (by mechairoi)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,10 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Wed Aug 30 2017 <mackerel-developers@hatena.ne.jp> - 0.44.2
+- Change the log level for failure of posting metric values (by itchyny)
+- Show CPU/SoC model name on Linux/MIPS (by hnw)
+
 * Wed Aug 23 2017 <mackerel-developers@hatena.ne.jp> - 0.44.1
 - Fail to start when custom identifiers are mismatched (by mechairoi)
 - Fix the Azure VM check (by stefafafan)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,10 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Aug 30 2017 <mackerel-developers@hatena.ne.jp> - 0.44.2
+- Change the log level for failure of posting metric values (by itchyny)
+- Show CPU/SoC model name on Linux/MIPS (by hnw)
+
 * Wed Aug 23 2017 <mackerel-developers@hatena.ne.jp> - 0.44.1
 - Fail to start when custom identifiers are mismatched (by mechairoi)
 - Fix the Azure VM check (by stefafafan)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.44.1"
+const version = "0.44.2"
 
 var gitcommit string


### PR DESCRIPTION
- Change the log level for failure of posting metric values #409
- Show CPU/SoC model name on Linux/MIPS #408