### PR TITLE
[nit] Refactor interface generators

### DIFF
--- a/metrics/darwin/interface.go
+++ b/metrics/darwin/interface.go
@@ -29,14 +29,14 @@ var interfaceLogger = logging.GetLogger("metrics.interface")
 
 // Generate XXX
 func (g *InterfaceGenerator) Generate() (metrics.Values, error) {
-	prevValues, err := g.collectIntarfacesValues()
+	prevValues, err := g.collectInterfacesValues()
 	if err != nil {
 		return nil, err
 	}
 
 	time.Sleep(g.Interval)
 
-	currValues, err := g.collectIntarfacesValues()
+	currValues, err := g.collectInterfacesValues()
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (g *InterfaceGenerator) Generate() (metrics.Values, error) {
 	return metrics.Values(ret), nil
 }
 
-func (g *InterfaceGenerator) collectIntarfacesValues() (map[string]uint64, error) {
+func (g *InterfaceGenerator) collectInterfacesValues() (map[string]uint64, error) {
 	networks, err := network.Get()
 	if err != nil {
 		interfaceLogger.Errorf("failed to get network statistics: %s", err)

--- a/metrics/darwin/interface.go
+++ b/metrics/darwin/interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mackerelio/go-osstat/network"
 	"github.com/mackerelio/golib/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
+	"github.com/mackerelio/mackerel-agent/util"
 )
 
 /*
@@ -63,8 +64,9 @@ func (g *InterfaceGenerator) collectInterfacesValues() (map[string]uint64, error
 	}
 	results := make(map[string]uint64, len(networks)*2)
 	for _, network := range networks {
-		results["interface."+network.Name+".rxBytes"] = network.RxBytes
-		results["interface."+network.Name+".txBytes"] = network.TxBytes
+		name := util.SanitizeMetricKey(network.Name)
+		results["interface."+name+".rxBytes"] = network.RxBytes
+		results["interface."+name+".txBytes"] = network.TxBytes
 	}
 	return results, nil
 }

--- a/metrics/linux/interface.go
+++ b/metrics/linux/interface.go
@@ -3,7 +3,6 @@
 package linux
 
 import (
-	"regexp"
 	"time"
 
 	"github.com/mackerelio/go-osstat/network"
@@ -24,16 +23,6 @@ interface = "eth0", "eth1" and so on...
 type InterfaceGenerator struct {
 	Interval time.Duration
 }
-
-var interfaceMetrics = []string{
-	"rxBytes", "rxPackets", "rxErrors", "rxDrops",
-	"rxFifo", "rxFrame", "rxCompressed", "rxMulticast",
-	"txBytes", "txPackets", "txErrors", "txDrops",
-	"txFifo", "txColls", "txCarrier", "txCompressed",
-}
-
-// metrics for posting to Mackerel
-var postInterfaceMetricsRegexp = regexp.MustCompile(`^interface\..+\.(?:rxBytes|txBytes)$`)
 
 var interfaceLogger = logging.GetLogger("metrics.interface")
 


### PR DESCRIPTION
I removed unused variable (on linux) and fixed some typo (on darwin). I added sanitization for darwin but I think there's no difference. (Can a network interface name contain some dots?)