### PR TITLE
Ignore device-mapper in disk I/O metrics on Linux. (Docker creats a lot)

### DIFF
--- a/metrics/linux/disk.go
+++ b/metrics/linux/disk.go
@@ -121,6 +121,9 @@ func parseDiskStats(out []byte, mapping map[string]string) (metrics.Values, erro
 		}
 
 		deviceLabel := util.SanitizeMetricKey(device)
+		if strings.HasPrefix(deviceLabel, "dm-") {
+			continue
+		}
 		mountpoint, exists := mapping[device]
 		if exists {
 			deviceLabel = util.SanitizeMetricKey(mountpoint)

--- a/metrics/linux/disk_test.go
+++ b/metrics/linux/disk_test.go
@@ -44,7 +44,9 @@ func TestParseDiskStats(t *testing.T) {
 	// insert empty line intentionally
 	out := []byte(`202       1 xvda1 750193 3037 28116978 368712 16600606 7233846 424712632 23987908 0 2355636 24345740
 
-202       2 xvda2 1641 9310 87552 1252 6365 3717 80664 24192 0 15040 25428`)
+202       2 xvda2 1641 9310 87552 1252 6365 3717 80664 24192 0 15040 25428
+253       0 dm-0 2 0 40 0 314 0 2512 2136 0 236 2136
+253       1 dm-1 964 0 57886 944 74855 0 644512 5421192 0 1580 5422136`)
 
 	var emptyMapping map[string]string
 	result, err := parseDiskStats(out, emptyMapping)


### PR DESCRIPTION
- Disk read/writes metrics on device-mapper virtual devices are not useful
- Docker creates a lot of device-mapper device nodes
- Ignore "dm-" (device-mapper) devices in disk metrics