### PR TITLE
Release version 0.47.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.47.2 (2017-11-09)
+
+* Use go 1.9.2 #437 (astj)
+* Commonize loadavg5 generators for Linux, Darwin and BSD systems #435 (itchyny)
+* Change log level in device generator if /sys/block does not exist #424 (itchyny)
+
+
 ## 0.47.1 (2017-10-26)
 
 * Use go-osstat library on linux #428 (itchyny)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION = 0.47.1
+VERSION = 0.47.2
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent (0.47.2-1.systemd) stable; urgency=low
+
+  * Use go 1.9.2 (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/437>
+  * Commonize loadavg5 generators for Linux, Darwin and BSD systems (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/435>
+  * Change log level in device generator if /sys/block does not exist (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/424>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 09 Nov 2017 11:35:16 +0900
+
 mackerel-agent (0.47.1-1.systemd) stable; urgency=low
 
   * Use go-osstat library on linux (by itchyny)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent (0.47.2-1) stable; urgency=low
+
+  * Use go 1.9.2 (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/437>
+  * Commonize loadavg5 generators for Linux, Darwin and BSD systems (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/435>
+  * Change log level in device generator if /sys/block does not exist (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/424>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 09 Nov 2017 11:35:16 +0900
+
 mackerel-agent (0.47.1-1) stable; urgency=low
 
   * Use go-osstat library on linux (by itchyny)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,11 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Thu Nov 09 2017 <mackerel-developers@hatena.ne.jp> - 0.47.2
+- Use go 1.9.2 (by astj)
+- Commonize loadavg5 generators for Linux, Darwin and BSD systems (by itchyny)
+- Change log level in device generator if /sys/block does not exist (by itchyny)
+
 * Thu Oct 26 2017 <mackerel-developers@hatena.ne.jp> - 0.47.1
 - Use go-osstat library on linux (by itchyny)
 

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,11 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Thu Nov 09 2017 <mackerel-developers@hatena.ne.jp> - 0.47.2
+- Use go 1.9.2 (by astj)
+- Commonize loadavg5 generators for Linux, Darwin and BSD systems (by itchyny)
+- Change log level in device generator if /sys/block does not exist (by itchyny)
+
 * Thu Oct 26 2017 <mackerel-developers@hatena.ne.jp> - 0.47.1
 - Use go-osstat library on linux (by itchyny)
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.47.1"
+const version = "0.47.2"
 
 var gitcommit string


### PR DESCRIPTION
- Use go 1.9.2 #437
- Commonize loadavg5 generators for Linux, Darwin and BSD systems #435
- Change log level in device generator if /sys/block does not exist #424