### PR TITLE
Ignore devicemapper

### DIFF
--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -91,7 +91,10 @@ func parseDfLines(out string) []*DfStat {
 			continue
 		}
 		// https://github.com/docker/docker/blob/v1.5.0/daemon/graphdriver/devmapper/deviceset.go#L981
-		if strings.HasPrefix(dfstat.Name, "/dev/mapper/docker-") || strings.Contains(dfstat.Mounted, "docker/devicemapper") {
+		if strings.HasPrefix(dfstat.Name, "/dev/mapper/docker-") {
+			continue
+		}
+		if strings.HasPrefix(dfstat.Name, "/dev/dm-") && strings.Contains(dfstat.Mounted, "devicemapper/mnt") {
 			continue
 		}
 		filesystems = append(filesystems, dfstat)

--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -91,7 +91,7 @@ func parseDfLines(out string) []*DfStat {
 			continue
 		}
 		// https://github.com/docker/docker/blob/v1.5.0/daemon/graphdriver/devmapper/deviceset.go#L981
-		if strings.HasPrefix(dfstat.Name, "/dev/mapper/docker-") {
+		if strings.HasPrefix(dfstat.Name, "/dev/mapper/docker-") || strings.Contains(dfstat.Mounted, "docker/devicemapper") {
 			continue
 		}
 		filesystems = append(filesystems, dfstat)

--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -94,6 +94,9 @@ func parseDfLines(out string) []*DfStat {
 		if strings.HasPrefix(dfstat.Name, "/dev/mapper/docker-") {
 			continue
 		}
+		// https://debbugs.gnu.org/cgi/bugreport.cgi?bug=10363
+		// http://git.savannah.gnu.org/gitweb/?p=coreutils.git;a=commit;h=1e18d8416f9ef43bf08982cabe54220587061a08
+		// coreutils >= 8.15
 		if strings.HasPrefix(dfstat.Name, "/dev/dm-") && strings.Contains(dfstat.Mounted, "devicemapper/mnt") {
 			continue
 		}

--- a/util/filesystem_test.go
+++ b/util/filesystem_test.go
@@ -21,6 +21,7 @@ tmpfs                                   517224        0  517224         0% /lib/
 udev                                    512780       96  512684         1% /dev
 tmpfs                                   517224        4  517220         1% /dev/shm
 /dev/mapper/docker-000:0-000-00000    10190136   168708 9480756         2% /var/lib/docker/devicemapper/mnt/00000
+/dev/dm-4                             10474496   149684 10324812        2% /var/lib/docker/devicemapper/mnt/11111
 `
 	expect := []*DfStat{
 		{


### PR DESCRIPTION
* `df` output changed to canonicalized name (`/dev/mapper/docker-...` is symlink to `/dev/dm-...`)