### PR TITLE
Change log level in device generator if /sys/block does not exist

### DIFF
--- a/spec/linux/block_device.go
+++ b/spec/linux/block_device.go
@@ -26,6 +26,11 @@ var blockDeviceLogger = logging.GetLogger("spec.block_device")
 func (g *BlockDeviceGenerator) Generate() (interface{}, error) {
 	fileInfos, err := ioutil.ReadDir("/sys/block")
 	if err != nil {
+		// /sys/block is unavailable on some PaaS (Heroku, for example)
+		if os.IsNotExist(err) {
+			blockDeviceLogger.Debugf("Failed (skip this spec): %s", err)
+			return nil, nil
+		}
 		blockDeviceLogger.Errorf("Failed (skip this spec): %s", err)
 		return nil, err
 	}

--- a/spec/linux/block_device.go
+++ b/spec/linux/block_device.go
@@ -22,20 +22,10 @@ func (g *BlockDeviceGenerator) Key() string {
 
 var blockDeviceLogger = logging.GetLogger("spec.block_device")
 
-var sysBlockUnavailable = false
-
 // Generate generate metric values
 func (g *BlockDeviceGenerator) Generate() (interface{}, error) {
-	if sysBlockUnavailable {
-		return nil, nil
-	}
 	fileInfos, err := ioutil.ReadDir("/sys/block")
 	if err != nil {
-		// /sys/block is unavailable on some PaaS (Heroku, for example)
-		if os.IsNotExist(err) {
-			sysBlockUnavailable = true
-			return nil, nil
-		}
 		blockDeviceLogger.Errorf("Failed (skip this spec): %s", err)
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #421. Some the directory is unavailable on some PaaS. 