### PR TITLE
Filter plugin metrics value by include_pattern and exclude_pattern option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -88,17 +88,17 @@ type PluginConfig struct {
 	MaxCheckAttempts      *int32  `toml:"max_check_attempts"`
 	CustomIdentifier      *string `toml:"custom_identifier"`
 	PreventAlertAutoClose bool    `toml:"prevent_alert_auto_close"`
-	MetricNamePattern     *string `toml:"metric_name_pattern"`
+	IncludePattern        *string `toml:"include_pattern"`
 }
 
 // MetricPlugin represents the configuration of a metric plugin
 // The User option is ignored on Windows
 type MetricPlugin struct {
-	Command           string
-	CommandArgs       []string
-	User              string
-	CustomIdentifier  *string
-	MetricNamePattern *regexp.Regexp
+	Command          string
+	CommandArgs      []string
+	User             string
+	CustomIdentifier *string
+	IncludePattern   *regexp.Regexp
 }
 
 func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
@@ -108,19 +108,19 @@ func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
 	}
 
 	var pattern *regexp.Regexp
-	if pconf.MetricNamePattern != nil {
-		pattern, err = regexp.Compile(*pconf.MetricNamePattern)
+	if pconf.IncludePattern != nil {
+		pattern, err = regexp.Compile(*pconf.IncludePattern)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	return &MetricPlugin{
-		Command:           pconf.Command,
-		CommandArgs:       pconf.CommandArgs,
-		User:              pconf.User,
-		CustomIdentifier:  pconf.CustomIdentifier,
-		MetricNamePattern: pattern,
+		Command:          pconf.Command,
+		CommandArgs:      pconf.CommandArgs,
+		User:             pconf.User,
+		CustomIdentifier: pconf.CustomIdentifier,
+		IncludePattern:   pattern,
 	}, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,7 @@ type PluginConfig struct {
 	CustomIdentifier      *string `toml:"custom_identifier"`
 	PreventAlertAutoClose bool    `toml:"prevent_alert_auto_close"`
 	IncludePattern        *string `toml:"include_pattern"`
+	ExcludePattern        *string `toml:"exclude_pattern"`
 }
 
 // MetricPlugin represents the configuration of a metric plugin
@@ -99,6 +100,7 @@ type MetricPlugin struct {
 	User             string
 	CustomIdentifier *string
 	IncludePattern   *regexp.Regexp
+	ExcludePattern   *regexp.Regexp
 }
 
 func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
@@ -107,9 +109,18 @@ func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
 		return nil, err
 	}
 
-	var pattern *regexp.Regexp
+	var (
+		includePattern *regexp.Regexp
+		excludePattern *regexp.Regexp
+	)
 	if pconf.IncludePattern != nil {
-		pattern, err = regexp.Compile(*pconf.IncludePattern)
+		includePattern, err = regexp.Compile(*pconf.IncludePattern)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if pconf.ExcludePattern != nil {
+		excludePattern, err = regexp.Compile(*pconf.ExcludePattern)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +131,8 @@ func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
 		CommandArgs:      pconf.CommandArgs,
 		User:             pconf.User,
 		CustomIdentifier: pconf.CustomIdentifier,
-		IncludePattern:   pattern,
+		IncludePattern:   includePattern,
+		ExcludePattern:   excludePattern,
 	}, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -88,15 +88,17 @@ type PluginConfig struct {
 	MaxCheckAttempts      *int32  `toml:"max_check_attempts"`
 	CustomIdentifier      *string `toml:"custom_identifier"`
 	PreventAlertAutoClose bool    `toml:"prevent_alert_auto_close"`
+	MetricNamePattern     *string `toml:"metric_name_pattern"`
 }
 
 // MetricPlugin represents the configuration of a metric plugin
 // The User option is ignored on Windows
 type MetricPlugin struct {
-	Command          string
-	CommandArgs      []string
-	User             string
-	CustomIdentifier *string
+	Command           string
+	CommandArgs       []string
+	User              string
+	CustomIdentifier  *string
+	MetricNamePattern *regexp.Regexp
 }
 
 func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
@@ -104,11 +106,21 @@ func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	var pattern *regexp.Regexp
+	if pconf.MetricNamePattern != nil {
+		pattern, err = regexp.Compile(*pconf.MetricNamePattern)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &MetricPlugin{
-		Command:          pconf.Command,
-		CommandArgs:      pconf.CommandArgs,
-		User:             pconf.User,
-		CustomIdentifier: pconf.CustomIdentifier,
+		Command:           pconf.Command,
+		CommandArgs:       pconf.CommandArgs,
+		User:              pconf.User,
+		CustomIdentifier:  pconf.CustomIdentifier,
+		MetricNamePattern: pattern,
 	}, nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,8 +30,8 @@ custom_identifier = "app1.example.com"
 
 [plugin.metrics.mysql2]
 command = "ruby /path/to/your/plugin/mysql.rb"
-include_pattern = 'mysql\.innodb\..+'
-exclude_pattern = 'mysql\.innodb\.ignore'
+include_pattern = '^mysql\.innodb\..+'
+exclude_pattern = '^mysql\.innodb\.ignore'
 
 [plugin.checks.heartbeat]
 command = "heartbeat.sh"
@@ -230,10 +230,10 @@ func TestLoadConfigFile(t *testing.T) {
 	}
 
 	pluginConf2 := config.MetricPlugins["mysql2"]
-	if pluginConf2.IncludePattern.String() != regexp.MustCompile(`mysql\.innodb\..+`).String() {
+	if pluginConf2.IncludePattern.String() != regexp.MustCompile(`^mysql\.innodb\..+`).String() {
 		t.Errorf("unexpected include_pattern: %v", pluginConf2.IncludePattern)
 	}
-	if pluginConf2.ExcludePattern.String() != regexp.MustCompile(`mysql\.innodb\.ignore`).String() {
+	if pluginConf2.ExcludePattern.String() != regexp.MustCompile(`^mysql\.innodb\.ignore`).String() {
 		t.Errorf("unexpected exclude_pattern: %v", pluginConf2.ExcludePattern)
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -26,6 +27,10 @@ post_metrics_retry_max = 5
 command = "ruby /path/to/your/plugin/mysql.rb"
 user = "mysql"
 custom_identifier = "app1.example.com"
+
+[plugin.metrics.mysql2]
+command = "ruby /path/to/your/plugin/mysql.rb"
+metric_name_pattern = "custom\.mysql\.innodb.+"
 
 [plugin.checks.heartbeat]
 command = "heartbeat.sh"
@@ -215,6 +220,14 @@ func TestLoadConfigFile(t *testing.T) {
 	}
 	if customIdentifiers[0] != "app1.example.com" {
 		t.Errorf("first custom_identifier should be 'app1.example.com'")
+	}
+	if pluginConf.MetricNamePattern != nil {
+		t.Errorf("plugin metric_name_pattern should be nil but got %v", pluginConf.MetricNamePattern)
+	}
+
+	pluginConf2 := config.MetricPlugins["mysql2"]
+	if pluginConf2.MetricNamePattern != regexp.MustCompile(`custom\.mysql\.innodb.+`) {
+		t.Errorf("plugin metric_name_pattern should be nil but got %v", pluginConf.MetricNamePattern)
 	}
 
 	if config.CheckPlugins == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,6 +31,7 @@ custom_identifier = "app1.example.com"
 [plugin.metrics.mysql2]
 command = "ruby /path/to/your/plugin/mysql.rb"
 include_pattern = 'mysql\.innodb\..+'
+exclude_pattern = 'mysql\.innodb\.ignore'
 
 [plugin.checks.heartbeat]
 command = "heartbeat.sh"
@@ -224,10 +225,16 @@ func TestLoadConfigFile(t *testing.T) {
 	if pluginConf.IncludePattern != nil {
 		t.Errorf("plugin include_pattern should be nil but got %v", pluginConf.IncludePattern)
 	}
+	if pluginConf.ExcludePattern != nil {
+		t.Errorf("plugin exclude_pattern should be nil but got %v", pluginConf.ExcludePattern)
+	}
 
 	pluginConf2 := config.MetricPlugins["mysql2"]
 	if pluginConf2.IncludePattern.String() != regexp.MustCompile(`mysql\.innodb\..+`).String() {
 		t.Errorf("unexpected include_pattern: %v", pluginConf2.IncludePattern)
+	}
+	if pluginConf2.ExcludePattern.String() != regexp.MustCompile(`mysql\.innodb\.ignore`).String() {
+		t.Errorf("unexpected exclude_pattern: %v", pluginConf2.ExcludePattern)
 	}
 
 	if config.CheckPlugins == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,7 +30,7 @@ custom_identifier = "app1.example.com"
 
 [plugin.metrics.mysql2]
 command = "ruby /path/to/your/plugin/mysql.rb"
-metric_name_pattern = "custom\.mysql\.innodb.+"
+metric_name_pattern = 'mysql\.innodb\..+'
 
 [plugin.checks.heartbeat]
 command = "heartbeat.sh"
@@ -226,8 +226,8 @@ func TestLoadConfigFile(t *testing.T) {
 	}
 
 	pluginConf2 := config.MetricPlugins["mysql2"]
-	if pluginConf2.MetricNamePattern != regexp.MustCompile(`custom\.mysql\.innodb.+`) {
-		t.Errorf("plugin metric_name_pattern should be nil but got %v", pluginConf.MetricNamePattern)
+	if pluginConf2.MetricNamePattern.String() != regexp.MustCompile(`mysql\.innodb\..+`).String() {
+		t.Errorf("unexpected metric_name_pattern: %v", pluginConf2.MetricNamePattern)
 	}
 
 	if config.CheckPlugins == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,7 +30,7 @@ custom_identifier = "app1.example.com"
 
 [plugin.metrics.mysql2]
 command = "ruby /path/to/your/plugin/mysql.rb"
-metric_name_pattern = 'mysql\.innodb\..+'
+include_pattern = 'mysql\.innodb\..+'
 
 [plugin.checks.heartbeat]
 command = "heartbeat.sh"
@@ -221,13 +221,13 @@ func TestLoadConfigFile(t *testing.T) {
 	if customIdentifiers[0] != "app1.example.com" {
 		t.Errorf("first custom_identifier should be 'app1.example.com'")
 	}
-	if pluginConf.MetricNamePattern != nil {
-		t.Errorf("plugin metric_name_pattern should be nil but got %v", pluginConf.MetricNamePattern)
+	if pluginConf.IncludePattern != nil {
+		t.Errorf("plugin include_pattern should be nil but got %v", pluginConf.IncludePattern)
 	}
 
 	pluginConf2 := config.MetricPlugins["mysql2"]
-	if pluginConf2.MetricNamePattern.String() != regexp.MustCompile(`mysql\.innodb\..+`).String() {
-		t.Errorf("unexpected metric_name_pattern: %v", pluginConf2.MetricNamePattern)
+	if pluginConf2.IncludePattern.String() != regexp.MustCompile(`mysql\.innodb\..+`).String() {
+		t.Errorf("unexpected include_pattern: %v", pluginConf2.IncludePattern)
 	}
 
 	if config.CheckPlugins == nil {

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -237,7 +237,7 @@ func (g *pluginGenerator) collectValues() (Values, error) {
 
 		key := items[0]
 
-		if g.Config.MetricNamePattern != nil && !g.Config.MetricNamePattern.MatchString(key) {
+		if g.Config.IncludePattern != nil && !g.Config.IncludePattern.MatchString(key) {
 			continue
 		}
 

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -241,6 +241,10 @@ func (g *pluginGenerator) collectValues() (Values, error) {
 			continue
 		}
 
+		if g.Config.ExcludePattern != nil && g.Config.ExcludePattern.MatchString(key) {
+			continue
+		}
+
 		value, err := strconv.ParseFloat(items[1], 64)
 		if err != nil {
 			pluginLogger.Warningf("Failed to parse values: %s", err)

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -234,13 +234,18 @@ func (g *pluginGenerator) collectValues() (Values, error) {
 		if len(items) != 3 {
 			continue
 		}
+
+		key := items[0]
+
+		if g.Config.MetricNamePattern != nil && !g.Config.MetricNamePattern.MatchString(key) {
+			continue
+		}
+
 		value, err := strconv.ParseFloat(items[1], 64)
 		if err != nil {
 			pluginLogger.Warningf("Failed to parse values: %s", err)
 			continue
 		}
-
-		key := items[0]
 
 		results[pluginPrefix+key] = value
 	}

--- a/metrics/plugin_test.go
+++ b/metrics/plugin_test.go
@@ -48,8 +48,8 @@ func TestPluginCollectValues(t *testing.T) {
 
 func TestPluginCollectValuesWithPattern(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
-		Command:           "ruby ../example/metrics-plugins/dice-with-meta.rb",
-		MetricNamePattern: regexp.MustCompile(`^dice\.d6`),
+		Command:        "ruby ../example/metrics-plugins/dice-with-meta.rb",
+		IncludePattern: regexp.MustCompile(`^dice\.d6`),
 	},
 	}
 	values, err := g.collectValues()

--- a/metrics/plugin_test.go
+++ b/metrics/plugin_test.go
@@ -59,7 +59,7 @@ func TestPluginCollectValuesWithPattern(t *testing.T) {
 	if len(values) != 1 {
 		t.Errorf("Collected metrics are unexpected ")
 	}
-	if _, ok := values["dice.d6"]; !ok {
+	if _, ok := values["custom.dice.d6"]; !ok {
 		t.Errorf("Value for dice.d6 should be present ")
 	}
 }

--- a/metrics/plugin_test.go
+++ b/metrics/plugin_test.go
@@ -49,7 +49,7 @@ func TestPluginCollectValues(t *testing.T) {
 func TestPluginCollectValuesWithPattern(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
 		Command:           "ruby ../example/metrics-plugins/dice-with-meta.rb",
-		MetricNamePattern: regexp.MustCompile(`dice\.d6`),
+		MetricNamePattern: regexp.MustCompile(`^dice\.d6`),
 	},
 	}
 	values, err := g.collectValues()

--- a/metrics/plugin_test.go
+++ b/metrics/plugin_test.go
@@ -46,6 +46,24 @@ func TestPluginCollectValues(t *testing.T) {
 	}
 }
 
+func TestPluginCollectValuesWithPattern(t *testing.T) {
+	g := &pluginGenerator{Config: &config.MetricPlugin{
+		Command:           "ruby ../example/metrics-plugins/dice-with-meta.rb",
+		MetricNamePattern: regexp.MustCompile(`dice\.d6`),
+	},
+	}
+	values, err := g.collectValues()
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	if len(values) != 1 {
+		t.Errorf("Collected metrics are unexpected ")
+	}
+	if _, ok := values["dice.d6"]; !ok {
+		t.Errorf("Value for dice.d6 should be present ")
+	}
+}
+
 func TestPluginMakeCreateGraphDefsPayload(t *testing.T) {
 	// this plugin emits "one.foo1", "one.foo2" and "two.bar1" metrics
 	g := &pluginGenerator{

--- a/metrics/plugin_test.go
+++ b/metrics/plugin_test.go
@@ -46,7 +46,7 @@ func TestPluginCollectValues(t *testing.T) {
 	}
 }
 
-func TestPluginCollectValuesWithPattern(t *testing.T) {
+func TestPluginCollectValuesWithIncludePattern(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
 		Command:        "ruby ../example/metrics-plugins/dice-with-meta.rb",
 		IncludePattern: regexp.MustCompile(`^dice\.d6`),
@@ -61,6 +61,40 @@ func TestPluginCollectValuesWithPattern(t *testing.T) {
 	}
 	if _, ok := values["custom.dice.d6"]; !ok {
 		t.Errorf("Value for dice.d6 should be present ")
+	}
+}
+
+func TestPluginCollectValuesWithExcludePattern(t *testing.T) {
+	g := &pluginGenerator{Config: &config.MetricPlugin{
+		Command:        "ruby ../example/metrics-plugins/dice-with-meta.rb",
+		ExcludePattern: regexp.MustCompile(`^dice\.d20`),
+	},
+	}
+	values, err := g.collectValues()
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	if len(values) != 1 {
+		t.Errorf("Collected metrics are unexpected ")
+	}
+	if _, ok := values["custom.dice.d6"]; !ok {
+		t.Errorf("Value for dice.d6 should be present ")
+	}
+}
+
+func TestPluginCollectValuesWithBothPattern(t *testing.T) {
+	g := &pluginGenerator{Config: &config.MetricPlugin{
+		Command:        "ruby ../example/metrics-plugins/dice-with-meta.rb",
+		IncludePattern: regexp.MustCompile(`^dice\.d20`),
+		ExcludePattern: regexp.MustCompile(`^dice\.d20`),
+	},
+	}
+	values, err := g.collectValues()
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	if len(values) != 0 {
+		t.Errorf("No values should be present")
 	}
 }
 


### PR DESCRIPTION
When `ruby ./dice.rb` generates two metrics `dice6` and `dice20`, following plugin config now only sends `dice6` metrics to Mackerel.

```toml
[plugin.metrics.dice]
command = "ruby ./dice.rb"
include_pattern = '^dice6'
```

And `exclude_pattern` will exclude metrics if the metric name matches `exclude_pattern`.