### PR TITLE
Set environment variables for plugins

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -143,12 +143,30 @@ type PluginConfig struct {
 	IncludePattern        *string       `toml:"include_pattern"`
 	ExcludePattern        *string       `toml:"exclude_pattern"`
 	Action                CommandConfig `toml:"action"`
+	Env                   Env           `toml:"env"`
 }
 
 // CommandConfig represents an executable command configuration.
 type CommandConfig struct {
 	Raw  interface{} `toml:"command"`
 	User string
+	Env  Env `toml:"env"`
+}
+
+// Env represents environments.
+type Env map[string]string
+
+// ConvertToStrings converts to a slice of the form "key=value".
+func (e Env) ConvertToStrings() []string {
+	env := make([]string, 0, len(e))
+	for k, v := range e {
+		k = strings.Trim(k, " ")
+		if k == "" {
+			continue
+		}
+		env = append(env, k+"="+v)
+	}
+	return env
 }
 
 // Command represents an executable command.
@@ -156,18 +174,20 @@ type Command struct {
 	Cmd  string
 	Args []string
 	User string
+	Env  []string
 }
 
 // Run the Command.
 func (cmd *Command) Run() (stdout, stderr string, exitCode int, err error) {
 	if len(cmd.Args) > 0 {
-		return util.RunCommandArgs(cmd.Args, cmd.User, nil)
+		return util.RunCommandArgs(cmd.Args, cmd.User, cmd.Env)
 	}
-	return util.RunCommand(cmd.Cmd, cmd.User, nil)
+	return util.RunCommand(cmd.Cmd, cmd.User, cmd.Env)
 }
 
 // RunWithEnv runs the Command with Environment.
 func (cmd *Command) RunWithEnv(env []string) (stdout, stderr string, exitCode int, err error) {
+	env = append(cmd.Env, env...)
 	if len(cmd.Args) > 0 {
 		return util.RunCommandArgs(cmd.Args, cmd.User, env)
 	}
@@ -199,6 +219,7 @@ func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
 	if cmd == nil {
 		return nil, fmt.Errorf("failed to parse plugin command. A configuration value of `command` should be string or string slice, but %T", pconf.CommandRaw)
 	}
+	cmd.Env = pconf.Env.ConvertToStrings()
 
 	var (
 		includePattern *regexp.Regexp
@@ -244,10 +265,14 @@ func (pconf *PluginConfig) buildCheckPlugin(name string) (*CheckPlugin, error) {
 	if cmd == nil {
 		return nil, fmt.Errorf("failed to parse plugin command. A configuration value of `command` should be string or string slice, but %T", pconf.CommandRaw)
 	}
+	cmd.Env = pconf.Env.ConvertToStrings()
+
 	action, err := parseCommand(pconf.Action.Raw, pconf.Action.User)
 	if err != nil {
 		return nil, err
 	}
+	action.Env = pconf.Action.Env.ConvertToStrings()
+
 	plugin := CheckPlugin{
 		Command:               *cmd,
 		NotificationInterval:  pconf.NotificationInterval,
@@ -278,6 +303,7 @@ func (pconf *PluginConfig) buildMetadataPlugin() (*MetadataPlugin, error) {
 	if cmd == nil {
 		return nil, fmt.Errorf("failed to parse plugin command. A configuration value of `command` should be string or string slice, but %T", pconf.CommandRaw)
 	}
+	cmd.Env = pconf.Env.ConvertToStrings()
 	return &MetadataPlugin{
 		Command:           *cmd,
 		ExecutionInterval: pconf.ExecutionInterval,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -391,10 +391,10 @@ func TestLoadConfigFile(t *testing.T) {
 	if len(pluginConf3.Command.Env) != 2 {
 		t.Errorf("env should have 2 keys: %v", pluginConf3.Command.Env)
 	}
-	if !containsString(pluginConf3.Command.Env, "MYSQL_USERNAME=USERNAME") {
+	if !expectContainsString(pluginConf3.Command.Env, "MYSQL_USERNAME=USERNAME") {
 		t.Errorf("Command.Env should contain 'MYSQL_USERNAME=USERNAME'")
 	}
-	if !containsString(pluginConf3.Command.Env, "MYSQL_PASSWORD=PASSWORD") {
+	if !expectContainsString(pluginConf3.Command.Env, "MYSQL_PASSWORD=PASSWORD") {
 		t.Errorf("Command.Env should contain 'MYSQL_PASSWORD=PASSWORD'")
 	}
 
@@ -428,7 +428,7 @@ func TestLoadConfigFile(t *testing.T) {
 	if len(checks2.Command.Env) != 1 {
 		t.Errorf("env of check plugin should have a key: %v", checks2.Command.Env)
 	}
-	if !containsString(checks2.Command.Env, "ES_HOSTS=10.45.3.2:9220,10.45.3.1:9230") {
+	if !expectContainsString(checks2.Command.Env, "ES_HOSTS=10.45.3.2:9220,10.45.3.1:9230") {
 		t.Errorf("Command.Env should contain 'ES_HOSTS=10.45.3.2:9220,10.45.3.1:9230'")
 	}
 	if checks2.Action.Env == nil {
@@ -437,14 +437,14 @@ func TestLoadConfigFile(t *testing.T) {
 	if len(checks2.Action.Env) != 3 {
 		t.Errorf("action.env of check plugin should have 3 keys: %v", checks2.Action.Env)
 	}
-	if !containsString(checks2.Action.Env, "NAME_1=VALUE_1") {
+	if !expectContainsString(checks2.Action.Env, "NAME_1=VALUE_1") {
 		t.Errorf("Command.Env should contain 'NAME_1=VALUE_1'")
 	}
-	if !containsString(checks2.Action.Env, "NAME_2=VALUE_2") {
+	if !expectContainsString(checks2.Action.Env, "NAME_2=VALUE_2") {
 		t.Errorf("Command.Env should contain 'NAME_2=VALUE_2'")
 	}
 
-	if !containsString(checks2.Action.Env, "NAME_3=VALUE_3") {
+	if !expectContainsString(checks2.Action.Env, "NAME_3=VALUE_3") {
 		t.Errorf("Command.Env should contain 'NAME_3=VALUE_3'")
 	}
 
@@ -469,7 +469,7 @@ func TestLoadConfigFile(t *testing.T) {
 	if len(metadataPlugin2.Command.Env) != 1 {
 		t.Errorf("env of metadata plugin should have a key: %v", metadataPlugin2.Command.Env)
 	}
-	if !containsString(metadataPlugin2.Command.Env, "NAME_1=VALUE_1") {
+	if !expectContainsString(metadataPlugin2.Command.Env, "NAME_1=VALUE_1") {
 		t.Errorf("Command.Env should contain 'NAME_1=VALUE_1'")
 	}
 
@@ -697,7 +697,7 @@ func TestEnv_ConvertToStrings(t *testing.T) {
 			t.Errorf("env strings should contains %d keys but: %d", len(c.expected), len(got))
 		}
 		for _, v := range got {
-			if !containsString(c.expected, v) {
+			if !expectContainsString(c.expected, v) {
 				t.Errorf("env strings not expected %+v", got)
 			}
 		}
@@ -802,7 +802,7 @@ func newTempFileWithContent(content string) (*os.File, error) {
 	return tmpf, nil
 }
 
-func containsString(slice []string, contains string) bool {
+func expectContainsString(slice []string, contains string) bool {
 	for _, v := range slice {
 		if v == contains {
 			return true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -735,7 +735,7 @@ func main() {
 apikey = "abcde"
 
 [plugin.metrics.sample]
-command = ["go", "run", "%s"]
+command = ["go", "run", '%s']
 env = { "SAMPLE_KEY1" = " foo bar ", "SAMPLE_KEY2" = " baz qux " }
 `, gof)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -674,20 +674,25 @@ command = ["perl", "-E", "say 'Hello'"]
 
 func TestEnv_ConvertToStrings(t *testing.T) {
 	cases := []struct {
-		env      Env
-		expected []string
+		env         Env
+		expected    []string
+		expectError bool
 	}{
-		{Env{}, []string{}},
-		{Env{"KEY": "VALUE"}, []string{"KEY=VALUE"}},
-		{Env{"KEY1": "VALUE1", "KEY2": "VALUE2", "KEY3": "VALUE3"}, []string{"KEY1=VALUE1", "KEY2=VALUE2", "KEY3=VALUE3"}},
-		{Env{"KEY1": "VALUE1 VALUE2 VALUE3", "KEY2": "VALUE4 VALUE5 VALUE6"}, []string{"KEY1=VALUE1 VALUE2 VALUE3", "KEY2=VALUE4 VALUE5 VALUE6"}},
-		{Env{"KEY": ""}, []string{"KEY="}},
-		{Env{"   KEY   ": "   VALUE   "}, []string{"KEY=   VALUE   "}},
-		{Env{"": ""}, []string{}},
+		{Env{}, []string{}, false},
+		{Env{"KEY": "VALUE"}, []string{"KEY=VALUE"}, false},
+		{Env{"KEY1": "VALUE1", "KEY2": "VALUE2", "KEY3": "VALUE3"}, []string{"KEY1=VALUE1", "KEY2=VALUE2", "KEY3=VALUE3"}, false},
+		{Env{"KEY1": "VALUE1 VALUE2 VALUE3", "KEY2": "VALUE4 VALUE5 VALUE6"}, []string{"KEY1=VALUE1 VALUE2 VALUE3", "KEY2=VALUE4 VALUE5 VALUE6"}, false},
+		{Env{"KEY": ""}, []string{"KEY="}, false},
+		{Env{"   KEY   ": "   VALUE   "}, []string{"KEY=   VALUE   "}, false},
+		{Env{"": ""}, []string{}, false},
+		{Env{"KEY=KEY": "VALUE"}, nil, true},
 	}
 
 	for _, c := range cases {
-		got := c.env.ConvertToStrings()
+		got, err := c.env.ConvertToStrings()
+		if err != nil && c.expectError == false {
+			t.Errorf("should raise error: %v", c.env)
+		}
 		if len(got) != len(c.expected) {
 			t.Errorf("env strings should contains %d keys but: %d", len(c.expected), len(got))
 		}


### PR DESCRIPTION
Set environment variables when running plugin.

The following is a config example.

```
[plugin.metrics.mysql3]
command = "ruby /path/to/your/plugin/mysql.rb"
env = { "MYSQL_USERNAME" = "user", "MYSQL_PASSWORD" = "password" }

[plugin.checks.heartbeat2]
command = "heartbeat.sh"
env = { "ES_HOSTS" = "10.45.3.2:9220,10.45.3.1:9230" }
action = { command = "cardiac_massage", user = "doctor", env = { "NAME_1" = "value_1", "NAME_2" = "value_2", "NAME_3" = "value_3" } }

[plugin.metadata.hostinfo2]
command = "hostinfo.sh"
env = { "NAME_1" = "value_1" }
```