### PR TITLE
Use go 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 language: go
 go:
-- 1.9
+- 1.9.x
 env:
   global:
   - PATH=/home/travis/gopath/bin:$PATH DEBIAN_FRONTEND=noninteractive

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 language: go
 go:
-- 1.9.x
+- 1.9.2
 env:
   global:
   - PATH=/home/travis/gopath/bin:$PATH DEBIAN_FRONTEND=noninteractive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ install:
   - echo %Path%
   - choco install -y ruby
   - rd c:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.9.windows-386.zip
-  - 7z x go1.9.windows-386.zip -oC:\ >nul
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.9.2.windows-386.zip
+  - 7z x go1.9.2.windows-386.zip -oC:\ >nul
   - go version
   - go env
   - set CERT= & set CERTPASS= & set


### PR DESCRIPTION
In travis we want use `1.9.x`, but currently `1.9.x` is still treated as 1.9... : https://github.com/travis-ci/travis-build/blob/f45d07993c7ec104a7a5acf3788f10480d2c6735/public/version-aliases/go.json#L20