### PR TITLE
Ignore connection configurations in mackerel-agent.conf

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -373,22 +373,19 @@ func parseCommand(commandRaw interface{}, user string) (command *Command, err er
 	}
 }
 
-const postMetricsDequeueDelaySecondsMax = 59   // max delay seconds for dequeuing from buffer queue
-const postMetricsRetryDelaySecondsMax = 3 * 60 // max delay seconds for retrying a request that caused errors
-
 // PostMetricsInterval XXX
 var PostMetricsInterval = 1 * time.Minute
 
 // ConnectionConfig XXX
 type ConnectionConfig struct {
-	PostMetricsDequeueDelaySeconds int `toml:"post_metrics_dequeue_delay_seconds"` // delay for dequeuing from buffer queue
-	PostMetricsRetryDelaySeconds   int `toml:"post_metrics_retry_delay_seconds"`   // delay for retrying a request that caused errors
-	PostMetricsRetryMax            int `toml:"post_metrics_retry_max"`             // max numbers of retries for a request that causes errors
-	PostMetricsBufferSize          int `toml:"post_metrics_buffer_size"`           // max numbers of requests stored in buffer queue.
-	ReportCheckDelaySeconds        int `toml:"report_checks_delay_seconds"`        // delay for request reports
-	ReportCheckDelaySecondsMax     int `toml:"report_checks_delay_seconds_max"`    // max delay for request reports
-	ReportCheckRetryDelaySeconds   int `toml:"report_checks_retry_delay_seconds"`  // delay for retrying a request that caused errors
-	ReportCheckBufferSize          int `toml:"report_checks_buffer_size"`          // max numbers of requests stored in buffer queue.
+	PostMetricsDequeueDelaySeconds int // delay for dequeuing from buffer queue
+	PostMetricsRetryDelaySeconds   int // delay for retrying a request that caused errors
+	PostMetricsRetryMax            int // max numbers of retries for a request that causes errors
+	PostMetricsBufferSize          int // max numbers of requests stored in buffer queue.
+	ReportCheckDelaySeconds        int // delay for request reports
+	ReportCheckDelaySecondsMax     int // max delay for request reports
+	ReportCheckRetryDelaySeconds   int // delay for retrying a request that caused errors
+	ReportCheckBufferSize          int // max numbers of requests stored in buffer queue.
 }
 
 // HostStatus configure host status on agent start/stop
