### PR TITLE
Ensure returned value of retrieveAzureVMMetadata is not null

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -297,7 +297,7 @@ func retrieveAzureVMMetadata(metadataMap map[string]string, baseURL string, urlS
 		req, err := http.NewRequest("GET", baseURL+urlSuffix+key+"?api-version=2017-04-02&format=text", nil)
 		if err != nil {
 			cloudLogger.Debugf("This host may not be running on Azure VM. Error while reading '%s'", key)
-			return nil
+			return metadataMap
 		}
 
 		req.Header.Set("Metadata", "true")
@@ -305,7 +305,7 @@ func retrieveAzureVMMetadata(metadataMap map[string]string, baseURL string, urlS
 		resp, err := cl.Do(req)
 		if err != nil {
 			cloudLogger.Debugf("This host may not be running on Azure VM. Error while reading '%s'", key)
-			return nil
+			return metadataMap
 		}
 		defer resp.Body.Close()
 


### PR DESCRIPTION
ref: https://github.com/mackerelio/mackerel-agent/blob/b346699b247364717240c9a35bbfa10748e67ce6/spec/cloud.go#L282-L284

When first `retrieveAzureVMMetadata` fails but second succeeds. second `retrieveAzureVMMetadata` tries to access `metadata`, which became `nil` by first `retrieveAzureVMMetadata`.

With this change, returned values of `retrieveAzureVMMetadata` is guaranteed not be `nil` (unless `metadataMap` parameter is `nil` initially), so that parameter of `retrieveAzureVMMetadata` in L284 will be always non-nil.