### PR TITLE
Release version 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.47.0 (2017-10-19)
+
+* Trigger action command after check plugin running. #425 (mechairoi)
+* Ensure returned value of retrieveAzureVMMetadata is not null #429 (astj)
+* Use go-osstat library on darwin #422 (itchyny)
+* Subtract cpu.guest from cpu.user on Linux #423 (itchyny)
+* Improve kernel spec generator performance for Linux #427 (itchyny)
+* Improve implementation for memory spec on Linux #426 (itchyny)
+* Do not send too many reports in one API request. #420 (astj)
+
+
 ## 0.46.0 (2017-10-04)
 
 * Use new API BaseURL #417 (astj)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION = 0.46.0
+VERSION = 0.47.0
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,22 @@
+mackerel-agent (0.47.0-1.systemd) stable; urgency=low
+
+  * Trigger action command after check plugin running. (by mechairoi)
+    <https://github.com/mackerelio/mackerel-agent/pull/425>
+  * Ensure returned value of retrieveAzureVMMetadata is not null (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/429>
+  * Use go-osstat library on darwin (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/422>
+  * Subtract cpu.guest from cpu.user on Linux (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/423>
+  * Improve kernel spec generator performance for Linux (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/427>
+  * Improve implementation for memory spec on Linux (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/426>
+  * Do not send too many reports in one API request. (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/420>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 19 Oct 2017 10:57:13 +0900
+
 mackerel-agent (0.46.0-1.systemd) stable; urgency=low
 
   * Use new API BaseURL (by astj)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,22 @@
+mackerel-agent (0.47.0-1) stable; urgency=low
+
+  * Trigger action command after check plugin running. (by mechairoi)
+    <https://github.com/mackerelio/mackerel-agent/pull/425>
+  * Ensure returned value of retrieveAzureVMMetadata is not null (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/429>
+  * Use go-osstat library on darwin (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/422>
+  * Subtract cpu.guest from cpu.user on Linux (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/423>
+  * Improve kernel spec generator performance for Linux (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/427>
+  * Improve implementation for memory spec on Linux (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/426>
+  * Do not send too many reports in one API request. (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/420>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 19 Oct 2017 10:57:13 +0900
+
 mackerel-agent (0.46.0-1) stable; urgency=low
 
   * Use new API BaseURL (by astj)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,15 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Thu Oct 19 2017 <mackerel-developers@hatena.ne.jp> - 0.47.0
+- Trigger action command after check plugin running. (by mechairoi)
+- Ensure returned value of retrieveAzureVMMetadata is not null (by astj)
+- Use go-osstat library on darwin (by itchyny)
+- Subtract cpu.guest from cpu.user on Linux (by itchyny)
+- Improve kernel spec generator performance for Linux (by itchyny)
+- Improve implementation for memory spec on Linux (by itchyny)
+- Do not send too many reports in one API request. (by astj)
+
 * Wed Oct 04 2017 <mackerel-developers@hatena.ne.jp> - 0.46.0
 - Use new API BaseURL (by astj)
 - Filter plugin metrics value by include_pattern and exclude_pattern option (by astj)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,15 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Thu Oct 19 2017 <mackerel-developers@hatena.ne.jp> - 0.47.0
+- Trigger action command after check plugin running. (by mechairoi)
+- Ensure returned value of retrieveAzureVMMetadata is not null (by astj)
+- Use go-osstat library on darwin (by itchyny)
+- Subtract cpu.guest from cpu.user on Linux (by itchyny)
+- Improve kernel spec generator performance for Linux (by itchyny)
+- Improve implementation for memory spec on Linux (by itchyny)
+- Do not send too many reports in one API request. (by astj)
+
 * Wed Oct 04 2017 <mackerel-developers@hatena.ne.jp> - 0.46.0
 - Use new API BaseURL (by astj)
 - Filter plugin metrics value by include_pattern and exclude_pattern option (by astj)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.46.0"
+const version = "0.47.0"
 
 var gitcommit string


### PR DESCRIPTION
- Trigger action command after check plugin running. #425
- Ensure returned value of retrieveAzureVMMetadata is not null #429
- Use go-osstat library on darwin #422
- Subtract cpu.guest from cpu.user on Linux #423
- Improve kernel spec generator performance for Linux #427
- Improve implementation for memory spec on Linux #426
- Do not send too many reports in one API request. #420