### PR TITLE
fix error check in TestStart of start_test.go

### DIFF
--- a/start_test.go
+++ b/start_test.go
@@ -87,14 +87,14 @@ func TestStart(t *testing.T) {
 	}
 	conf.SaveHostID(hostID)
 	termCh := make(chan struct{})
-	done := make(chan struct{})
+	done := make(chan error)
 	go func() {
 		err = start(conf, termCh)
-		done <- struct{}{}
+		done <- err
 	}()
 	time.Sleep(5 * time.Second)
 	termCh <- struct{}{}
-	<-done
+	err = <-done
 	if err != nil {
 		t.Errorf("err should be nil but: %s", err)
 	}


### PR DESCRIPTION
This pull request is to fix the last check error returned from 'start()' in 'L.91: go func()'. 
Changed to send 'err' to 'done' channel, and receive 'err' from 'done' channel, then correctly check error returned from 'start()' in 'L.91: go func()'.
  