### PR TITLE
Add an option to declare cloud platform explicitly

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -49,7 +49,7 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 		return err
 	}
 
-	hostname, meta, interfaces, customIdentifier, lastErr := collectHostSpecs()
+	hostname, meta, interfaces, customIdentifier, lastErr := collectHostSpecs(conf)
 	if lastErr != nil {
 		return nil, fmt.Errorf("error while collecting host specs: %s", lastErr.Error())
 	}
@@ -519,14 +519,14 @@ func reportCheckMonitors(app *App, checkReportCh chan *checks.Report, reports []
 }
 
 // collectHostSpecs collects host specs (correspond to "name", "meta", "interfaces" and "customIdentifier" fields in API v0)
-func collectHostSpecs() (string, map[string]interface{}, []spec.NetInterface, string, error) {
+func collectHostSpecs(conf *config.Config) (string, map[string]interface{}, []spec.NetInterface, string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return "", nil, nil, "", fmt.Errorf("failed to obtain hostname: %s", err.Error())
 	}
 
 	specGens := specGenerators()
-	cGen := spec.SuggestCloudGenerator()
+	cGen := spec.SuggestCloudGenerator(conf)
 	if cGen != nil {
 		specGens = append(specGens, cGen)
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -342,7 +342,7 @@ func loop(app *App, termCh chan struct{}) error {
 
 func updateHostSpecsLoop(app *App, quit chan struct{}) {
 	for {
-		app.UpdateHostSpecs(app.Config)
+		app.UpdateHostSpecs()
 		select {
 		case <-quit:
 			return
@@ -555,10 +555,10 @@ func fillUpSpecMeta(meta map[string]interface{}, ver, rev string) map[string]int
 }
 
 // UpdateHostSpecs updates the host information that is already registered on Mackerel.
-func (app *App) UpdateHostSpecs(conf *config.Config) {
+func (app *App) UpdateHostSpecs() {
 	logger.Debugf("Updating host specs...")
 
-	hostname, meta, interfaces, customIdentifier, err := collectHostSpecs(conf)
+	hostname, meta, interfaces, customIdentifier, err := collectHostSpecs(app.Config)
 	if err != nil {
 		logger.Errorf("While collecting host specs: %s", err)
 		return

--- a/command/command.go
+++ b/command/command.go
@@ -342,7 +342,7 @@ func loop(app *App, termCh chan struct{}) error {
 
 func updateHostSpecsLoop(app *App, quit chan struct{}) {
 	for {
-		app.UpdateHostSpecs()
+		app.UpdateHostSpecs(app.Config)
 		select {
 		case <-quit:
 			return
@@ -555,10 +555,10 @@ func fillUpSpecMeta(meta map[string]interface{}, ver, rev string) map[string]int
 }
 
 // UpdateHostSpecs updates the host information that is already registered on Mackerel.
-func (app *App) UpdateHostSpecs() {
+func (app *App) UpdateHostSpecs(conf *config.Config) {
 	logger.Debugf("Updating host specs...")
 
-	hostname, meta, interfaces, customIdentifier, err := collectHostSpecs()
+	hostname, meta, interfaces, customIdentifier, err := collectHostSpecs(conf)
 	if err != nil {
 		logger.Errorf("While collecting host specs: %s", err)
 		return
@@ -642,7 +642,7 @@ func RunOnce(conf *config.Config, ameta *AgentMeta) error {
 }
 
 func runOncePayload(conf *config.Config, ameta *AgentMeta) ([]mackerel.CreateGraphDefsPayload, *mackerel.HostSpec, *agent.MetricsResult, error) {
-	hostname, meta, interfaces, customIdentifier, err := collectHostSpecs()
+	hostname, meta, interfaces, customIdentifier, err := collectHostSpecs(conf)
 	if err != nil {
 		logger.Errorf("While collecting host specs: %s", err)
 		return nil, nil, nil, err

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -189,7 +189,8 @@ func TestPrepareWithUpdate(t *testing.T) {
 }
 
 func TestCollectHostSpecs(t *testing.T) {
-	hostname, meta, _ /*interfaces*/, _ /*customIdentifier*/, err := collectHostSpecs()
+	conf := config.Config{}
+	hostname, meta, _ /*interfaces*/, _ /*customIdentifier*/, err := collectHostSpecs(&conf)
 
 	if err != nil {
 		t.Errorf("collectHostSpecs should not fail: %s", err)

--- a/config/config.go
+++ b/config/config.go
@@ -46,22 +46,72 @@ var defaultConnectionConfig = ConnectionConfig{
 	PostMetricsBufferSize:          6 * 60, // Keep metric values of 6 hours span in the queue
 }
 
+type CloudPlatform int
+
+const (
+	CloudPlatformAuto CloudPlatform = iota
+	CloudPlatformNone
+	CloudPlatformEC2
+	CloudPlatformGCE
+	CloudPlatformAzureVM
+)
+
+func (c CloudPlatform) String() string {
+	switch c {
+	case CloudPlatformAuto:
+		return "auto"
+	case CloudPlatformNone:
+		return "none"
+	case CloudPlatformEC2:
+		return "ec2"
+	case CloudPlatformGCE:
+		return "gce"
+	case CloudPlatformAzureVM:
+		return "azurevm"
+	}
+	return ""
+}
+
+func (c *CloudPlatform) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "auto", "":
+		*c = CloudPlatformAuto
+		return nil
+	case "none":
+		*c = CloudPlatformNone
+		return nil
+	case "ec2":
+		*c = CloudPlatformEC2
+		return nil
+	case "gce":
+		*c = CloudPlatformGCE
+		return nil
+	case "azurevm":
+		*c = CloudPlatformAzureVM
+		return nil
+	default:
+		*c = CloudPlatformNone // Avoid panic
+		return fmt.Errorf("failed to parse")
+	}
+}
+
 // Config represents mackerel-agent's configuration file.
 type Config struct {
-	Apibase     string
-	Apikey      string
-	Root        string
-	Pidfile     string
-	Conffile    string
-	Roles       []string
-	Verbose     bool
-	Silent      bool
-	Diagnostic  bool `toml:"diagnostic"`
-	Connection  ConnectionConfig
-	DisplayName string      `toml:"display_name"`
-	HostStatus  HostStatus  `toml:"host_status"`
-	Filesystems Filesystems `toml:"filesystems"`
-	HTTPProxy   string      `toml:"http_proxy"`
+	Apibase       string
+	Apikey        string
+	Root          string
+	Pidfile       string
+	Conffile      string
+	Roles         []string
+	Verbose       bool
+	Silent        bool
+	Diagnostic    bool `toml:"diagnostic"`
+	Connection    ConnectionConfig
+	DisplayName   string        `toml:"display_name"`
+	HostStatus    HostStatus    `toml:"host_status"`
+	Filesystems   Filesystems   `toml:"filesystems"`
+	HTTPProxy     string        `toml:"http_proxy"`
+	CloudPlatform CloudPlatform `toml:"cloud_platform"`
 
 	// This Plugin field is used to decode the toml file. After reading the
 	// configuration from file, this field is set to nil.

--- a/config/config.go
+++ b/config/config.go
@@ -46,8 +46,10 @@ var defaultConnectionConfig = ConnectionConfig{
 	PostMetricsBufferSize:          6 * 60, // Keep metric values of 6 hours span in the queue
 }
 
+// CloudPlatform is an enum to represent which cloud platform the host is running on.
 type CloudPlatform int
 
+// CloudPlatform enum values
 const (
 	CloudPlatformAuto CloudPlatform = iota
 	CloudPlatformNone
@@ -72,6 +74,7 @@ func (c CloudPlatform) String() string {
 	return ""
 }
 
+// UnmarshalText is used by toml unmarshaller
 func (c *CloudPlatform) UnmarshalText(text []byte) error {
 	switch string(text) {
 	case "auto", "":

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -253,6 +253,61 @@ func TestLoadConfigWithInvalidMetadataCommand(t *testing.T) {
 	}
 }
 
+var sampleConfigWithCloudPlatformTemplate = `
+apikey = "abcde"
+cloud_platform = "%s"
+`
+
+var LoadConfigWithCloudPlatformTests = []struct {
+	value    string
+	expected CloudPlatform
+}{
+	{"", CloudPlatformAuto},
+	{"auto", CloudPlatformAuto},
+	{"none", CloudPlatformNone},
+	{"ec2", CloudPlatformEC2},
+	{"gce", CloudPlatformGCE},
+	{"azurevm", CloudPlatformAzureVM},
+}
+
+func TestLoadConfigWithCloudPlatform(t *testing.T) {
+	for _, test := range LoadConfigWithCloudPlatformTests {
+		content := fmt.Sprintf(sampleConfigWithCloudPlatformTemplate, test.value)
+		tmpFile, err := newTempFileWithContent(content)
+		if err != nil {
+			t.Errorf("should not raise error: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		config, err := LoadConfig(tmpFile.Name())
+		if err != nil {
+			t.Errorf("should not raise error: %v", err)
+		}
+
+		if config.CloudPlatform != test.expected {
+			t.Errorf("CloudPlatform should be set to %s, but %s", test.expected, config.CloudPlatform)
+		}
+	}
+}
+
+var sampleConfigWithInvalidCloudPlatform = `
+apikey = "abcde"
+cloud_platform = "unknown"
+`
+
+func TestLoadConfigWithInvalidCloudPlatform(t *testing.T) {
+	tmpFile, err := newTempFileWithContent(sampleConfigWithInvalidCloudPlatform)
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, err = LoadConfig(tmpFile.Name())
+	if err == nil {
+		t.Errorf("should raise error: %v", err)
+	}
+}
+
 func TestLoadConfigFile(t *testing.T) {
 	tmpFile, err := newTempFileWithContent(sampleConfig)
 	if err != nil {

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-agent/config"
 )
 
 // This Generator collects metadata about cloud instances.
@@ -47,7 +48,19 @@ func init() {
 var timeout = 100 * time.Millisecond
 
 // SuggestCloudGenerator returns suitable CloudGenerator
-func SuggestCloudGenerator() *CloudGenerator {
+func SuggestCloudGenerator(conf *config.Config) *CloudGenerator {
+	// if CloudPlatform is specified, return corresponding one
+	switch conf.CloudPlatform {
+	case config.CloudPlatformNone:
+		return nil
+	case config.CloudPlatformEC2:
+		return &CloudGenerator{&EC2Generator{ec2BaseURL}}
+	case config.CloudPlatformGCE:
+		return &CloudGenerator{&GCEGenerator{gceMetaURL}}
+	case config.CloudPlatformAzureVM:
+		return &CloudGenerator{&AzureVMGenerator{azureVMBaseURL}}
+	}
+
 	if isEC2() {
 		return &CloudGenerator{&EC2Generator{ec2BaseURL}}
 	}

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -260,7 +260,7 @@ func TestSuggestCloudGenerator_CloudPlatformSpecified(t *testing.T) {
 	gceMetaURL = unreachableURL
 	azureVMBaseURL = unreachableURL
 
-	func() {
+	{
 		conf := config.Config{
 			CloudPlatform: config.CloudPlatformNone,
 		}
@@ -269,9 +269,9 @@ func TestSuggestCloudGenerator_CloudPlatformSpecified(t *testing.T) {
 		if cGen != nil {
 			t.Errorf("cGen should be nil.")
 		}
-	}()
+	}
 
-	func() {
+	{
 		conf := config.Config{
 			CloudPlatform: config.CloudPlatformEC2,
 		}
@@ -285,9 +285,9 @@ func TestSuggestCloudGenerator_CloudPlatformSpecified(t *testing.T) {
 		if !ok {
 			t.Errorf("cGen should be *EC2Generator")
 		}
-	}()
+	}
 
-	func() {
+	{
 		conf := config.Config{
 			CloudPlatform: config.CloudPlatformGCE,
 		}
@@ -301,9 +301,9 @@ func TestSuggestCloudGenerator_CloudPlatformSpecified(t *testing.T) {
 		if !ok {
 			t.Errorf("cGen should be *GCEGenerator")
 		}
-	}()
+	}
 
-	func() {
+	{
 		conf := config.Config{
 			CloudPlatform: config.CloudPlatformAzureVM,
 		}
@@ -317,5 +317,5 @@ func TestSuggestCloudGenerator_CloudPlatformSpecified(t *testing.T) {
 		if !ok {
 			t.Errorf("cGen should be *AzureVMGenerator")
 		}
-	}()
+	}
 }

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/mackerelio/mackerel-agent/config"
 )
 
 func TestCloudKey(t *testing.T) {
@@ -179,7 +181,10 @@ func TestSuggestCloudGenerator(t *testing.T) {
 	unreachableURL, _ := url.Parse("http://unreachable.localhost")
 	ec2BaseURL = unreachableURL
 	gceMetaURL = unreachableURL
-	cGen := SuggestCloudGenerator()
+
+	conf := config.Config{}
+
+	cGen := SuggestCloudGenerator(&conf)
 	if cGen != nil {
 		t.Errorf("cGen should be nil but, %s", cGen)
 	}
@@ -190,7 +195,7 @@ func TestSuggestCloudGenerator(t *testing.T) {
 		u, _ := url.Parse(ts.URL)
 		ec2BaseURL = u
 
-		cGen = SuggestCloudGenerator()
+		cGen = SuggestCloudGenerator(&conf)
 		if cGen != nil {
 			t.Errorf("cGen should be nil but, %s", cGen)
 		}
@@ -205,7 +210,7 @@ func TestSuggestCloudGenerator(t *testing.T) {
 		u, _ := url.Parse(ts.URL)
 		gceMetaURL = u
 
-		cGen = SuggestCloudGenerator()
+		cGen = SuggestCloudGenerator(&conf)
 		if cGen == nil {
 			t.Errorf("cGen should not be nil.")
 		}

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -252,3 +252,70 @@ func TestSuggestCloudGenerator(t *testing.T) {
 		}
 	}()
 }
+
+func TestSuggestCloudGenerator_CloudPlatformSpecified(t *testing.T) {
+	// All Cloud meta URLs are unreachable
+	unreachableURL, _ := url.Parse("http://unreachable.localhost")
+	ec2BaseURL = unreachableURL
+	gceMetaURL = unreachableURL
+	azureVMBaseURL = unreachableURL
+
+	func() {
+		conf := config.Config{
+			CloudPlatform: config.CloudPlatformNone,
+		}
+
+		cGen := SuggestCloudGenerator(&conf)
+		if cGen != nil {
+			t.Errorf("cGen should be nil.")
+		}
+	}()
+
+	func() {
+		conf := config.Config{
+			CloudPlatform: config.CloudPlatformEC2,
+		}
+
+		cGen := SuggestCloudGenerator(&conf)
+		if cGen == nil {
+			t.Errorf("cGen should not be nil.")
+		}
+
+		_, ok := cGen.CloudMetaGenerator.(*EC2Generator)
+		if !ok {
+			t.Errorf("cGen should be *EC2Generator")
+		}
+	}()
+
+	func() {
+		conf := config.Config{
+			CloudPlatform: config.CloudPlatformGCE,
+		}
+
+		cGen := SuggestCloudGenerator(&conf)
+		if cGen == nil {
+			t.Errorf("cGen should not be nil.")
+		}
+
+		_, ok := cGen.CloudMetaGenerator.(*GCEGenerator)
+		if !ok {
+			t.Errorf("cGen should be *GCEGenerator")
+		}
+	}()
+
+	func() {
+		conf := config.Config{
+			CloudPlatform: config.CloudPlatformAzureVM,
+		}
+
+		cGen := SuggestCloudGenerator(&conf)
+		if cGen == nil {
+			t.Errorf("cGen should not be nil.")
+		}
+
+		_, ok := cGen.CloudMetaGenerator.(*AzureVMGenerator)
+		if !ok {
+			t.Errorf("cGen should be *AzureVMGenerator")
+		}
+	}()
+}


### PR DESCRIPTION
In mackerel-agent.conf:
```
cloud_platform = "ec2"
```

available values are following:
- ec2, azurevm, gce
- auto: default behavior. will determine platform using `isXXX()`
- none: does not use CloudGenerator
