### PR TITLE
Ignore veth in network I/O metrics on Linux. (Docker creats a lot)

### DIFF
--- a/metrics/interface.go
+++ b/metrics/interface.go
@@ -3,6 +3,7 @@
 package metrics
 
 import (
+	"strings"
 	"time"
 
 	"github.com/mackerelio/go-osstat/network"
@@ -61,6 +62,9 @@ func (g *InterfaceGenerator) collectInterfacesValues() (map[string]uint64, error
 	results := make(map[string]uint64, len(networks)*2)
 	for _, network := range networks {
 		name := util.SanitizeMetricKey(network.Name)
+		if strings.HasPrefix(name, "veth") {
+			continue
+		}
 		results["interface."+name+".rxBytes"] = network.RxBytes
 		results["interface."+name+".txBytes"] = network.TxBytes
 	}

--- a/metrics/interface_test.go
+++ b/metrics/interface_test.go
@@ -41,7 +41,7 @@ func TestInterfaceGenerator(t *testing.T) {
 	}
 
 	if runtime.GOOS == "linux" {
-		for k, _ := range values {
+		for k := range values {
 			if strings.HasPrefix(k, "interface.veth") {
 				t.Errorf("Value for %s should NOT be collected", k)
 			}

--- a/metrics/interface_test.go
+++ b/metrics/interface_test.go
@@ -4,6 +4,7 @@ package metrics
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -36,6 +37,14 @@ func TestInterfaceGenerator(t *testing.T) {
 		metricName := "interface." + name + "." + metric + ".delta"
 		if _, ok := values[metricName]; ok {
 			t.Errorf("Value for %s should NOT be collected", metricName)
+		}
+	}
+
+	if runtime.GOOS == "linux" {
+		for k, _ := range values {
+			if strings.HasPrefix(k, "interface.veth") {
+				t.Errorf("Value for %s should NOT be collected", k)
+			}
 		}
 	}
 


### PR DESCRIPTION
- network metrics on veth are not useful
- Docker creates a lot of veth interfaces
- Ignore "vethXXX" interfaces in network metrics