### PR TITLE
Subtract cpu.guest from cpu.user on Linux (ref: #419)

### DIFF
--- a/metrics/linux/cpuusage.go
+++ b/metrics/linux/cpuusage.go
@@ -127,9 +127,11 @@ func (g *CPUUsageGenerator) collectProcStatValues() ([]float64, float64, uint, e
 	// Since cpustat[CPUTIME_USER] includes cpustat[CPUTIME_GUEST], subtract the duplicated values from total.
 	// https://github.com/torvalds/linux/blob/4ec9f7a18/kernel/sched/cputime.c#L151-L158
 	// https://github.com/mackerelio/mackerel-agent/issues/419
-	totalValues -= values[8]
-	// Also, subtract guest from user.
-	values[0] -= values[8]
+	if len(values) >= 9 {
+		totalValues -= values[8]
+		// Also, subtract guest from user.
+		values[0] -= values[8]
+	}
 
 	return values, totalValues, cpuCount, nil
 }

--- a/metrics/linux/cpuusage.go
+++ b/metrics/linux/cpuusage.go
@@ -124,5 +124,12 @@ func (g *CPUUsageGenerator) collectProcStatValues() ([]float64, float64, uint, e
 		totalValues += values[i]
 	}
 
+	// Since cpustat[CPUTIME_USER] includes cpustat[CPUTIME_GUEST], subtract the duplicated values from total.
+	// https://github.com/torvalds/linux/blob/4ec9f7a18/kernel/sched/cputime.c#L151-L158
+	// https://github.com/mackerelio/mackerel-agent/issues/419
+	totalValues -= values[8]
+	// Also, subtract guest from user.
+	values[0] -= values[8]
+
 	return values, totalValues, cpuCount, nil
 }


### PR DESCRIPTION
This pull request fixes #419, fixes the inaccuracy of cpu.user on Linux. In Mackerel, all the metrics for cpu graph are drawn in stacked so it's preferable to subtract guest from user. There's another problem that we have to take account for `guest_nice` (subtract `guest_nice` from `nice` and `total`), but Mackerel doesn't support `guest_nice` yet so we'll fix the problem in another pull request.
