### PR TITLE
[nit] Print timed out command itself

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/Songmu/timeout"
@@ -57,7 +56,7 @@ func RunCommandArgs(cmdArgs []string, user string, env []string) (stdout, stderr
 		err = fmt.Errorf("command timed out")
 	}
 	if err != nil {
-		utilLogger.Errorf("RunCommand error command: %s, error: %s", strings.Join(cmdArgs, " "), err.Error())
+		utilLogger.Errorf("RunCommand error command: %v, error: %s", cmdArgs, err.Error())
 	}
 	return stdout, stderr, exitStatus.GetChildExitCode(), err
 }

--- a/util/util.go
+++ b/util/util.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/Songmu/timeout"
@@ -56,7 +57,7 @@ func RunCommandArgs(cmdArgs []string, user string, env []string) (stdout, stderr
 		err = fmt.Errorf("command timed out")
 	}
 	if err != nil {
-		utilLogger.Errorf("RunCommand error command: %T, error: %s", cmdArgs, err.Error())
+		utilLogger.Errorf("RunCommand error command: %s, error: %s", strings.Join(cmdArgs, " "), err.Error())
 	}
 	return stdout, stderr, exitStatus.GetChildExitCode(), err
 }


### PR DESCRIPTION
When the command ran by mackerel-agent timed out, mackerel-agent print following error message to `mackerel-agent.log`.

```
2017/11/06 06:29:42 ERROR <util> RunCommand error command: []string, error: command timed out
```

We cannot know which command actually timed out. WIth this pull request, mackerel-agent prints the command when it timed out.