### PR TITLE
Improve plugin command parsing error message

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/mackerelio/golib/logging"
 	"github.com/mackerelio/mackerel-agent/util"
+	"github.com/pkg/errors"
 )
 
 var configLogger = logging.GetLogger("config")
@@ -387,7 +388,7 @@ func (conf *Config) setEachPlugins() error {
 		for name, pconf := range pconfs {
 			conf.MetricPlugins[name], err = pconf.buildMetricPlugin()
 			if err != nil {
-				return err
+				return errors.Wrap(err, "plugin.metrics."+name)
 			}
 		}
 	}
@@ -396,7 +397,7 @@ func (conf *Config) setEachPlugins() error {
 		for name, pconf := range pconfs {
 			conf.CheckPlugins[name], err = pconf.buildCheckPlugin(name)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "plugin.checks."+name)
 			}
 		}
 	}
@@ -405,7 +406,7 @@ func (conf *Config) setEachPlugins() error {
 		for name, pconf := range pconfs {
 			conf.MetadataPlugins[name], err = pconf.buildMetadataPlugin()
 			if err != nil {
-				return err
+				return errors.Wrap(err, "plugin.metadata."+name)
 			}
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -175,6 +175,84 @@ func TestLoadConfigWithInvalidIgnoreRegexp(t *testing.T) {
 	}
 }
 
+var sampleConfigWithInvalidMetricsCommand = `
+apikey = "abcde"
+
+[plugin.metrics.mysql]
+command = 100
+user = "mysql"
+`
+
+func TestLoadConfigWithInvalidMetricsCommand(t *testing.T) {
+	tmpFile, err := newTempFileWithContent(sampleConfigWithInvalidMetricsCommand)
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, err = LoadConfig(tmpFile.Name())
+	if err == nil {
+		t.Errorf("should raise error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "should be string or string slice, but int64") {
+		t.Errorf("should raise error containing type information: %v", err)
+	}
+	if !strings.Contains(err.Error(), "plugin.metrics.mysql") {
+		t.Errorf("should raise error containing metrics key: %v", err)
+	}
+}
+
+var sampleConfigWithInvalidCheckCommand = `
+apikey = "abcde"
+
+[plugin.checks.dice]
+`
+
+func TestLoadConfigWithInvalidCheckCommand(t *testing.T) {
+	tmpFile, err := newTempFileWithContent(sampleConfigWithInvalidCheckCommand)
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, err = LoadConfig(tmpFile.Name())
+	if err == nil {
+		t.Errorf("should raise error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "should be string or string slice, but <nil>") {
+		t.Errorf("should raise error containing type information: %v", err)
+	}
+	if !strings.Contains(err.Error(), "plugin.checks.dice") {
+		t.Errorf("should raise error containing metrics key: %v", err)
+	}
+}
+
+var sampleConfigWithInvalidMetadataCommand = `
+apikey = "abcde"
+
+[plugin.metadata.sample]
+command = [ 10, 20, 30 ]
+`
+
+func TestLoadConfigWithInvalidMetadataCommand(t *testing.T) {
+	tmpFile, err := newTempFileWithContent(sampleConfigWithInvalidMetadataCommand)
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, err = LoadConfig(tmpFile.Name())
+	if err == nil {
+		t.Errorf("should raise error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "should be string or string slice, but []interface {}") {
+		t.Errorf("should raise error containing type information: %v", err)
+	}
+	if !strings.Contains(err.Error(), "plugin.metadata.sample") {
+		t.Errorf("should raise error containing metrics key: %v", err)
+	}
+}
+
 func TestLoadConfigFile(t *testing.T) {
 	tmpFile, err := newTempFileWithContent(sampleConfig)
 	if err != nil {


### PR DESCRIPTION
This pull request improves the error message on parsing command. When `command` for (metric|check|metadata) plugin is not configured correctly, agent should report errors which plugin configuration is not correct.
```
failed to test config: failed to load the config file: plugin.metrics.mysql: failed to parse plugin command. A configuration value of `command` should be string or string slice, but
 int64
```
The message contains `plugin.metrics.mysql` so that user can configure which plugin configuration is invalid.

Example invalid conf:
```
apikey = "abcde"

[plugin.checks.ok]
command = 'echo ok'

[plugin.metrics.mysql]
command = 100
user = "mysql"
```