### PR TITLE
Improve kernel spec generator performance for Linux

### DIFF
--- a/spec/linux/kernel.go
+++ b/spec/linux/kernel.go
@@ -43,18 +43,18 @@ func (g *KernelGenerator) Generate() (interface{}, error) {
 		results[key] = str
 	}
 
-	hostInfo, err := host.Info()
+	platform, _, version, err := host.PlatformInformation()
 	if err != nil {
 		kernelLogger.Errorf("Failed to get platform information: %s", err)
 		return results, nil
 	}
 
-	if platformName := normalizePlatform(hostInfo.Platform); platformName != "" {
+	if platformName := normalizePlatform(platform); platformName != "" {
 		results["platform_name"] = platformName
 	}
 
-	if platformVersion := hostInfo.PlatformVersion; platformVersion != "" {
-		results["platform_version"] = platformVersion
+	if version != "" {
+		results["platform_version"] = version
 	}
 
 	return results, nil

--- a/spec/linux/kernel_test.go
+++ b/spec/linux/kernel_test.go
@@ -29,4 +29,14 @@ func TestKernelGenerate(t *testing.T) {
 	if len(kernel["name"]) == 0 {
 		t.Error("kernel.name should be filled")
 	}
+
+	if len(kernel["platform_name"]) == 0 {
+		t.Error("kernel.platform_name should be filled")
+	}
+
+	if len(kernel["platform_version"]) == 0 {
+		t.Error("kernel.platform_version should be filled")
+	}
+
+	t.Logf("kernel spec: %+v", kernel)
 }


### PR DESCRIPTION
This pull request refines the kernel spec generator for Linux. `host.Info()` is used to get the Linux distribution (introduced in #274). For this purpose, `host.PlatformInformation()` is enough to use. 
References:
- https://godoc.org/github.com/shirou/gopsutil/host#PlatformInformation
-
 https://github.com/shirou/gopsutil/blob/e30b7839cd6161b2fbef5f187377a345157abe04/host/host_linux.go#L33