### PR TITLE
Use go-osstat library on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ deps: generate
 	go get github.com/pierrre/gotestcover
 	go get github.com/laher/goxc
 	go get github.com/mattn/goveralls
-	go get github.com/mackerelio/go-osstat/... # to build darwin on TravisCI (can be deleted after we use go-osstat on linux)
 
 lint: deps
 	go tool vet -all -printfuncs=Criticalf,Infof,Warningf,Debugf,Tracef .

--- a/metrics/linux/cpuusage.go
+++ b/metrics/linux/cpuusage.go
@@ -44,6 +44,9 @@ func (g *CPUUsageGenerator) Generate() (metrics.Values, error) {
 	totalDiff := float64(current.Total - previous.Total)
 	cpuCount := float64(current.CPUCount)
 
+	// Since cpustat[CPUTIME_USER] includes cpustat[CPUTIME_GUEST], we subtract guest from user for the stacked graph of Mackerel.
+	// https://github.com/torvalds/linux/blob/4ec9f7a18/kernel/sched/cputime.c#L151-L158
+	// We should also subtract guest_nice from nice, but guest_nice is not supported in Mackerel yet.
 	ret := map[string]float64{
 		"cpu.user.percentage":    float64((current.User-current.Guest)-(previous.User-previous.Guest)) * cpuCount * 100.0 / totalDiff,
 		"cpu.nice.percentage":    float64(current.Nice-previous.Nice) * cpuCount * 100.0 / totalDiff,

--- a/metrics/linux/cpuusage.go
+++ b/metrics/linux/cpuusage.go
@@ -20,14 +20,14 @@ metric = "user", "nice", "system", "idle", "iowait", "irq", "softirq", "steal", 
 graph: stacks `cpu.{metric}.percentage`
 */
 
-// CPUUsageGenerator XXX
+// CPUUsageGenerator generates CPU metric values
 type CPUUsageGenerator struct {
 	Interval time.Duration
 }
 
 var cpuUsageLogger = logging.GetLogger("metrics.cpuUsage")
 
-// Generate XXX
+// Generate CPU metric values
 func (g *CPUUsageGenerator) Generate() (metrics.Values, error) {
 	before, err := g.collectProcStatValues()
 	if err != nil {

--- a/metrics/linux/cpuusage.go
+++ b/metrics/linux/cpuusage.go
@@ -48,18 +48,30 @@ func (g *CPUUsageGenerator) Generate() (metrics.Values, error) {
 	// https://github.com/torvalds/linux/blob/4ec9f7a18/kernel/sched/cputime.c#L151-L158
 	// We should also subtract guest_nice from nice, but guest_nice is not supported in Mackerel yet.
 	ret := map[string]float64{
-		"cpu.user.percentage":    float64((current.User-current.Guest)-(previous.User-previous.Guest)) * cpuCount * 100.0 / totalDiff,
-		"cpu.nice.percentage":    float64(current.Nice-previous.Nice) * cpuCount * 100.0 / totalDiff,
-		"cpu.system.percentage":  float64(current.System-previous.System) * cpuCount * 100.0 / totalDiff,
-		"cpu.idle.percentage":    float64(current.Idle-previous.Idle) * cpuCount * 100.0 / totalDiff,
-		"cpu.iowait.percentage":  float64(current.Iowait-previous.Iowait) * cpuCount * 100.0 / totalDiff,
-		"cpu.irq.percentage":     float64(current.Irq-previous.Irq) * cpuCount * 100.0 / totalDiff,
-		"cpu.softirq.percentage": float64(current.Softirq-previous.Softirq) * cpuCount * 100.0 / totalDiff,
-		"cpu.steal.percentage":   float64(current.Steal-previous.Steal) * cpuCount * 100.0 / totalDiff,
-		"cpu.guest.percentage":   float64(current.Guest-previous.Guest) * cpuCount * 100.0 / totalDiff,
-		// guest_nice is not yet supported in Mackerel
-		// "cpu.guest_nice.percentage": float64(current.GuestNice - previous.GuestNice) * cpuCount * 100.0 / totalDiff,
+		"cpu.user.percentage":   float64((current.User-current.Guest)-(previous.User-previous.Guest)) * cpuCount * 100.0 / totalDiff,
+		"cpu.nice.percentage":   float64(current.Nice-previous.Nice) * cpuCount * 100.0 / totalDiff,
+		"cpu.system.percentage": float64(current.System-previous.System) * cpuCount * 100.0 / totalDiff,
+		"cpu.idle.percentage":   float64(current.Idle-previous.Idle) * cpuCount * 100.0 / totalDiff,
 	}
+	if current.StatCount >= 5 {
+		ret["cpu.iowait.percentage"] = float64(current.Iowait-previous.Iowait) * cpuCount * 100.0 / totalDiff
+	}
+	if current.StatCount >= 6 {
+		ret["cpu.irq.percentage"] = float64(current.Irq-previous.Irq) * cpuCount * 100.0 / totalDiff
+	}
+	if current.StatCount >= 7 {
+		ret["cpu.softirq.percentage"] = float64(current.Softirq-previous.Softirq) * cpuCount * 100.0 / totalDiff
+	}
+	if current.StatCount >= 8 {
+		ret["cpu.steal.percentage"] = float64(current.Steal-previous.Steal) * cpuCount * 100.0 / totalDiff
+	}
+	if current.StatCount >= 9 {
+		ret["cpu.guest.percentage"] = float64(current.Guest-previous.Guest) * cpuCount * 100.0 / totalDiff
+	}
+	// guest_nice is not yet supported in Mackerel
+	// if current.StatCount >= 10 {
+	// 	ret["cpu.guest_nice.percentage"]=   float64(current.GuestNice - previous.GuestNice) * cpuCount * 100.0 / totalDiff
+	// }
 	return metrics.Values(ret), nil
 }
 

--- a/metrics/linux/cpuusage.go
+++ b/metrics/linux/cpuusage.go
@@ -29,32 +29,33 @@ var cpuUsageLogger = logging.GetLogger("metrics.cpuUsage")
 
 // Generate CPU metric values
 func (g *CPUUsageGenerator) Generate() (metrics.Values, error) {
-	before, err := g.collectProcStatValues()
+	previous, err := g.collectProcStatValues()
 	if err != nil {
 		return nil, err
 	}
 
 	time.Sleep(g.Interval)
 
-	after, err := g.collectProcStatValues()
+	current, err := g.collectProcStatValues()
 	if err != nil {
 		return nil, err
 	}
 
-	totalDiff := float64(after.Total - before.Total)
-	cpuCount := float64(after.CPUCount)
+	totalDiff := float64(current.Total - previous.Total)
+	cpuCount := float64(current.CPUCount)
 
 	ret := map[string]float64{
-		"cpu.user.percentage":    float64((after.User-after.Guest)-(before.User-before.Guest)) * cpuCount * 100.0 / totalDiff,
-		"cpu.nice.percentage":    float64(after.Nice-before.Nice) * cpuCount * 100.0 / totalDiff,
-		"cpu.system.percentage":  float64(after.System-before.System) * cpuCount * 100.0 / totalDiff,
-		"cpu.idle.percentage":    float64(after.Idle-before.Idle) * cpuCount * 100.0 / totalDiff,
-		"cpu.iowait.percentage":  float64(after.Iowait-before.Iowait) * cpuCount * 100.0 / totalDiff,
-		"cpu.irq.percentage":     float64(after.Irq-before.Irq) * cpuCount * 100.0 / totalDiff,
-		"cpu.softirq.percentage": float64(after.Softirq-before.Softirq) * cpuCount * 100.0 / totalDiff,
-		"cpu.steal.percentage":   float64(after.Steal-before.Steal) * cpuCount * 100.0 / totalDiff,
-		"cpu.guest.percentage":   float64(after.Guest-before.Guest) * cpuCount * 100.0 / totalDiff,
-		// "cpu.guest_nice.percentage": float64(after.GuestNice - before.GuestNice) * cpuCount * 100.0 / totalDiff,
+		"cpu.user.percentage":    float64((current.User-current.Guest)-(previous.User-previous.Guest)) * cpuCount * 100.0 / totalDiff,
+		"cpu.nice.percentage":    float64(current.Nice-previous.Nice) * cpuCount * 100.0 / totalDiff,
+		"cpu.system.percentage":  float64(current.System-previous.System) * cpuCount * 100.0 / totalDiff,
+		"cpu.idle.percentage":    float64(current.Idle-previous.Idle) * cpuCount * 100.0 / totalDiff,
+		"cpu.iowait.percentage":  float64(current.Iowait-previous.Iowait) * cpuCount * 100.0 / totalDiff,
+		"cpu.irq.percentage":     float64(current.Irq-previous.Irq) * cpuCount * 100.0 / totalDiff,
+		"cpu.softirq.percentage": float64(current.Softirq-previous.Softirq) * cpuCount * 100.0 / totalDiff,
+		"cpu.steal.percentage":   float64(current.Steal-previous.Steal) * cpuCount * 100.0 / totalDiff,
+		"cpu.guest.percentage":   float64(current.Guest-previous.Guest) * cpuCount * 100.0 / totalDiff,
+		// guest_nice is not yet supported in Mackerel
+		// "cpu.guest_nice.percentage": float64(current.GuestNice - previous.GuestNice) * cpuCount * 100.0 / totalDiff,
 	}
 	return metrics.Values(ret), nil
 }

--- a/metrics/linux/cpuusage.go
+++ b/metrics/linux/cpuusage.go
@@ -3,13 +3,9 @@
 package linux
 
 import (
-	"bufio"
-	"os"
-	"regexp"
-	"strconv"
-	"strings"
 	"time"
 
+	"github.com/mackerelio/go-osstat/cpu"
 	"github.com/mackerelio/golib/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 )
@@ -22,20 +18,6 @@ collect CPU usage
 metric = "user", "nice", "system", "idle", "iowait", "irq", "softirq", "steal", "guest"
 
 graph: stacks `cpu.{metric}.percentage`
-
-cat /proc/stat sample: {{{
-	cpu  7792253 5479 4851396 18056319678 127239 0 146818 2383839
-	cpu0 5385397 1412 1970781 4509432750 103260 0 136689 876389
-	cpu1 641247 1361 782257 4516019361 7247 0 2403 452803
-	cpu2 652342 1366 617100 4516172153 7762 0 2447 453509
-	cpu3 1113265 1339 1481257 4514695413 8968 0 5278 601135
-	intr 6664031039 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3682869251 40969382 60 304 40427429 141 567698585 39988217 145 500771676 67725387 95 1170166889 187 33636967 83463 519692861 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-	ctxt 14007527061
-	btime 1349954031
-	processes 60807520
-	procs_running 1
-	procs_blocked 0
-}}}
 */
 
 // CPUUsageGenerator XXX
@@ -43,95 +25,46 @@ type CPUUsageGenerator struct {
 	Interval time.Duration
 }
 
-// In additions these metrics, collect *.percentage metrics
-var cpuUsageMetricNames = []string{
-	"cpu.user", "cpu.nice", "cpu.system", "cpu.idle", "cpu.iowait",
-	"cpu.irq", "cpu.softirq", "cpu.steal", "cpu.guest",
-}
-
-var cpuNumberPattern = regexp.MustCompile(`^cpu\d+\s`)
-
 var cpuUsageLogger = logging.GetLogger("metrics.cpuUsage")
 
 // Generate XXX
 func (g *CPUUsageGenerator) Generate() (metrics.Values, error) {
-	prevValues, prevTotal, _, err := g.collectProcStatValues()
+	before, err := g.collectProcStatValues()
 	if err != nil {
 		return nil, err
 	}
 
 	time.Sleep(g.Interval)
 
-	currValues, currTotal, cpuCount, err := g.collectProcStatValues()
+	after, err := g.collectProcStatValues()
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make(map[string]float64)
-	for i, name := range cpuUsageMetricNames {
-		// Values in /proc/stat differ in Linux kernel versions.
-		// Not all metrics in cpuUsageMetricNames can be retrieved.
-		// ref: `man 5 proc`
-		if i >= len(currValues) || i >= len(prevValues) {
-			break
-		}
+	totalDiff := float64(after.Total - before.Total)
+	cpuCount := float64(after.CPUCount)
 
-		// percentage of increased amount of CPU time
-		ret[name+".percentage"] = (currValues[i] - prevValues[i]) * 100.0 * float64(cpuCount) / (currTotal - prevTotal)
+	ret := map[string]float64{
+		"cpu.user.percentage":    float64((after.User-after.Guest)-(before.User-before.Guest)) * cpuCount * 100.0 / totalDiff,
+		"cpu.nice.percentage":    float64(after.Nice-before.Nice) * cpuCount * 100.0 / totalDiff,
+		"cpu.system.percentage":  float64(after.System-before.System) * cpuCount * 100.0 / totalDiff,
+		"cpu.idle.percentage":    float64(after.Idle-before.Idle) * cpuCount * 100.0 / totalDiff,
+		"cpu.iowait.percentage":  float64(after.Iowait-before.Iowait) * cpuCount * 100.0 / totalDiff,
+		"cpu.irq.percentage":     float64(after.Irq-before.Irq) * cpuCount * 100.0 / totalDiff,
+		"cpu.softirq.percentage": float64(after.Softirq-before.Softirq) * cpuCount * 100.0 / totalDiff,
+		"cpu.steal.percentage":   float64(after.Steal-before.Steal) * cpuCount * 100.0 / totalDiff,
+		"cpu.guest.percentage":   float64(after.Guest-before.Guest) * cpuCount * 100.0 / totalDiff,
+		// "cpu.guest_nice.percentage": float64(after.GuestNice - before.GuestNice) * cpuCount * 100.0 / totalDiff,
 	}
-
 	return metrics.Values(ret), nil
 }
 
 // returns values corresponding to cpuUsageMetricNames, those total and the number of CPUs
-func (g *CPUUsageGenerator) collectProcStatValues() ([]float64, float64, uint, error) {
-	file, err := os.Open("/proc/stat")
+func (g *CPUUsageGenerator) collectProcStatValues() (*cpu.Stats, error) {
+	cpu, err := cpu.Get()
 	if err != nil {
-		cpuUsageLogger.Errorf("Failed (skip these metrics): %s", err)
-		return nil, 0, 0, err
+		cpuUsageLogger.Errorf("failed to get cpu statistics: %s", err)
+		return nil, err
 	}
-
-	lineScanner := bufio.NewScanner(bufio.NewReader(file))
-
-	var cols []string
-	var cpuCount uint
-	firstLine := true
-
-	for lineScanner.Scan() {
-		line := lineScanner.Text()
-
-		if firstLine {
-			// first line contains total values of all CPUs
-			cols = strings.Fields(lineScanner.Text())[1:]
-			firstLine = false
-		} else if cpuNumberPattern.MatchString(line) {
-			// number of cores
-			cpuCount++
-		} else {
-			break
-		}
-	}
-
-	values := make([]float64, len(cols))
-
-	var totalValues float64
-	for i, strValue := range cols {
-		values[i], err = strconv.ParseFloat(strValue, 64)
-		if err != nil {
-			cpuUsageLogger.Errorf("Failed to parse cpuUsage metrics (skip these metrics): %s", err)
-			return nil, 0, 0, err
-		}
-		totalValues += values[i]
-	}
-
-	// Since cpustat[CPUTIME_USER] includes cpustat[CPUTIME_GUEST], subtract the duplicated values from total.
-	// https://github.com/torvalds/linux/blob/4ec9f7a18/kernel/sched/cputime.c#L151-L158
-	// https://github.com/mackerelio/mackerel-agent/issues/419
-	if len(values) >= 9 {
-		totalValues -= values[8]
-		// Also, subtract guest from user.
-		values[0] -= values[8]
-	}
-
-	return values, totalValues, cpuCount, nil
+	return cpu, nil
 }

--- a/metrics/linux/cpuusage_test.go
+++ b/metrics/linux/cpuusage_test.go
@@ -4,8 +4,6 @@ package linux
 
 import (
 	"math"
-)
-import (
 	"testing"
 	"time"
 )

--- a/metrics/linux/cpuusage_test.go
+++ b/metrics/linux/cpuusage_test.go
@@ -14,16 +14,18 @@ func TestCPUUsageGenerate(t *testing.T) {
 	g := &CPUUsageGenerator{1 * time.Second}
 	values, _ := g.Generate()
 
+	var metricNames = []string{
+		"user", "nice", "system", "idle", "iowait",
+		"irq", "softirq", "steal", "guest",
+	}
+
 	sumPercentage := float64(0)
-	for _, metricName := range cpuUsageMetricNames {
-		metricName += ".percentage"
+	for _, name := range metricNames {
+		metricName := "cpu." + name + ".percentage"
 		value, ok := values[metricName]
 		if !ok {
-			t.Errorf("CPUUsageGenerator should generate metric value for '%s'", metricName)
-		} else {
-			t.Logf("CPUUsage '%s' collected: %+v", metricName, value)
+			t.Errorf("cpu values shuold have '%s': %v", metricName, values)
 		}
-
 		sumPercentage += value
 	}
 
@@ -35,10 +37,5 @@ func TestCPUUsageGenerate(t *testing.T) {
 		t.Logf("Sum of CPU usage percentage values: %f", sumPercentage)
 	}
 
-	// Checks any errors will not occure
-	// when the number of retrieved values from /proc/spec is less than length of cpuUsageMetricNames
-	cpuUsageMetricNames = append(cpuUsageMetricNames, "unimplemented-new-metric")
-	defer func() { cpuUsageMetricNames = cpuUsageMetricNames[0 : len(cpuUsageMetricNames)-1] }()
-
-	g.Generate()
+	t.Logf("cpu metric metrics: %+v", values)
 }

--- a/metrics/linux/interface.go
+++ b/metrics/linux/interface.go
@@ -21,7 +21,7 @@ interface = "eth0", "eth1" and so on...
 see interface_test.go for sample input/output
 */
 
-// InterfaceGenerator XXX
+// InterfaceGenerator generates interface metric values
 type InterfaceGenerator struct {
 	Interval time.Duration
 }
@@ -38,7 +38,7 @@ var postInterfaceMetricsRegexp = regexp.MustCompile(`^interface\..+\.(?:rxBytes|
 
 var interfaceLogger = logging.GetLogger("metrics.interface")
 
-// Generate XXX
+// Generate interface metric values
 func (g *InterfaceGenerator) Generate() (metrics.Values, error) {
 	prevValues, err := g.collectInterfacesValues()
 	if err != nil {

--- a/metrics/linux/interface.go
+++ b/metrics/linux/interface.go
@@ -18,8 +18,6 @@ collect network interface I/O
 `interface.{interface}.{metric}.delta`: The increased amount of network I/O per minute retrieved from /proc/net/dev
 
 interface = "eth0", "eth1" and so on...
-
-see interface_test.go for sample input/output
 */
 
 // InterfaceGenerator generates interface metric values

--- a/metrics/linux/interface.go
+++ b/metrics/linux/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mackerelio/go-osstat/network"
 	"github.com/mackerelio/golib/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
+	"github.com/mackerelio/mackerel-agent/util"
 )
 
 /*
@@ -73,8 +74,9 @@ func (g *InterfaceGenerator) collectInterfacesValues() (map[string]uint64, error
 	}
 	results := make(map[string]uint64, len(networks)*2)
 	for _, network := range networks {
-		results["interface."+network.Name+".rxBytes"] = network.RxBytes
-		results["interface."+network.Name+".txBytes"] = network.TxBytes
+		name := util.SanitizeMetricKey(network.Name)
+		results["interface."+name+".rxBytes"] = network.RxBytes
+		results["interface."+name+".txBytes"] = network.TxBytes
 	}
 	return results, nil
 }

--- a/metrics/linux/interface_test.go
+++ b/metrics/linux/interface_test.go
@@ -3,94 +3,30 @@
 package linux
 
 import (
-	"os"
-	"reflect"
 	"testing"
 	"time"
-
-	"github.com/mackerelio/mackerel-agent/metrics"
 )
 
 func TestInterfaceGenerator(t *testing.T) {
-	if _, err := os.Stat("/etc/fedora-release"); err == nil {
-		t.Skip("The OS seems to be Fedora. Skipping interface test for now")
-	}
-
 	g := &InterfaceGenerator{1 * time.Second}
 	values, err := g.Generate()
 	if err != nil {
-		t.Errorf("should not raise error: %v", err)
+		t.Errorf("error should be nil but got: %s", err)
 	}
 
-	metrics := []string{
-		"rxBytes", "txBytes",
-	}
+	metrics := []string{"rxBytes", "txBytes"}
 
 	for _, metric := range metrics {
-		if value, ok := values["interface.eth0."+metric+".delta"]; !ok {
+		if _, ok := values["interface.eth0."+metric+".delta"]; !ok {
 			t.Errorf("Value for interface.eth0.%s.delta should be collected", metric)
-		} else {
-			t.Logf("Interface eth0 '%s' delta collected: %+v", metric, value)
 		}
 	}
 
 	for _, metric := range metrics {
 		if _, ok := values["interface.lo."+metric+".delta"]; ok {
 			t.Errorf("Value for interface.lo.%s should NOT be collected", metric)
-		} else {
-			t.Logf("Interface lo '%s' NOT collected", metric)
 		}
 	}
-}
 
-func TestParseNetdev(t *testing.T) {
-	out := []byte(`Inter-|   Receive                                                |  Transmit
- face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
-eth0: 5461472598 24386569    0    2    0     0          0         0 7215710422 6079810    0    0    0     0       0          0
-lo: 7779878638 1952628    0    0    0     0          0         0 7779878638 1952628    0    0    0     0       0          0
-docker0: 250219988  333736    0    0    0     0          0         0 2024726607 1409929    0    0    0     0       0          0`)
-
-	result, err := parseNetdev(out)
-	if err != nil {
-		t.Errorf("error should be nil but: %s", err)
-	}
-
-	expect := metrics.Values{
-		"interface.eth0.rxBytes":         5461472598,
-		"interface.eth0.rxPackets":       24386569,
-		"interface.eth0.rxErrors":        0,
-		"interface.eth0.rxDrops":         2,
-		"interface.eth0.rxFifo":          0,
-		"interface.eth0.rxFrame":         0,
-		"interface.eth0.rxCompressed":    0,
-		"interface.eth0.rxMulticast":     0,
-		"interface.eth0.txBytes":         7215710422,
-		"interface.eth0.txPackets":       6079810,
-		"interface.eth0.txErrors":        0,
-		"interface.eth0.txDrops":         0,
-		"interface.eth0.txFifo":          0,
-		"interface.eth0.txColls":         0,
-		"interface.eth0.txCarrier":       0,
-		"interface.eth0.txCompressed":    0,
-		"interface.docker0.rxBytes":      250219988,
-		"interface.docker0.rxPackets":    333736,
-		"interface.docker0.rxErrors":     0,
-		"interface.docker0.rxDrops":      0,
-		"interface.docker0.rxFifo":       0,
-		"interface.docker0.rxFrame":      0,
-		"interface.docker0.rxCompressed": 0,
-		"interface.docker0.rxMulticast":  0,
-		"interface.docker0.txBytes":      2024726607,
-		"interface.docker0.txPackets":    1409929,
-		"interface.docker0.txErrors":     0,
-		"interface.docker0.txDrops":      0,
-		"interface.docker0.txFifo":       0,
-		"interface.docker0.txColls":      0,
-		"interface.docker0.txCarrier":    0,
-		"interface.docker0.txCompressed": 0,
-	}
-
-	if !reflect.DeepEqual(result, expect) {
-		t.Errorf("result is not expected one: %+v", result)
-	}
+	t.Logf("interface metrics: %+v", values)
 }

--- a/metrics/linux/loadavg5.go
+++ b/metrics/linux/loadavg5.go
@@ -3,21 +3,13 @@
 package linux
 
 import (
-	"io/ioutil"
-	"strconv"
-	"strings"
-
+	"github.com/mackerelio/go-osstat/loadavg"
 	"github.com/mackerelio/golib/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 )
 
-/*
-collect load average
-
-`loadavg5`: load average per 5 minutes retrieved from /proc/loadavg
-
-graph: `loadavg5`
-*/
+// loadavg5
+//   - loadavg5: load average per 5 minutes
 
 // Loadavg5Generator XXX
 type Loadavg5Generator struct {
@@ -25,21 +17,12 @@ type Loadavg5Generator struct {
 
 var loadavg5Logger = logging.GetLogger("metrics.loadavg5")
 
-// Generate XXX
+// Generate load averages
 func (g *Loadavg5Generator) Generate() (metrics.Values, error) {
-	contentbytes, err := ioutil.ReadFile("/proc/loadavg")
+	loadavgs, err := loadavg.Get()
 	if err != nil {
-		loadavg5Logger.Errorf("Failed (skip these metrics): %s", err)
+		loadavg5Logger.Errorf("%s", err)
 		return nil, err
 	}
-	content := string(contentbytes)
-	cols := strings.Split(content, " ")
-
-	f, err := strconv.ParseFloat(cols[1], 64)
-	if err != nil {
-		loadavg5Logger.Errorf("Failed to parse loadavg5 metrics (skip these metrics): %s", err)
-		return nil, err
-	}
-
-	return metrics.Values{"loadavg5": f}, nil
+	return metrics.Values{"loadavg5": loadavgs.Loadavg5}, nil
 }

--- a/metrics/linux/loadavg5.go
+++ b/metrics/linux/loadavg5.go
@@ -11,7 +11,7 @@ import (
 // loadavg5
 //   - loadavg5: load average per 5 minutes
 
-// Loadavg5Generator XXX
+// Loadavg5Generator generates load average values
 type Loadavg5Generator struct {
 }
 

--- a/metrics/linux/loadavg5_test.go
+++ b/metrics/linux/loadavg5_test.go
@@ -5,9 +5,19 @@ package linux
 import "testing"
 
 func TestLoadAvg5Generate(t *testing.T) {
-	_, err := (&Loadavg5Generator{}).Generate()
+	g := &Loadavg5Generator{}
+	values, err := g.Generate()
 
 	if err != nil {
-		t.Errorf("something went wrong")
+		t.Errorf("error should be nil but got: %s", err)
 	}
+
+	metricName := []string{"loadavg5"}
+	for _, n := range metricName {
+		if _, ok := values[n]; !ok {
+			t.Errorf("loadavg5 metrics should have '%s': %v", n, values)
+		}
+	}
+
+	t.Logf("loadavg5 metrics: %+v", values)
 }

--- a/metrics/linux/memory.go
+++ b/metrics/linux/memory.go
@@ -35,7 +35,7 @@ func (g *MemoryGenerator) Generate() (metrics.Values, error) {
 
 	ret := map[string]float64{
 		"memory.total":       float64(memory.Total),
-		"memory.used":        float64(memory.Used),
+		"memory.used":        float64(memory.Total - memory.Free - memory.Buffers - memory.Cached),
 		"memory.available":   float64(memory.Available),
 		"memory.buffers":     float64(memory.Buffers),
 		"memory.cached":      float64(memory.Cached),

--- a/metrics/linux/memory.go
+++ b/metrics/linux/memory.go
@@ -36,6 +36,7 @@ func (g *MemoryGenerator) Generate() (metrics.Values, error) {
 	ret := map[string]float64{
 		"memory.total":       float64(memory.Total),
 		"memory.used":        float64(memory.Used),
+		"memory.available":   float64(memory.Available),
 		"memory.buffers":     float64(memory.Buffers),
 		"memory.cached":      float64(memory.Cached),
 		"memory.free":        float64(memory.Free),

--- a/metrics/linux/memory.go
+++ b/metrics/linux/memory.go
@@ -3,12 +3,7 @@
 package linux
 
 import (
-	"bufio"
-	"bytes"
-	"io/ioutil"
-	"regexp"
-	"strconv"
-
+	"github.com/mackerelio/go-osstat/memory"
 	"github.com/mackerelio/golib/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
 )
@@ -30,64 +25,26 @@ type MemoryGenerator struct {
 
 var memoryLogger = logging.GetLogger("metrics.memory")
 
-// Generate generate metrics values
+// Generate memory values
 func (g *MemoryGenerator) Generate() (metrics.Values, error) {
-	out, err := ioutil.ReadFile("/proc/meminfo")
+	memory, err := memory.Get()
 	if err != nil {
-		memoryLogger.Errorf("Failed (skip these metrics): %s", err)
+		memoryLogger.Errorf("failed to get memory statistics: %s", err)
 		return nil, err
 	}
-	return parseMeminfo(out)
-}
 
-var memReg = regexp.MustCompile(`^([A-Za-z]+):\s+([0-9]+)\s+kB`)
-
-var memItems = map[string]string{
-	"MemTotal":     "total",
-	"MemFree":      "free",
-	"MemAvailable": "available",
-	"Buffers":      "buffers",
-	"Cached":       "cached",
-	"Active":       "active",
-	"Inactive":     "inactive",
-	"SwapCached":   "swap_cached",
-	"SwapTotal":    "swap_total",
-	"SwapFree":     "swap_free",
-}
-
-func parseMeminfo(out []byte) (metrics.Values, error) {
-	scanner := bufio.NewScanner(bytes.NewReader(out))
-
-	ret := metrics.Values{}
-	used := float64(0)
-	usedCnt := 0
-	for scanner.Scan() {
-		line := scanner.Text()
-		// ex.) MemTotal:        3916792 kB
-		if matches := memReg.FindStringSubmatch(line); len(matches) == 3 {
-			k, ok := memItems[matches[1]]
-			if !ok {
-				continue
-			}
-			value, _ := strconv.ParseFloat(matches[2], 64)
-			ret["memory."+k] = value * 1024
-			switch k {
-			case "free", "buffers", "cached":
-				used -= value
-				usedCnt++
-			case "total":
-				used += value
-				usedCnt++
-			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		memoryLogger.Errorf("Failed (skip these metrics): %s", err)
-		return nil, err
-	}
-	if usedCnt == 4 { // 4 is free, buffers, cached and total
-		ret["memory.used"] = used * 1024
+	ret := map[string]float64{
+		"memory.total":       float64(memory.Total),
+		"memory.used":        float64(memory.Used),
+		"memory.buffers":     float64(memory.Buffers),
+		"memory.cached":      float64(memory.Cached),
+		"memory.free":        float64(memory.Free),
+		"memory.active":      float64(memory.Active),
+		"memory.inactive":    float64(memory.Inactive),
+		"memory.swap_total":  float64(memory.SwapTotal),
+		"memory.swap_cached": float64(memory.SwapCached),
+		"memory.swap_free":   float64(memory.SwapFree),
 	}
 
-	return ret, nil
+	return metrics.Values(ret), nil
 }

--- a/metrics/linux/memory_test.go
+++ b/metrics/linux/memory_test.go
@@ -3,20 +3,18 @@
 package linux
 
 import (
-	"reflect"
 	"testing"
-
-	"github.com/mackerelio/mackerel-agent/metrics"
 )
 
 func TestMemoryGenerator(t *testing.T) {
 	g := &MemoryGenerator{}
 	values, err := g.Generate()
+
 	if err != nil {
-		t.Errorf("should not raise error: %v", err)
+		t.Errorf("error should be nil but got: %s", err)
 	}
 
-	for _, name := range []string{
+	metricNames := []string{
 		"total",
 		"free",
 		"buffers",
@@ -27,78 +25,13 @@ func TestMemoryGenerator(t *testing.T) {
 		"swap_total",
 		"swap_free",
 		"used",
-	} {
-		if v, ok := values["memory."+name]; !ok {
-			t.Errorf("memory should has %s", name)
-		} else {
-			t.Logf("memory '%s' collected: %+v", name, v)
+	}
+
+	for _, name := range metricNames {
+		if _, ok := values["memory."+name]; !ok {
+			t.Errorf("memory should have %s", name)
 		}
 	}
-}
 
-func TestParseMeminfo(t *testing.T) {
-	out := []byte(`MemTotal:        1922196 kB
-MemFree:          166416 kB
-Buffers:          171724 kB
-Cached:           647172 kB
-SwapCached:        13564 kB
-Active:           829688 kB
-Inactive:         762348 kB
-Active(anon):     338616 kB
-Inactive(anon):   434700 kB
-Active(file):     491072 kB
-Inactive(file):   327648 kB
-Unevictable:           0 kB
-Mlocked:               0 kB
-SwapTotal:       2097148 kB
-SwapFree:        2050772 kB
-Dirty:               216 kB
-Writeback:             8 kB
-AnonPages:        760120 kB
-Mapped:            17284 kB
-Shmem:               176 kB
-Slab:             130012 kB
-SReclaimable:     107300 kB
-SUnreclaim:        22712 kB
-KernelStack:        1440 kB
-PageTables:         6024 kB
-NFS_Unstable:          0 kB
-Bounce:                0 kB
-WritebackTmp:          0 kB
-CommitLimit:     3058244 kB
-Committed_AS:    1306640 kB
-VmallocTotal:   34359738367 kB
-VmallocUsed:       11492 kB
-VmallocChunk:   34359722904 kB
-HardwareCorrupted:     0 kB
-AnonHugePages:    417792 kB
-HugePages_Total:       0
-HugePages_Free:        0
-HugePages_Rsvd:        0
-HugePages_Surp:        0
-Hugepagesize:       2048 kB
-DirectMap4k:        8180 kB
-DirectMap2M:     2088960 kB
-`)
-
-	result, err := parseMeminfo(out)
-	if err != nil {
-		t.Errorf("error should be nil but: %s", err)
-	}
-
-	expect := metrics.Values{
-		"memory.total":       1968328704,
-		"memory.free":        170409984,
-		"memory.inactive":    780644352,
-		"memory.swap_total":  2147479552,
-		"memory.used":        959369216,
-		"memory.buffers":     175845376,
-		"memory.cached":      662704128,
-		"memory.swap_cached": 13889536,
-		"memory.active":      849600512,
-		"memory.swap_free":   2099990528,
-	}
-	if !reflect.DeepEqual(result, expect) {
-		t.Errorf("result is not expected one: %#v", result)
-	}
+	t.Logf("memory metrics: %+v", values)
 }


### PR DESCRIPTION
related pull request: #422 

## Differences in detail linux
### Loadavg
#### Before: parsing /proc/loadavg
Example
```
 $ cat /proc/loadavg
1.25 1.75 2.94 4/2901 11394
```

#### After: same as before
https://github.com/mackerelio/go-osstat/blob/58447ecf4b747cb24326247a29efdb138fe6fc37/loadavg/loadavg_unix_nocgo.go
(mackerel-agent is built without cgo)

#### Difference
- None

### CPU usage
#### Before: parsing /proc/stat
Example
```
 $ cat /proc/stat
cpu  125165764 574 13765456 5433660898 2032317 6376 2330914 960854 0 0
cpu0 19150668 117 2945528 671320624 692766 4795 920553 172679 0 0
cpu1 18315112 43 2302242 674580917 305432 328 382144 162538 0 0
```

#### After: same as before
https://github.com/mackerelio/go-osstat/blob/58447ecf4b747cb24326247a29efdb138fe6fc37/cpu/cpu_linux.go

#### Difference
- Subtract GuestNice from Total
  - Previously we calculated the total cpu count by summing up all the columns and subtracting guest (as pointed out by https://github.com/mackerelio/mackerel-agent/issues/419). The count for guest_nice was still counted twice in the total count.
  - Now go-osstat subtract both guest and guest_nice from total so it's more accurate. The go-osstat library does not subtract guest from user (I think it's better that library provides the raw numbers of counters).
- Improvement in accuracy for each counters
  - Using uint64 instead of float64, the difference of the counters are more accurate than before (subtraction of huge floating numbers will sometimes result into inaccurate value).

### Memory
#### Before: parsing /proc/meminfo
Example
```
 $ cat /proc/meminfo
MemTotal:       15434208 kB
MemFree:         4559336 kB
MemAvailable:    7024984 kB
Buffers:          220904 kB
Cached:          2588752 kB
SwapCached:            0 kB
Active:          8554660 kB
Inactive:        1530452 kB
...
```

#### After: same as before
https://github.com/mackerelio/go-osstat/blob/58447ecf4b747cb24326247a29efdb138fe6fc37/memory/memory_linux.go

#### Difference
- Improvement in performance
  - less number of regexp

### Network interface
#### Before: parsing /proc/net/dev
Example
```
$ cat /proc/net/dev
Inter-|   Receive                                                |  Transmit
 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
    lo:     260       4    0    0    0     0          0         0      260       4    0    0    0     0       0          0
docker0: 157768604 3351357    0    0    0     0          0         0 25207244150 7365348    0    0    0     0       0          0
  eth0: 692521645584 1394588965    0    0    0     0          0         0 518625665032 1023030120    0    0    0     0       0          0
```

#### After: same as before
https://github.com/mackerelio/go-osstat/blob/58447ecf4b747cb24326247a29efdb138fe6fc37/network/network_linux.go

#### Difference
- Improvement in performance
  - less number of regexp
  - go-osstat currently parses received and transmitted bytes but should we provide all the counters?