### PR TITLE
using os.Executable() for getting executable path on windows environment

### DIFF
--- a/config/config_windows.go
+++ b/config/config_windows.go
@@ -2,13 +2,12 @@ package config
 
 import (
 	"log"
+	"os"
 	"path/filepath"
-
-	"github.com/mackerelio/mackerel-agent/util/windows"
 )
 
 func init() {
-	path, err := windows.ExecPath()
+	path, err := os.Executable()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/init_windows.go
+++ b/init_windows.go
@@ -5,26 +5,10 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"syscall"
-	"unsafe"
 )
-
-var (
-	kernel32              = syscall.NewLazyDLL("kernel32")
-	procGetModuleFileName = kernel32.NewProc("GetModuleFileNameW")
-)
-
-func getModuleFileName() (string, error) {
-	var p [syscall.MAX_PATH]uint16
-	result, _, err := procGetModuleFileName.Call(0, uintptr(unsafe.Pointer(&p[0])), uintptr(len(p)))
-	if result == 0 {
-		return os.Args[0], err
-	}
-	return syscall.UTF16ToString(p[:]), nil
-}
 
 func init() {
-	if p, err := getModuleFileName(); err == nil {
+	if p, err := os.Executable(); err == nil {
 		os.Setenv("PATH", filepath.Dir(p)+
 			string(filepath.ListSeparator)+os.Getenv("PATH"))
 	}

--- a/util/windows/windows_api.go
+++ b/util/windows/windows_api.go
@@ -81,7 +81,6 @@ var (
 	QueryDosDevice              = modkernel32.NewProc("QueryDosDeviceW")
 	GetVolumeInformationW       = modkernel32.NewProc("GetVolumeInformationW")
 	GlobalMemoryStatusEx        = modkernel32.NewProc("GlobalMemoryStatusEx")
-	GetModuleFileName           = modkernel32.NewProc("GetModuleFileNameW")
 	GetLastError                = modkernel32.NewProc("GetLastError")
 	MultiByteToWideChar         = modkernel32.NewProc("MultiByteToWideChar")
 	PdhOpenQuery                = modpdh.NewProc("PdhOpenQuery")
@@ -236,14 +235,4 @@ func AnsiBytePtrToString(p *uint8) (string, error) {
 		return "", syscall.GetLastError()
 	}
 	return syscall.UTF16ToString(us), nil
-}
-
-// ExecPath returns path of executable file (self).
-func ExecPath() (string, error) {
-	var wpath [syscall.MAX_PATH]uint16
-	r1, _, err := GetModuleFileName.Call(0, uintptr(unsafe.Pointer(&wpath[0])), uintptr(len(wpath)))
-	if r1 == 0 {
-		return "", err
-	}
-	return syscall.UTF16ToString(wpath[:]), nil
 }

--- a/util/windows/windows_api.go
+++ b/util/windows/windows_api.go
@@ -48,12 +48,6 @@ type MEMORY_STATUS_EX struct {
 	AvailExtendedVirtual uint64
 }
 
-// PDH_FMT_COUNTERVALUE_DOUBLE XXX
-type PDH_FMT_COUNTERVALUE_DOUBLE struct {
-	CStatus     uint32
-	DoubleValue float64
-}
-
 // windows system const
 const (
 	ERROR_SUCCESS        = 0

--- a/util/windows/windows_api.go
+++ b/util/windows/windows_api.go
@@ -8,6 +8,8 @@ import (
 	"unsafe"
 )
 
+// ref. https://github.com/mackerelio/mackerel-agent/pull/134
+
 /*
 //#include <pdh.h>
 typedef unsigned long DWORD;

--- a/wix/wrapper/wrapper_windows.go
+++ b/wix/wrapper/wrapper_windows.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-	"unsafe"
 
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -29,7 +28,6 @@ var (
 	kernel32                     = syscall.NewLazyDLL("kernel32")
 	procAllocConsole             = kernel32.NewProc("AllocConsole")
 	procGenerateConsoleCtrlEvent = kernel32.NewProc("GenerateConsoleCtrlEvent")
-	procGetModuleFileName        = kernel32.NewProc("GetModuleFileNameW")
 )
 
 func main() {
@@ -264,10 +262,9 @@ L:
 }
 
 func execdir() string {
-	var wpath [syscall.MAX_PATH]uint16
-	r1, _, err := procGetModuleFileName.Call(0, uintptr(unsafe.Pointer(&wpath[0])), uintptr(len(wpath)))
-	if r1 == 0 {
+	p, err := os.Executable()
+	if err != nil {
 		log.Fatal(err)
 	}
-	return filepath.Dir(syscall.UTF16ToString(wpath[:]))
+	return filepath.Dir(p)
 }


### PR DESCRIPTION
os.Executable() is available in go1.8 or later