### PR TITLE
Raise an error in mackerel.FindHost when hostId is empty

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -42,7 +42,7 @@ func prepareHost(conf *config.Config, api *mackerel.API) (*mackerel.Host, error)
 		if err != nil {
 			logger.Warningf("%s", err.Error())
 		}
-		if apiErr, ok := err.(*mackerel.Error); ok && apiErr.IsClientError() {
+		if apiErr, ok := err.(*mackerel.Error); ok && apiErr.IsPermanentError() {
 			// don't retry when client error (APIKey error etc.) occurred
 			return nil
 		}

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -386,6 +386,24 @@ func TestFindHost(t *testing.T) {
 	}
 }
 
+func TestFindHostEmpty(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		t.Error("The request should not happen")
+	}))
+	defer ts.Close()
+
+	api, _ := NewAPI(ts.URL, "dummy-key", false)
+	_, err := api.FindHost("")
+
+	if err == nil {
+		t.Error("err should not be nil")
+	}
+
+	if apiErr, ok := err.(*Error); !ok || !apiErr.IsPermanentError() {
+		t.Errorf("err should be a permanent error but: ", err)
+	}
+}
+
 func TestFindHostByCustomIdentifier(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if req.URL.Path != "/api/v0/hosts" {

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -400,7 +400,7 @@ func TestFindHostEmpty(t *testing.T) {
 	}
 
 	if apiErr, ok := err.(*Error); !ok || !apiErr.IsPermanentError() {
-		t.Errorf("err should be a permanent error but: ", err)
+		t.Error("err should be a permanent error but: ", err)
 	}
 }
 


### PR DESCRIPTION
This can happen when `/var/lib/mackerel-agent/id` exits but its contents is (somehow) empty.
Currently, `api.FindHost("")` requests `GET /api/v0/hosts/`, and will be redirected to `/api/v0/host` with status code 200 🙀 