@@ -467,38 +464,7 @@ func LoadConfig(conffile string) (*Config, error) {
 	if config.Diagnostic == false {
 		config.Diagnostic = DefaultConfig.Diagnostic
 	}
-	if config.Connection.PostMetricsDequeueDelaySeconds == 0 {
-		config.Connection.PostMetricsDequeueDelaySeconds = DefaultConfig.Connection.PostMetricsDequeueDelaySeconds
-	}
-	if config.Connection.PostMetricsDequeueDelaySeconds > postMetricsDequeueDelaySecondsMax {
-		configLogger.Warningf("'post_metrics_dequese_delay_seconds' is set to %d (Maximum Value).", postMetricsDequeueDelaySecondsMax)
-		config.Connection.PostMetricsDequeueDelaySeconds = postMetricsDequeueDelaySecondsMax
-	}
-	if config.Connection.PostMetricsRetryDelaySeconds == 0 {
-		config.Connection.PostMetricsRetryDelaySeconds = DefaultConfig.Connection.PostMetricsRetryDelaySeconds
-	}
-	if config.Connection.PostMetricsRetryDelaySeconds > postMetricsRetryDelaySecondsMax {
-		configLogger.Warningf("'post_metrics_retry_delay_seconds' is set to %d (Maximum Value).", postMetricsRetryDelaySecondsMax)
-		config.Connection.PostMetricsRetryDelaySeconds = postMetricsRetryDelaySecondsMax
-	}
-	if config.Connection.PostMetricsRetryMax == 0 {
-		config.Connection.PostMetricsRetryMax = DefaultConfig.Connection.PostMetricsRetryMax
-	}
-	if config.Connection.PostMetricsBufferSize == 0 {
-		config.Connection.PostMetricsBufferSize = DefaultConfig.Connection.PostMetricsBufferSize
-	}
-	if config.Connection.ReportCheckDelaySeconds == 0 {
-		config.Connection.ReportCheckDelaySeconds = DefaultConfig.Connection.ReportCheckDelaySeconds
-	}
-	if config.Connection.ReportCheckDelaySecondsMax == 0 {
-		config.Connection.ReportCheckDelaySecondsMax = DefaultConfig.Connection.ReportCheckDelaySecondsMax
-	}
-	if config.Connection.ReportCheckRetryDelaySeconds == 0 {
-		config.Connection.ReportCheckRetryDelaySeconds = DefaultConfig.Connection.ReportCheckRetryDelaySeconds
-	}
-	if config.Connection.ReportCheckBufferSize == 0 {
-		config.Connection.ReportCheckBufferSize = DefaultConfig.Connection.ReportCheckBufferSize
-	}
+	config.Connection = DefaultConfig.Connection
 
 	return config, err
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,10 +19,6 @@ diagnostic = true
 [filesystems]
 ignore = "/dev/ram.*"
 
-[connection]
-post_metrics_retry_delay_seconds = 600
-post_metrics_retry_max = 5
-
 [plugin.metrics.mysql]
 command = "ruby /path/to/your/plugin/mysql.rb"
 user = "mysql"
@@ -95,31 +91,31 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	if config.Connection.PostMetricsDequeueDelaySeconds != 30 {
-		t.Error("should be 30 (default value should be used)")
+		t.Errorf("should be 30 but got: %d", config.Connection.PostMetricsDequeueDelaySeconds)
 	}
 
-	if config.Connection.PostMetricsRetryDelaySeconds != 180 {
-		t.Error("should be 180 (max retry delay seconds is 180)")
+	if config.Connection.PostMetricsRetryDelaySeconds != 60 {
+		t.Errorf("should be 60 but got: %d", config.Connection.PostMetricsRetryDelaySeconds)
 	}
 
-	if config.Connection.PostMetricsRetryMax != 5 {
-		t.Error("should be 5 (config value should be used)")
+	if config.Connection.PostMetricsRetryMax != 60 {
+		t.Errorf("should be 60 but got: %d", config.Connection.PostMetricsRetryMax)
 	}
 
 	if config.Connection.ReportCheckDelaySeconds != 1 {
-		t.Error("should be 1 (config value should be used)")
+		t.Errorf("should be 1 but got: %d", config.Connection.ReportCheckDelaySeconds)
 	}
 
 	if config.Connection.ReportCheckDelaySecondsMax != 30 {
-		t.Error("should be 30 (config value should be used)")
+		t.Errorf("should be 30 but got: %d", config.Connection.ReportCheckDelaySecondsMax)
 	}
 
 	if config.Connection.ReportCheckRetryDelaySeconds != 30 {
-		t.Error("should be 30 (config value should be used)")
+		t.Errorf("should be 30 but got: %d", config.Connection.ReportCheckRetryDelaySeconds)
 	}
 
 	if config.Connection.ReportCheckBufferSize != 360 {
-		t.Error("should be 360 (config value should be used)")
+		t.Errorf("should be 360 but got: %d", config.Connection.ReportCheckBufferSize)
 	}
 }
 
@@ -362,10 +358,6 @@ func TestLoadConfigFile(t *testing.T) {
 
 	if config.Diagnostic != true {
 		t.Error("Diagnostic should be true")
-	}
-
-	if config.Connection.PostMetricsRetryMax != 5 {
-		t.Error("PostMetricsRetryMax should be 5")
 	}
 
 	if config.MetricPlugins == nil {
@@ -696,41 +688,6 @@ command = ["perl", "-E", "say 'Hello'"]
 
 	if p.Command.Cmd != "" {
 		t.Errorf("p.Command should be empty but: %s", p.Command.Cmd)
-	}
-}
-
-func TestLoadCOnfigWithConnectionReportChecksConfigs(t *testing.T) {
-	conff, err := newTempFileWithContent(`
-apikey = "abcde"
-
-[connection]
-report_checks_delay_seconds = 3
-report_checks_delay_seconds_max = 60
-report_checks_retry_delay_seconds = 60
-report_checks_buffer_size = 720
-`)
-	if err != nil {
-		t.Fatalf("should not raise error: %s", err)
-	}
-	defer os.Remove(conff.Name())
-
-	config, err := LoadConfig(conff.Name())
-	assertNoError(t, err)
-
-	if config.Connection.ReportCheckDelaySeconds != 3 {
-		t.Error("should be 3 (config value should be used)")
-	}
-
-	if config.Connection.ReportCheckDelaySecondsMax != 60 {
-		t.Error("should be 60 (config value should be used)")
-	}
-
-	if config.Connection.ReportCheckRetryDelaySeconds != 60 {
-		t.Error("should be 60 (config value should be used)")
-	}
-
-	if config.Connection.ReportCheckBufferSize != 720 {
-		t.Error("should be 720 (config value should be used)")
 	}
 }
 


### PR DESCRIPTION
Configuration of `connection` in mackerel-agent.conf is deprecated and no longer supported. User should not be aware of these configurations.