### PR TITLE
Improve implementation for memory spec on Linux

### DIFF
--- a/spec/linux/memory.go
+++ b/spec/linux/memory.go
@@ -74,8 +74,8 @@ func generateMemorySpec(out io.Reader) (map[string]string, error) {
 			continue
 		}
 		if k, ok := memItems[fields[0]]; ok {
-			// ex) MemTotal:        3916792 kB
-			//       -> "total": "3916782kB"
+			// ex) MemTotal:  3916792 kB
+			//   -> "total": "3916782kB"
 			result[k] = strings.Join(fields[1:], "")
 		}
 	}

--- a/spec/linux/memory.go
+++ b/spec/linux/memory.go
@@ -4,41 +4,42 @@ package linux
 
 import (
 	"bufio"
+	"io"
 	"os"
-	"regexp"
+	"strings"
 
 	"github.com/mackerelio/golib/logging"
 )
 
-var memItems = map[string]*regexp.Regexp{
-	"total":            regexp.MustCompile(`^MemTotal:\s+(\d+) (.+)$`),
-	"free":             regexp.MustCompile(`^MemFree:\s+(\d+) (.+)$`),
-	"buffers":          regexp.MustCompile(`^Buffers:\s+(\d+) (.+)$`),
-	"cached":           regexp.MustCompile(`^Cached:\s+(\d+) (.+)$`),
-	"active":           regexp.MustCompile(`^Active:\s+(\d+) (.+)$`),
-	"inactive":         regexp.MustCompile(`^Inactive:\s+(\d+) (.+)$`),
-	"high_total":       regexp.MustCompile(`^HighTotal:\s+(\d+) (.+)$`),
-	"high_free":        regexp.MustCompile(`^HighFree:\s+(\d+) (.+)$`),
-	"low_total":        regexp.MustCompile(`^LowTotal:\s+(\d+) (.+)$`),
-	"low_free":         regexp.MustCompile(`^LowFree:\s+(\d+) (.+)$`),
-	"dirty":            regexp.MustCompile(`^Dirty:\s+(\d+) (.+)$`),
-	"writeback":        regexp.MustCompile(`^Writeback:\s+(\d+) (.+)$`),
-	"anon_pages":       regexp.MustCompile(`^AnonPages:\s+(\d+) (.+)$`),
-	"mapped":           regexp.MustCompile(`^Mapped:\s+(\d+) (.+)$`),
-	"slab":             regexp.MustCompile(`^Slab:\s+(\d+) (.+)$`),
-	"slab_reclaimable": regexp.MustCompile(`^SReclaimable:\s+(\d+) (.+)$`),
-	"slab_unreclaim":   regexp.MustCompile(`^SUnreclaim:\s+(\d+) (.+)$`),
-	"page_tables":      regexp.MustCompile(`^PageTables:\s+(\d+) (.+)$`),
-	"nfs_unstable":     regexp.MustCompile(`^NFS_Unstable:\s+(\d+) (.+)$`),
-	"bounce":           regexp.MustCompile(`^Bounce:\s+(\d+) (.+)$`),
-	"commit_limit":     regexp.MustCompile(`^CommitLimit:\s+(\d+) (.+)$`),
-	"committed_as":     regexp.MustCompile(`^Committed_AS:\s+(\d+) (.+)$`),
-	"vmalloc_total":    regexp.MustCompile(`^VmallocTotal:\s+(\d+) (.+)$`),
-	"vmalloc_used":     regexp.MustCompile(`^VmallocUsed:\s+(\d+) (.+)$`),
-	"vmalloc_chunk":    regexp.MustCompile(`^VmallocChunk:\s+(\d+) (.+)$`),
-	"swap_cached":      regexp.MustCompile(`^SwapCached:\s+(\d+) (.+)$`),
-	"swap_total":       regexp.MustCompile(`^SwapTotal:\s+(\d+) (.+)$`),
-	"swap_free":        regexp.MustCompile(`^SwapFree:\s+(\d+) (.+)$`),
+var memItems = map[string]string{
+	"MemTotal:":     "total",
+	"MemFree:":      "free",
+	"Buffers:":      "buffers",
+	"Cached:":       "cached",
+	"Active:":       "active",
+	"Inactive:":     "inactive",
+	"HighTotal:":    "high_total",
+	"HighFree:":     "high_free",
+	"LowTotal:":     "low_total",
+	"LowFree:":      "low_free",
+	"Dirty:":        "dirty",
+	"Writeback:":    "writeback",
+	"AnonPages:":    "anon_pages",
+	"Mapped:":       "mapped",
+	"Slab:":         "slab",
+	"SReclaimable:": "slab_reclaimable",
+	"SUnreclaim:":   "slab_unreclaim",
+	"PageTables:":   "page_tables",
+	"NFS_Unstable:": "nfs_unstable",
+	"Bounce:":       "bounce",
+	"CommitLimit:":  "commit_limit",
+	"Committed_AS:": "committed_as",
+	"VmallocTotal:": "vmalloc_total",
+	"VmallocUsed:":  "vmalloc_used",
+	"VmallocChunk:": "vmalloc_chunk",
+	"SwapCached:":   "swap_cached",
+	"SwapTotal:":    "swap_total",
+	"SwapFree:":     "swap_free",
 }
 
 // MemoryGenerator collects the host's memory specs.
@@ -59,20 +60,23 @@ func (g *MemoryGenerator) Generate() (interface{}, error) {
 		memoryLogger.Errorf("Failed (skip this spec): %s", err)
 		return nil, err
 	}
+	defer file.Close()
+	return generateMemorySpec(file)
+}
 
