### PR TITLE
Ignore empty hostid file

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -122,7 +122,7 @@ func doRetire(fs *flag.FlagSet, argv []string) error {
 
 	hostID, err := conf.LoadHostID()
 	if err != nil {
-		return fmt.Errorf("hostID file is not found")
+		return fmt.Errorf("hostID file is not found or empty")
 	}
 
 	api, err := command.NewMackerelClient(conf.Apibase, conf.Apikey, version, gitcommit, conf.Verbose)

--- a/config/config.go
+++ b/config/config.go
@@ -643,11 +643,11 @@ func (s FileSystemHostIDStorage) LoadHostID() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	hostId := strings.TrimRight(string(content), "\r\n")
-	if hostId == "" {
+	hostID := strings.TrimRight(string(content), "\r\n")
+	if hostID == "" {
 		return "", fmt.Errorf("HostIDFile found, but the content is empty")
 	}
-	return hostId, nil
+	return hostID, nil
 }
 
 // SaveHostID saves the host ID to the mackerel-agent's id file.

--- a/config/config.go
+++ b/config/config.go
@@ -643,7 +643,11 @@ func (s FileSystemHostIDStorage) LoadHostID() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimRight(string(content), "\r\n"), nil
+	hostId := strings.TrimRight(string(content), "\r\n")
+	if hostId == "" {
+		return "", fmt.Errorf("HostIDFile found, but the content is empty")
+	}
+	return hostId, nil
 }
 
 // SaveHostID saves the host ID to the mackerel-agent's id file.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -635,6 +635,12 @@ func TestFileSystemHostIDStorage(t *testing.T) {
 
 	_, err = s.LoadHostID()
 	assert(t, err != nil, "LoadHostID after DeleteSavedHostID must fail")
+
+	// Write an empty id to simulate a case that could not save id properly
+	s.SaveHostID("")
+
+	_, err = s.LoadHostID()
+	assert(t, err != nil, "LoadHostID from empty HostID file must fail")
 }
 
 func TestConfig_HostIDStorage(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -637,7 +637,8 @@ func TestFileSystemHostIDStorage(t *testing.T) {
 	assert(t, err != nil, "LoadHostID after DeleteSavedHostID must fail")
 
 	// Write an empty id to simulate a case that could not save id properly
-	s.SaveHostID("")
+	err = s.SaveHostID("")
+	assertNoError(t, err)
 
 	_, err = s.LoadHostID()
 	assert(t, err != nil, "LoadHostID from empty HostID file must fail")


### PR DESCRIPTION
Delivered from #457 
Just ignore empty hostId file, to avoid panic.  In this case a new host will be registered by mackerel-agent.