### PR TITLE
[nit] Revert "Specify 1.9.2 explicitly for now"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 language: go
 go:
-- 1.9.2
+- 1.9.x
 env:
   global:
   - PATH=/home/travis/gopath/bin:$PATH DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This reverts commit cc553e73a92f802d5cbdc65d3c0b3555a859aa7c.

travis-build has been updated, so now `1.9.x` will be treated as `1.9.2`. 
https://github.com/travis-ci/gimme/pull/113 / https://github.com/travis-ci/travis-build/pull/1243