### PR TITLE
Refine metrics collector

### DIFF
--- a/agent/generator.go
+++ b/agent/generator.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"sync"
+	"time"
 
 	"github.com/mackerelio/golib/logging"
 	"github.com/mackerelio/mackerel-agent/metrics"
@@ -39,7 +40,9 @@ func generateValues(generators []metrics.Generator) []*metrics.ValuesCustomIdent
 					wg.Done()
 				}()
 
+				startedAt := time.Now()
 				values, err := g.Generate()
+				logger.Debugf("%T.Generate() finished in %d ms", g, (time.Now().Sub(startedAt) / time.Millisecond))
 				if err != nil {
 					logger.Errorf("Failed to generate value in %T (skip this metric): %s", g, err.Error())
 					return

--- a/agent/generator.go
+++ b/agent/generator.go
@@ -43,7 +43,7 @@ func generateValues(generators []metrics.Generator) []*metrics.ValuesCustomIdent
 				startedAt := time.Now()
 				values, err := g.Generate()
 				if seconds := (time.Now().Sub(startedAt) / time.Second); seconds > 120 {
-					logger.Warningf("%T.Generate() take a long time (%d seconds)", g, (time.Now().Sub(startedAt) / time.Second))
+					logger.Warningf("%T.Generate() take a long time (%d seconds)", g, seconds)
 				}
 				if err != nil {
 					logger.Errorf("Failed to generate value in %T (skip this metric): %s", g, err.Error())

--- a/agent/generator.go
+++ b/agent/generator.go
@@ -42,7 +42,9 @@ func generateValues(generators []metrics.Generator) []*metrics.ValuesCustomIdent
 
 				startedAt := time.Now()
 				values, err := g.Generate()
-				logger.Debugf("%T.Generate() finished in %d ms", g, (time.Now().Sub(startedAt) / time.Millisecond))
+				if seconds := (time.Now().Sub(startedAt) / time.Second); seconds > 120 {
+					logger.Warningf("%T.Generate() take a long time (%d seconds)", g, (time.Now().Sub(startedAt) / time.Second))
+				}
 				if err != nil {
 					logger.Errorf("Failed to generate value in %T (skip this metric): %s", g, err.Error())
 					return


### PR DESCRIPTION
In a specific environment, metrics not sent each minutes.

- Reduce gap between agent.MetricsResult.Created and the time of metriss collected.
  - When metrics collectors spent long time, I think there is possibilities that the gap is 10 or more minutes.
-  Log durations that each metrics generator spent 
  - To detect slow metrics generator.