### PR TITLE
Use new API BaseURL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
-MACKEREL_API_BASE ?= "https://mackerel.io"
+MACKEREL_API_BASE ?= "https://api.mackerelio.com"
 VERSION = 0.45.0
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,7 @@ func getApibase() string {
 	if apibase != "" {
 		return apibase
 	}
-	return "https://mackerel.io"
+	return "https://api.mackerelio.com"
 }
 
 var agentName string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,8 +57,8 @@ func TestLoadConfig(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	if config.Apibase != "https://mackerel.io" {
-		t.Error("should be https://mackerel.io (arg value should be used)")
+	if config.Apibase != "https://api.mackerelio.com" {
+		t.Error("should be https://api.mackerelio.com (arg value should be used)")
 	}
 
 	if config.Apikey != "abcde" {

--- a/main_test.go
+++ b/main_test.go
@@ -103,7 +103,7 @@ func TestResolveConfigForRetire(t *testing.T) {
 	// Because, these options are potentially passed in initd script by using $OTHER_OPTS.
 	argv := []string{
 		"-conf=" + confFile.Name(),
-		"-apibase=https://mackerel.io",
+		"-apibase=https://api.mackerelio.com",
 		"-pidfile=hoge",
 		"-root=hoge",
 		"-verbose",


### PR DESCRIPTION
Our announcement:
- En: https://mackerel.io/blog/entry/announcement/20170921
- Ja: https://mackerel.io/ja/blog/entry/announcement/20170921 

Now we use `api.mackerelio.com` instead of `mackerel.io` as the base URL for API requests.
`https://api.mackerelio.com/api/...` should behave as same as `https://mackerel.io/api/...`. 

### Note

This change only affects to API requests.  Mackerel console `https://mackerel.io/` is not affected. (We'll update other our projects, like `mackerel-client-go` and `mkr` also.)
And `https://mackerel.io/api/...` is still available, therefore immediate migration is not necessary.