-	scanner := bufio.NewScanner(file)
+func generateMemorySpec(out io.Reader) (map[string]string, error) {
+	scanner := bufio.NewScanner(out)
 
-	result := make(map[string]interface{})
+	result := make(map[string]string)
 	for scanner.Scan() {
-		line := scanner.Text()
-
-		for k, v := range memItems {
-			if matches := v.FindStringSubmatch(line); matches != nil {
-				// ex.) MemTotal:        3916792 kB
-				// matches[1] = 3916792, matches[2] = kB
-				result[k] = matches[1] + matches[2]
-				break
-			}
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		if k, ok := memItems[fields[0]]; ok {
+			// ex) MemTotal:        3916792 kB
+			//       -> "total": "3916782kB"
+			result[k] = strings.Join(fields[1:], "")
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/spec/linux/memory_test.go
+++ b/spec/linux/memory_test.go
@@ -3,6 +3,8 @@
 package linux
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -21,7 +23,7 @@ func TestMemoryGenerator(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	memory, typeOk := value.(map[string]interface{})
+	memory, typeOk := value.(map[string]string)
 	if !typeOk {
 		t.Errorf("value should be map. %+v", value)
 	}
@@ -57,5 +59,86 @@ func TestMemoryGenerator(t *testing.T) {
 		if _, ok := memory[key]; !ok {
 			t.Errorf("memory spec should have %s", key)
 		}
+	}
+}
+
+func TestGenerateMemorySpec(t *testing.T) {
+	got, err := generateMemorySpec(strings.NewReader(
+		`MemTotal:       15434208 kB
+MemFree:         3009856 kB
+MemAvailable:   10008916 kB
+Buffers:          443104 kB
+Cached:          6305168 kB
+SwapCached:            0 kB
+Active:          7662608 kB
+Inactive:        3375044 kB
+Active(anon):    4474764 kB
+Inactive(anon):   276180 kB
+Active(file):    3187844 kB
+Inactive(file):  3098864 kB
+Unevictable:           0 kB
+Mlocked:               0 kB
+SwapTotal:             0 kB
+SwapFree:              0 kB
+Dirty:               516 kB
+Writeback:             0 kB
+AnonPages:       4289480 kB
+Mapped:           258168 kB
+Shmem:            461560 kB
+Slab:            1169796 kB
+SReclaimable:     965756 kB
+SUnreclaim:       204040 kB
+KernelStack:       42688 kB
+PageTables:        61024 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:     7717104 kB
+Committed_AS:   23796544 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:       42608 kB
+VmallocChunk:   34359578580 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:       65536 kB
+DirectMap2M:     3211264 kB
+DirectMap1G:    12582912 kB
+`))
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	expected := map[string]string{
+		"total":            "15434208kB",
+		"free":             "3009856kB",
+		"buffers":          "443104kB",
+		"cached":           "6305168kB",
+		"active":           "7662608kB",
+		"inactive":         "3375044kB",
+		"dirty":            "516kB",
+		"writeback":        "0kB",
+		"anon_pages":       "4289480kB",
+		"mapped":           "258168kB",
+		"slab":             "1169796kB",
+		"slab_reclaimable": "965756kB",
+		"slab_unreclaim":   "204040kB",
+		"page_tables":      "61024kB",
+		"nfs_unstable":     "0kB",
+		"bounce":           "0kB",
+		"commit_limit":     "7717104kB",
+		"committed_as":     "23796544kB",
+		"vmalloc_total":    "34359738367kB",
+		"vmalloc_used":     "42608kB",
+		"vmalloc_chunk":    "34359578580kB",
+		"swap_cached":      "0kB",
+		"swap_total":       "0kB",
+		"swap_free":        "0kB",
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("invalid memory stat: %+v (expected: %+v)", got, expected)
 	}
 }

--- a/spec/linux/memory_test.go
+++ b/spec/linux/memory_test.go
@@ -26,115 +26,36 @@ func TestMemoryGenerator(t *testing.T) {
 		t.Errorf("value should be map. %+v", value)
 	}
 
-	if _, ok := memory["total"]; !ok {
-		t.Error("memory should has total")
+	memItemKeys := []string{
+		"total",
+		"free",
+		"buffers",
+		"cached",
+		"active",
+		"inactive",
+		"dirty",
+		"writeback",
+		"anon_pages",
+		"mapped",
+		"slab",
+		"slab_reclaimable",
+		"slab_unreclaim",
+		"page_tables",
+		"nfs_unstable",
+		"bounce",
+		"commit_limit",
+		"committed_as",
+		"vmalloc_total",
+		"vmalloc_used",
+		"vmalloc_chunk",
+		"swap_cached",
+		"swap_total",
+		"swap_free",
 	}
 
-	if _, ok := memory["free"]; !ok {
-		t.Error("memory should has free")
-	}
-
-	if _, ok := memory["buffers"]; !ok {
-		t.Error("memory should has buffers")
-	}
-
-	if _, ok := memory["cached"]; !ok {
-		t.Error("memory should has cached")
-	}
-
-	if _, ok := memory["active"]; !ok {
-		t.Error("memory should has active")
-	}
-
-	if _, ok := memory["inactive"]; !ok {
-		t.Error("memory should has inactive")
-	}
-
-	if _, ok := memory["high_total"]; !ok {
-		t.Log("Skip: memory should has high_total")
-	}
-
-	if _, ok := memory["high_free"]; !ok {
-		t.Log("Skip: memory should has high_free")
-	}
-
-	if _, ok := memory["low_total"]; !ok {
-		t.Log("Skip: memory should has low_tatal")
-	}
-
-	if _, ok := memory["low_free"]; !ok {
-		t.Log("Skip: memory should has low_free")
-	}
-
-	if _, ok := memory["dirty"]; !ok {
-		t.Error("memory should has dirty")
-	}
-
-	if _, ok := memory["writeback"]; !ok {
-		t.Error("memory should has writeback")
-	}
-
-	if _, ok := memory["anon_pages"]; !ok {
-		t.Error("memory should has anon_pages")
-	}
-
-	if _, ok := memory["mapped"]; !ok {
-		t.Error("memory should has mapped")
-	}
-
-	if _, ok := memory["slab"]; !ok {
-		t.Error("memory should has slab")
-	}
-
-	if _, ok := memory["slab_reclaimable"]; !ok {
-		t.Error("memory should has slab_reclaimable")
-	}
-
-	if _, ok := memory["slab_unreclaim"]; !ok {
-		t.Error("memory should has slab_unreclaim")
-	}
-
-	if _, ok := memory["page_tables"]; !ok {
-		t.Error("memory should has page_tables")
-	}
-
-	if _, ok := memory["nfs_unstable"]; !ok {
-		t.Error("memory should has nfs_unstable")
-	}
-
-	if _, ok := memory["bounce"]; !ok {
-		t.Error("memory should has bounce")
-	}
-
-	if _, ok := memory["commit_limit"]; !ok {
-		t.Error("memory should has commit_limmit")
-	}
-
-	if _, ok := memory["committed_as"]; !ok {
-		t.Error("memory should has committed_as")
-	}
-
-	if _, ok := memory["vmalloc_total"]; !ok {
-		t.Error("memory should has vmalloc_total")
-	}
-
-	if _, ok := memory["vmalloc_used"]; !ok {
-		t.Error("memory should has vmalloc_used")
-	}
-
-	if _, ok := memory["vmalloc_chunk"]; !ok {
-		t.Error("memory should has vmalloc_chunk")
-	}
-
-	if _, ok := memory["swap_cached"]; !ok {
-		t.Error("memory should has swap_cached")
-	}
-
-	if _, ok := memory["swap_total"]; !ok {
-		t.Error("memory should has swap_total")
-	}
-
-	if _, ok := memory["swap_free"]; !ok {
-		t.Error("memory should has swap_free")
+	for _, key := range memItemKeys {
+		if _, ok := memory[key]; !ok {
+			t.Errorf("memory spec should have %s", key)
+		}
 	}
 }


### PR DESCRIPTION
This pull request refactors spec/memory for Linux.

- Close file correctly
- Remove regexp to parse /proc/meminfo.
- Avoid nested loop and improve performance.
- Add a mock parsing test.