### PR TITLE
Release version 0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.49.0 (2018-01-10)
+
+* cut out `cmdutil` package from `util` and interface adjustment #470 (Songmu)
+* Ignore connection configurations in mackerel-agent.conf #463 (itchyny)
+* fix error check in TestStart of start_test.go #471 (Ken2mer)
+* [fix] `action` command in `checks` is able to have an individual timeout settings #469 (Songmu)
+* Add an option of timeout duration for executing command #460 (taku-k)
+* Adjust appveyor.yml #466 (Songmu)
+* introduce goxz #468 (Songmu)
+* using os.Executable() for getting executable path on windows environment #464 (Songmu)
+* include commands_gen.go in repo for go-gettability #467 (Songmu)
+* Ignore veth in network I/O metrics on Linux. (Docker creats a lot) #462 (hayajo)
+* Ignore device-mapper in disk I/O metrics on Linux. (Docker creats a lot) #461 (hayajo)
+* Ignore devicemapper #459 (hayajo)
+* Ignore empty hostid file #458 (astj)
+* add check-uptime.exe on msi #455 (Songmu)
+* fix the retry of check reports #453 (hayajo)
+
+
 ## 0.48.2 (2017-12-20)
 
 * Fix network interface spec collector on Windows #452 (itchyny)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION = 0.48.2
+VERSION = 0.49.0
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,38 @@
+mackerel-agent (0.49.0-1.systemd) stable; urgency=low
+
+  * cut out `cmdutil` package from `util` and interface adjustment (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/470>
+  * Ignore connection configurations in mackerel-agent.conf (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/463>
+  * fix error check in TestStart of start_test.go (by Ken2mer)
+    <https://github.com/mackerelio/mackerel-agent/pull/471>
+  * [fix] `action` command in `checks` is able to have an individual timeout settings (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/469>
+  * Add an option of timeout duration for executing command (by taku-k)
+    <https://github.com/mackerelio/mackerel-agent/pull/460>
+  * Adjust appveyor.yml (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/466>
+  * introduce goxz (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/468>
+  * using os.Executable() for getting executable path on windows environment (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/464>
+  * include commands_gen.go in repo for go-gettability (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/467>
+  * Ignore veth in network I/O metrics on Linux. (Docker creats a lot) (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/462>
+  * Ignore device-mapper in disk I/O metrics on Linux. (Docker creats a lot) (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/461>
+  * Ignore devicemapper (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/459>
+  * Ignore empty hostid file (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/458>
+  * add check-uptime.exe on msi (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/455>
+  * fix the retry of check reports (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/453>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 10 Jan 2018 16:13:40 +0900
+
 mackerel-agent (0.48.2-1.systemd) stable; urgency=low
 
   * Fix network interface spec collector on Windows (by itchyny)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,38 @@
+mackerel-agent (0.49.0-1) stable; urgency=low
+
+  * cut out `cmdutil` package from `util` and interface adjustment (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/470>
+  * Ignore connection configurations in mackerel-agent.conf (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/463>
+  * fix error check in TestStart of start_test.go (by Ken2mer)
+    <https://github.com/mackerelio/mackerel-agent/pull/471>
+  * [fix] `action` command in `checks` is able to have an individual timeout settings (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/469>
+  * Add an option of timeout duration for executing command (by taku-k)
+    <https://github.com/mackerelio/mackerel-agent/pull/460>
+  * Adjust appveyor.yml (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/466>
+  * introduce goxz (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/468>
+  * using os.Executable() for getting executable path on windows environment (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/464>
+  * include commands_gen.go in repo for go-gettability (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/467>
+  * Ignore veth in network I/O metrics on Linux. (Docker creats a lot) (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/462>
+  * Ignore device-mapper in disk I/O metrics on Linux. (Docker creats a lot) (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/461>
+  * Ignore devicemapper (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/459>
+  * Ignore empty hostid file (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/458>
+  * add check-uptime.exe on msi (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/455>
+  * fix the retry of check reports (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/453>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 10 Jan 2018 16:13:40 +0900
+
 mackerel-agent (0.48.2-1) stable; urgency=low
 
   * Fix network interface spec collector on Windows (by itchyny)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,23 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Wed Jan 10 2018 <mackerel-developers@hatena.ne.jp> - 0.49.0
+- cut out `cmdutil` package from `util` and interface adjustment (by Songmu)
+- Ignore connection configurations in mackerel-agent.conf (by itchyny)
+- fix error check in TestStart of start_test.go (by Ken2mer)
+- [fix] `action` command in `checks` is able to have an individual timeout settings (by Songmu)
+- Add an option of timeout duration for executing command (by taku-k)
+- Adjust appveyor.yml (by Songmu)
+- introduce goxz (by Songmu)
+- using os.Executable() for getting executable path on windows environment (by Songmu)
+- include commands_gen.go in repo for go-gettability (by Songmu)
+- Ignore veth in network I/O metrics on Linux. (Docker creats a lot) (by hayajo)
+- Ignore device-mapper in disk I/O metrics on Linux. (Docker creats a lot) (by hayajo)
+- Ignore devicemapper (by hayajo)
+- Ignore empty hostid file (by astj)
+- add check-uptime.exe on msi (by Songmu)
+- fix the retry of check reports (by hayajo)
+
 * Wed Dec 20 2017 <mackerel-developers@hatena.ne.jp> - 0.48.2
 - Fix network interface spec collector on Windows (by itchyny)
 

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,23 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Jan 10 2018 <mackerel-developers@hatena.ne.jp> - 0.49.0
+- cut out `cmdutil` package from `util` and interface adjustment (by Songmu)
+- Ignore connection configurations in mackerel-agent.conf (by itchyny)
+- fix error check in TestStart of start_test.go (by Ken2mer)
+- [fix] `action` command in `checks` is able to have an individual timeout settings (by Songmu)
+- Add an option of timeout duration for executing command (by taku-k)
+- Adjust appveyor.yml (by Songmu)
+- introduce goxz (by Songmu)
+- using os.Executable() for getting executable path on windows environment (by Songmu)
+- include commands_gen.go in repo for go-gettability (by Songmu)
+- Ignore veth in network I/O metrics on Linux. (Docker creats a lot) (by hayajo)
+- Ignore device-mapper in disk I/O metrics on Linux. (Docker creats a lot) (by hayajo)
+- Ignore devicemapper (by hayajo)
+- Ignore empty hostid file (by astj)
+- add check-uptime.exe on msi (by Songmu)
+- fix the retry of check reports (by hayajo)
+
 * Wed Dec 20 2017 <mackerel-developers@hatena.ne.jp> - 0.48.2
 - Fix network interface spec collector on Windows (by itchyny)
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.48.2"
+const version = "0.49.0"
 
 var gitcommit string


### PR DESCRIPTION
- cut out `cmdutil` package from `util` and interface adjustment #470
- Ignore connection configurations in mackerel-agent.conf #463
- fix error check in TestStart of start_test.go #471
- [fix] `action` command in `checks` is able to have an individual timeout settings #469
- Add an option of timeout duration for executing command #460
- Adjust appveyor.yml #466
- introduce goxz #468
- using os.Executable() for getting executable path on windows environment #464
- include commands_gen.go in repo for go-gettability #467
- Ignore veth in network I/O metrics on Linux. (Docker creats a lot) #462
- Ignore device-mapper in disk I/O metrics on Linux. (Docker creats a lot) #461
- Ignore devicemapper #459
- Ignore empty hostid file #458
- add check-uptime.exe on msi #455
- fix the retry of check reports #453