### PR TITLE
Trigger action command after check plugin running.

### DIFF
--- a/checks/checker.go
+++ b/checks/checker.go
@@ -58,7 +58,7 @@ func (c *Checker) String() string {
 // Check invokes the command and transforms its result to a Report.
 func (c *Checker) Check() *Report {
 	now := time.Now()
-	message, stderr, exitCode, err := c.Config.Run()
+	message, stderr, exitCode, err := c.Config.Command.Run()
 	if stderr != "" {
 		logger.Warningf("Checker %q output stderr: %s", c.Name, stderr)
 	}

--- a/checks/checker_test.go
+++ b/checks/checker_test.go
@@ -9,13 +9,13 @@ import (
 func TestChecker_Check(t *testing.T) {
 	checkerOK := Checker{
 		Config: &config.CheckPlugin{
-			Command: "go run testdata/exit.go -code 0 -message OK",
+			Command: config.Command{Cmd: "go run testdata/exit.go -code 0 -message OK"},
 		},
 	}
 
 	checkerWarning := Checker{
 		Config: &config.CheckPlugin{
-			Command: "go run testdata/exit.go -code 1 -message something_is_going_wrong",
+			Command: config.Command{Cmd: "go run testdata/exit.go -code 1 -message something_is_going_wrong"},
 		},
 	}
 

--- a/checks/checker_unix_test.go
+++ b/checks/checker_unix_test.go
@@ -19,7 +19,7 @@ func TestChecker_CheckTimeout(t *testing.T) {
 
 	checkerTimeout := Checker{
 		Config: &config.CheckPlugin{
-			Command: "sleep 2",
+			Command: config.Command{Cmd: "sleep 2"},
 		},
 	}
 

--- a/command/command.go
+++ b/command/command.go
@@ -412,6 +412,13 @@ func runChecker(checker *checks.Checker, checkReportCh chan *checks.Report, repo
 			nextInterval = interval - (now.Sub(nextTime) % interval)
 			nextTime = now.Add(nextInterval)
 
+			if checker.Config.Action != nil {
+				env := []string{fmt.Sprintf("MACKEREL_STATUS=%s", report.Status), fmt.Sprintf("MACKEREL_PREV_STATUS=%s", lastStatus)}
+				go func() {
+					checker.Config.Action.RunWithEnv(env)
+				}()
+			}
+
 			if report.Status == checks.StatusOK && report.Status == lastStatus && report.Message == lastMessage {
 				// Do not report if nothing has changed
 				continue

--- a/command/command.go
+++ b/command/command.go
@@ -413,7 +413,7 @@ func runChecker(checker *checks.Checker, checkReportCh chan *checks.Report, repo
 			nextTime = now.Add(nextInterval)
 
 			if checker.Config.Action != nil {
-				env := []string{fmt.Sprintf("MACKEREL_STATUS=%s", report.Status), fmt.Sprintf("MACKEREL_PREV_STATUS=%s", lastStatus)}
+				env := []string{fmt.Sprintf("MACKEREL_STATUS=%s", report.Status), fmt.Sprintf("MACKEREL_PREVIOUS_STATUS=%s", lastStatus)}
 				go func() {
 					checker.Config.Action.RunWithEnv(env)
 				}()

--- a/command/command_unix_test.go
+++ b/command/command_unix_test.go
@@ -25,12 +25,12 @@ func TestRunOnce(t *testing.T) {
 	conf := &config.Config{
 		MetricPlugins: map[string]*config.MetricPlugin{
 			"metric1": {
-				Command: diceCommand,
+				Command: config.Command{Cmd: diceCommand},
 			},
 		},
 		CheckPlugins: map[string]*config.CheckPlugin{
 			"check1": {
-				Command: "echo 1",
+				Command: config.Command{Cmd: "echo 1"},
 			},
 		},
 	}
@@ -52,12 +52,12 @@ func TestRunOncePayload(t *testing.T) {
 	conf := &config.Config{
 		MetricPlugins: map[string]*config.MetricPlugin{
 			"metric1": {
-				Command: diceCommand,
+				Command: config.Command{Cmd: diceCommand},
 			},
 		},
 		CheckPlugins: map[string]*config.CheckPlugin{
 			"check1": {
-				Command: "echo 1",
+				Command: config.Command{Cmd: "echo 1"},
 			},
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -123,7 +123,7 @@ type MetricPlugin struct {
 }
 
 func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
-	cmd, err := pconf.parseCommand()
+	cmd, err := parseCommand(pconf.CommandRaw, pconf.User)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ type CheckPlugin struct {
 }
 
 func (pconf *PluginConfig) buildCheckPlugin(name string) (*CheckPlugin, error) {
-	cmd, err := pconf.parseCommand()
+	cmd, err := parseCommand(pconf.CommandRaw, pconf.User)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ type MetadataPlugin struct {
 }
 
 func (pconf *PluginConfig) buildMetadataPlugin() (*MetadataPlugin, error) {
-	cmd, err := pconf.parseCommand()
+	cmd, err := parseCommand(pconf.CommandRaw, pconf.User)
 	if err != nil {
 		return nil, err
 	}
@@ -200,14 +200,13 @@ func (pconf *PluginConfig) buildMetadataPlugin() (*MetadataPlugin, error) {
 	}, nil
 }
 
-func (pconf *PluginConfig) parseCommand() (command Command, err error) {
+func parseCommand(commandRaw interface{}, user string) (command Command, err error) {
 	const errFmt = "failed to parse plugin command. A configuration value of `command` should be string or string slice, but %T"
-	v := pconf.CommandRaw
-	switch t := v.(type) {
+	switch t := commandRaw.(type) {
 	case string:
 		return Command{
 			Cmd:  t,
-			User: pconf.User,
+			User: user,
 		}, nil
 	case []interface{}:
 		if len(t) > 0 {
@@ -215,24 +214,24 @@ func (pconf *PluginConfig) parseCommand() (command Command, err error) {
 			for _, vv := range t {
 				str, ok := vv.(string)
 				if !ok {
-					return Command{}, fmt.Errorf(errFmt, v)
+					return Command{}, fmt.Errorf(errFmt, commandRaw)
 				}
 
 				args = append(args, str)
 			}
 			return Command{
 				Args: args,
-				User: pconf.User,
+				User: user,
 			}, nil
 		}
-		return Command{}, fmt.Errorf(errFmt, v)
+		return Command{}, fmt.Errorf(errFmt, commandRaw)
 	case []string:
 		return Command{
 			Args: t,
-			User: pconf.User,
+			User: user,
 		}, nil
 	default:
-		return Command{}, fmt.Errorf(errFmt, v)
+		return Command{}, fmt.Errorf(errFmt, commandRaw)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,14 @@ func (cmd *Command) Run() (stdout, stderr string, exitCode int, err error) {
 	return util.RunCommand(cmd.Cmd, cmd.User, nil)
 }
 
+// RunWithEnv runs the Command with Environment.
+func (cmd *Command) RunWithEnv(env []string) (stdout, stderr string, exitCode int, err error) {
+	if len(cmd.Args) > 0 {
+		return util.RunCommandArgs(cmd.Args, cmd.User, env)
+	}
+	return util.RunCommand(cmd.Cmd, cmd.User, env)
+}
+
 // CommandString returns the command string for log messages
 func (cmd *Command) CommandString() string {
 	if len(cmd.Args) > 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -107,9 +107,9 @@ type Command struct {
 // Run the Command.
 func (cmd *Command) Run() (stdout, stderr string, exitCode int, err error) {
 	if len(cmd.Args) > 0 {
-		return util.RunCommandArgs(cmd.Args, cmd.User)
+		return util.RunCommandArgs(cmd.Args, cmd.User, nil)
 	}
-	return util.RunCommand(cmd.Cmd, cmd.User)
+	return util.RunCommand(cmd.Cmd, cmd.User, nil)
 }
 
 // CommandString returns the command string for log messages

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,6 +38,7 @@ command = "heartbeat.sh"
 user = "xyz"
 notification_interval = 60
 max_check_attempts = 3
+action = { command = "cardiac_massage", user = "doctor" }
 
 [plugin.metadata.hostinfo]
 command = "hostinfo.sh"
@@ -206,10 +207,10 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Error("plugin should have metrics")
 	}
 	pluginConf := config.MetricPlugins["mysql"]
-	if pluginConf.Command != "ruby /path/to/your/plugin/mysql.rb" {
-		t.Errorf("plugin conf command should be 'ruby /path/to/your/plugin/mysql.rb' but %v", pluginConf.Command)
+	if pluginConf.Command.Cmd != "ruby /path/to/your/plugin/mysql.rb" {
+		t.Errorf("plugin conf command should be 'ruby /path/to/your/plugin/mysql.rb' but %v", pluginConf.Command.Cmd)
 	}
-	if pluginConf.User != "mysql" {
+	if pluginConf.Command.User != "mysql" {
 		t.Error("plugin user_name should be 'mysql'")
 	}
 	if *pluginConf.CustomIdentifier != "app1.example.com" {
@@ -241,10 +242,10 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Error("plugin should have checks")
 	}
 	checks := config.CheckPlugins["heartbeat"]
-	if checks.Command != "heartbeat.sh" {
+	if checks.Command.Cmd != "heartbeat.sh" {
 		t.Error("check command should be 'heartbeat.sh'")
 	}
-	if checks.User != "xyz" {
+	if checks.Command.User != "xyz" {
 		t.Error("check user_name should be 'xyz'")
 	}
 	if *checks.NotificationInterval != 60 {
@@ -253,16 +254,22 @@ func TestLoadConfigFile(t *testing.T) {
 	if *checks.MaxCheckAttempts != 3 {
 		t.Error("max_check_attempts should be 3")
 	}
+	if checks.Action.Cmd != "cardiac_massage" {
+		t.Error("action.command should be 'cardiac_massage'")
+	}
+	if checks.Action.User != "doctor" {
+		t.Error("action.user should be 'doctor'")
+	}
 
 	if config.MetadataPlugins == nil {
 		t.Error("config should have metadata plugin list")
 	}
 	metadataPlugin := config.MetadataPlugins["hostinfo"]
-	if metadataPlugin.Command != "hostinfo.sh" {
-		t.Errorf("command of metadata plugin should be 'hostinfo.sh' but got '%v'", metadataPlugin.Command)
+	if metadataPlugin.Command.Cmd != "hostinfo.sh" {
+		t.Errorf("command of metadata plugin should be 'hostinfo.sh' but got '%v'", metadataPlugin.Command.Cmd)
 	}
-	if metadataPlugin.User != "zzz" {
-		t.Errorf("user of metadata plugin should be 'zzz' but got '%v'", metadataPlugin.User)
+	if metadataPlugin.Command.User != "zzz" {
+		t.Errorf("user of metadata plugin should be 'zzz' but got '%v'", metadataPlugin.Command.User)
 	}
 	if *metadataPlugin.ExecutionInterval != 60 {
 		t.Errorf("execution interval of metadata plugin should be 60 but got '%v'", *metadataPlugin.ExecutionInterval)
@@ -345,9 +352,9 @@ command = "bar"
 	assert(t, config.Verbose == false, "verbose should be kept as it is when not configured in the included file")
 	assert(t, len(config.Roles) == 1, "roles should be overwritten")
 	assert(t, config.Roles[0] == "Service:role", "roles should be overwritten")
-	assert(t, config.MetricPlugins["foo1"].Command == "foo1", "plugin.metrics.foo1 should exist")
-	assert(t, config.MetricPlugins["foo2"].Command == "foo2", "plugin.metrics.foo2 should exist")
-	assert(t, config.MetricPlugins["bar"].Command == "bar", "plugin.metrics.bar should be overwritten")
+	assert(t, config.MetricPlugins["foo1"].Command.Cmd == "foo1", "plugin.metrics.foo1 should exist")
+	assert(t, config.MetricPlugins["foo2"].Command.Cmd == "foo2", "plugin.metrics.foo2 should exist")
+	assert(t, config.MetricPlugins["bar"].Command.Cmd == "bar", "plugin.metrics.bar should be overwritten")
 }
 
 func TestLoadConfigFileIncludeOverwritten(t *testing.T) {
@@ -456,14 +463,14 @@ command = ["perl", "-E", "say 'Hello'"]
 
 	expected := []string{"perl", "-E", "say 'Hello'"}
 	p := config.MetricPlugins["hoge"]
-	output := p.CommandArgs
+	output := p.Command.Args
 
 	if !reflect.DeepEqual(expected, output) {
 		t.Errorf("command args not expected: %+v", output)
 	}
 
-	if p.Command != "" {
-		t.Errorf("p.Command should be empty but: %s", p.Command)
+	if p.Command.Cmd != "" {
+		t.Errorf("p.Command should be empty but: %s", p.Command.Cmd)
 	}
 }
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -25,7 +25,7 @@ type Generator struct {
 
 // Fetch invokes the command and returns the result
 func (g *Generator) Fetch() (interface{}, error) {
-	message, stderr, exitCode, err := g.Config.Run()
+	message, stderr, exitCode, err := g.Config.Command.Run()
 
 	if err != nil {
 		logger.Warningf("Error occurred while executing a metadata plugin %q: %v", g.Name, err)

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -70,7 +70,7 @@ func TestMetadataGeneratorFetch(t *testing.T) {
 	for _, test := range tests {
 		g := Generator{
 			Config: &config.MetadataPlugin{
-				CommandArgs: test.command,
+				Command: config.Command{Args: test.command},
 			},
 		}
 		metadata, err := g.Fetch()

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -124,9 +124,9 @@ func (g *pluginGenerator) loadPluginMeta() error {
 	os.Setenv(pluginConfigurationEnvName, "1")
 	defer os.Setenv(pluginConfigurationEnvName, "")
 
-	stdout, stderr, exitCode, err := g.Config.Run()
+	stdout, stderr, exitCode, err := g.Config.Command.Run()
 	if err != nil {
-		return fmt.Errorf("running %s failed: %s, exit=%d stderr=%q", g.Config.CommandString(), err, exitCode, stderr)
+		return fmt.Errorf("running %s failed: %s, exit=%d stderr=%q", g.Config.Command.CommandString(), err, exitCode, stderr)
 	}
 
 	outBuffer := bufio.NewReader(strings.NewReader(stdout))
@@ -134,7 +134,7 @@ func (g *pluginGenerator) loadPluginMeta() error {
 
 	headerLine, err := outBuffer.ReadString('\n')
 	if err != nil {
-		return fmt.Errorf("while reading the first line of command %s: %s", g.Config.CommandString(), err)
+		return fmt.Errorf("while reading the first line of command %s: %s", g.Config.Command.CommandString(), err)
 	}
 
 	// Parse the header line of format:
@@ -216,13 +216,13 @@ var delimReg = regexp.MustCompile(`[\s\t]+`)
 
 func (g *pluginGenerator) collectValues() (Values, error) {
 	os.Setenv(pluginConfigurationEnvName, "")
-	stdout, stderr, _, err := g.Config.Run()
+	stdout, stderr, _, err := g.Config.Command.Run()
 
 	if stderr != "" {
-		pluginLogger.Infof("command %s outputted to STDERR: %q", g.Config.CommandString(), stderr)
+		pluginLogger.Infof("command %s outputted to STDERR: %q", g.Config.Command.CommandString(), stderr)
 	}
 	if err != nil {
-		pluginLogger.Errorf("Failed to execute command %s (skip these metrics):\n", g.Config.CommandString())
+		pluginLogger.Errorf("Failed to execute command %s (skip these metrics):\n", g.Config.Command.CommandString())
 		return nil, err
 	}
 

--- a/metrics/plugin_test.go
+++ b/metrics/plugin_test.go
@@ -19,7 +19,7 @@ func containsKeyRegexp(values Values, reg string) bool {
 
 func TestPluginGenerate(t *testing.T) {
 	conf := &config.MetricPlugin{
-		Command: "ruby ../example/metrics-plugins/dice.rb",
+		Command: config.Command{Cmd: "ruby ../example/metrics-plugins/dice.rb"},
 	}
 	g := &pluginGenerator{Config: conf}
 	values, err := g.Generate()
@@ -34,7 +34,7 @@ func TestPluginGenerate(t *testing.T) {
 
 func TestPluginCollectValues(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
-		Command: "ruby ../example/metrics-plugins/dice.rb",
+		Command: config.Command{Cmd: "ruby ../example/metrics-plugins/dice.rb"},
 	},
 	}
 	values, err := g.collectValues()
@@ -48,7 +48,7 @@ func TestPluginCollectValues(t *testing.T) {
 
 func TestPluginCollectValuesWithIncludePattern(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
-		Command:        "ruby ../example/metrics-plugins/dice-with-meta.rb",
+		Command:        config.Command{Cmd: "ruby ../example/metrics-plugins/dice-with-meta.rb"},
 		IncludePattern: regexp.MustCompile(`^dice\.d6`),
 	},
 	}
@@ -66,7 +66,7 @@ func TestPluginCollectValuesWithIncludePattern(t *testing.T) {
 
 func TestPluginCollectValuesWithExcludePattern(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
-		Command:        "ruby ../example/metrics-plugins/dice-with-meta.rb",
+		Command:        config.Command{Cmd: "ruby ../example/metrics-plugins/dice-with-meta.rb"},
 		ExcludePattern: regexp.MustCompile(`^dice\.d20`),
 	},
 	}
@@ -84,7 +84,7 @@ func TestPluginCollectValuesWithExcludePattern(t *testing.T) {
 
 func TestPluginCollectValuesWithBothPattern(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
-		Command:        "ruby ../example/metrics-plugins/dice-with-meta.rb",
+		Command:        config.Command{Cmd: "ruby ../example/metrics-plugins/dice-with-meta.rb"},
 		IncludePattern: regexp.MustCompile(`^dice\.d20`),
 		ExcludePattern: regexp.MustCompile(`^dice\.d20`),
 	},

--- a/metrics/plugin_unix_test.go
+++ b/metrics/plugin_unix_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPluginCollectValuesCommand(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
-		Command: "echo \"just.echo.1\t1\t1397822016\"",
+		Command: config.Command{Cmd: "echo \"just.echo.1\t1\t1397822016\""},
 	},
 	}
 
@@ -35,7 +35,7 @@ func TestPluginCollectValuesCommand(t *testing.T) {
 
 func TestPluginCollectValuesCommandWithSpaces(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
-		Command: `echo "just.echo.2   2   1397822016"`,
+		Command: config.Command{Cmd: `echo "just.echo.2   2   1397822016"`},
 	}}
 
 	values, err := g.collectValues()
@@ -60,7 +60,7 @@ func TestPluginCollectValuesCommandWithSpaces(t *testing.T) {
 func TestPluginLoadPluginMeta(t *testing.T) {
 	g := &pluginGenerator{
 		Config: &config.MetricPlugin{
-			Command: `echo '# mackerel-agent-plugin version=1
+			Command: config.Command{Cmd: `echo '# mackerel-agent-plugin version=1
 {
   "graphs": {
     "query": {
@@ -95,6 +95,7 @@ func TestPluginLoadPluginMeta(t *testing.T) {
   }
 }
 '`,
+			},
 		},
 	}
 
@@ -116,7 +117,7 @@ func TestPluginLoadPluginMeta(t *testing.T) {
 
 	generatorWithoutConf := &pluginGenerator{
 		Config: &config.MetricPlugin{
-			Command: "echo \"just.echo.1\t1\t1397822016\"",
+			Command: config.Command{Cmd: "echo \"just.echo.1\t1\t1397822016\""},
 		},
 	}
 
@@ -127,7 +128,7 @@ func TestPluginLoadPluginMeta(t *testing.T) {
 
 	generatorWithBadVersion := &pluginGenerator{
 		Config: &config.MetricPlugin{
-			Command: `echo "# mackerel-agent-plugin version=666"`,
+			Command: config.Command{Cmd: `echo "# mackerel-agent-plugin version=666"`},
 		},
 	}
 

--- a/metrics/plugin_windows_test.go
+++ b/metrics/plugin_windows_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPluginCollectValuesCommand(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
-		Command: "echo just.echo.1	1	1397822016",
+		Command: config.Command{Cmd: "echo just.echo.1	1	1397822016"},
 	},
 	}
 
@@ -35,7 +35,7 @@ func TestPluginCollectValuesCommand(t *testing.T) {
 
 func TestPluginCollectValuesCommandWithSpaces(t *testing.T) {
 	g := &pluginGenerator{Config: &config.MetricPlugin{
-		Command: `echo just.echo.2   2   1397822016`,
+		Command: config.Command{Cmd: `echo just.echo.2   2   1397822016`},
 	}}
 
 	values, err := g.collectValues()
@@ -60,7 +60,7 @@ func TestPluginCollectValuesCommandWithSpaces(t *testing.T) {
 func TestPluginLoadPluginMeta(t *testing.T) {
 	g := &pluginGenerator{
 		Config: &config.MetricPlugin{
-			Command: "ruby ../example/metrics-plugins/dice-with-meta.rb",
+			Command: config.Command{Cmd: "ruby ../example/metrics-plugins/dice-with-meta.rb"},
 		},
 	}
 
@@ -79,7 +79,7 @@ func TestPluginLoadPluginMeta(t *testing.T) {
 
 	generatorWithoutConf := &pluginGenerator{
 		Config: &config.MetricPlugin{
-			Command: "echo just.echo.1	1	1397822016",
+			Command: config.Command{Cmd: "echo just.echo.1	1	1397822016"},
 		},
 	}
 
@@ -90,7 +90,7 @@ func TestPluginLoadPluginMeta(t *testing.T) {
 
 	generatorWithBadVersion := &pluginGenerator{
 		Config: &config.MetricPlugin{
-			Command: `echo # mackerel-agent-plugin version=666`,
+			Command: config.Command{Cmd: `echo # mackerel-agent-plugin version=666`},
 		},
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"time"
@@ -27,13 +28,13 @@ func init() {
 }
 
 // RunCommand runs command (in two string) and returns stdout, stderr strings and its exit code.
-func RunCommand(command, user string) (stdout, stderr string, exitCode int, err error) {
+func RunCommand(command, user string, env []string) (stdout, stderr string, exitCode int, err error) {
 	cmdArgs := append(cmdBase, command)
-	return RunCommandArgs(cmdArgs, user)
+	return RunCommandArgs(cmdArgs, user, env)
 }
 
 // RunCommandArgs run the command
-func RunCommandArgs(cmdArgs []string, user string) (stdout, stderr string, exitCode int, err error) {
+func RunCommandArgs(cmdArgs []string, user string, env []string) (stdout, stderr string, exitCode int, err error) {
 	args := append([]string{}, cmdArgs...)
 	if user != "" {
 		if runtime.GOOS == "windows" {
@@ -43,6 +44,7 @@ func RunCommandArgs(cmdArgs []string, user string) (stdout, stderr string, exitC
 		}
 	}
 	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Env = append(os.Environ(), env...)
 	tio := &timeout.Timeout{
 		Cmd:       cmd,
 		Duration:  TimeoutDuration,

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 func TestRunCommand(t *testing.T) {
-	stdout, stderr, exitCode, err := RunCommand("echo 1", "")
+	stdout, stderr, exitCode, err := RunCommand("echo 1", "", nil)
 	if runtime.GOOS == "windows" {
 		stdout = strings.Replace(stdout, "\r\n", "\n", -1)
 		stderr = strings.Replace(stderr, "\r\n", "\n", -1)
@@ -61,7 +61,7 @@ func TestRunCommandWithTimeout(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		command, tmpdir = makeSleep(t)
 	}
-	stdout, stderr, _, err := RunCommand(command, "")
+	stdout, stderr, _, err := RunCommand(command, "", nil)
 	if stdout != "" {
 		t.Errorf("stdout shoud be empty")
 	}
@@ -73,5 +73,30 @@ func TestRunCommandWithTimeout(t *testing.T) {
 	}
 	if tmpdir != "" {
 		os.RemoveAll(tmpdir)
+	}
+}
+
+func TestRunCommandWithEnv(t *testing.T) {
+	command := `echo $TEST_RUN_COMMAND_ENV`
+	if runtime.GOOS == "windows" {
+		command = `echo %TEST_RUN_COMMAND_ENV%`
+	}
+
+	stdout, stderr, exitCode, err := RunCommand(command, "", []string{"TEST_RUN_COMMAND_ENV=mackerel-agent"})
+	if runtime.GOOS == "windows" {
+		stdout = strings.Replace(stdout, "\r\n", "\n", -1)
+		stderr = strings.Replace(stderr, "\r\n", "\n", -1)
+	}
+	if stdout != "mackerel-agent\n" {
+		t.Errorf("stdout shoud be 1")
+	}
+	if stderr != "" {
+		t.Errorf("stderr shoud be empty")
+	}
+	if exitCode != 0 {
+		t.Errorf("exitCode should be zero")
+	}
+	if err != nil {
+		t.Error("err should be nil but:", err)
 	}
 }


### PR DESCRIPTION
Trigger action command after check plugin running with `MACKEREL_STATUS` and `MACKEREL_PREVIOUS_STATUS` environment variables. These values are one of `""` ,  `"OK"`,  `"WARNING"` , `"CRITICAL"` and `"UNKNOWN"`.

The following is a config example.
```
[plugin.checks.sample]
command = "ruby dice.rb"
action = { command = "bash -c '[ \"$MACKEREL_STATUS\" != \"$MACKEREL_PREVIOUS_STATUS\" ] && notify $MACKEREL_STATUS'", user = "someone" }
```