### PR TITLE
pass returned value from command.RunOnce so that `mackerel-agent once…

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -162,9 +162,8 @@ func doOnce(fs *flag.FlagSet, argv []string) error {
 		logger.Warningf("failed to load config (but `once` must not required conf): %s", err)
 		conf = &config.Config{}
 	}
-	command.RunOnce(conf, &command.AgentMeta{
+	return command.RunOnce(conf, &command.AgentMeta{
 		Version:  version,
 		Revision: gitcommit,
 	})
-	return nil
 }


### PR DESCRIPTION
Currently `mackerel-agent once` never fails (unless it panics).  With this p-r, it will exit with non-0 status when agent failed collecting metrics. Should be useful when using as better `configtest`.

Confirmed with CentOS7 on Docker. (the Docker image has neither `ip` or `ifconfig` therefore fails at first. after installing `iproute` package it successes collecting metrics.
```
[github.com/mackerelio/mackerel-agent]$ GOOS=linux GOARCH=amd64 make build
go get -d -v -t ./...
go get github.com/golang/lint/golint
go get github.com/pierrre/gotestcover
go get github.com/Songmu/goxz/cmd/goxz
go get github.com/mattn/goveralls
go get github.com/motemen/go-cli/gen
go build -ldflags=" -X main.version=0.49.0 -X main.gitcommit=eb7b51b -X github.com/mackerelio/mackerel-agent/config.agentName="mackerel-agent" -X github.com/mackerelio/mackerel-agent/config.apibase="https://api.mackerelio.com"" \
	  -o build/"mackerel-agent"
[github.com/mackerelio/mackerel-agent]$ docker run -v $(PWD):/app --rm -it centos:centos7
[root@2fb5453b956e /]# ./app/build/mackerel-agent once
2018/01/10 09:29:37 WARNING <main> failed to load config (but `once` must not required conf): failed to load the config file: open /etc/mackerel-agent/mackerel-agent.conf: no such file or directory
2018/01/10 09:29:37 ERROR <spec.interface> Failed to run ifconfig command (skip this spec): exec: "ifconfig": executable file not found in $PATH
2018/01/10 09:29:37 ERROR <command> While collecting host specs: failed to collect interfaces: exec: "ifconfig": executable file not found in $PATH
failed to collect interfaces: exec: "ifconfig": executable file not found in $PATH
[root@2fb5453b956e /]# echo $?
1
[root@2fb5453b956e /]# yum install -y iproute
...
Complete!
[root@2fb5453b956e /]# ./app/build/mackerel-agent once
2018/01/10 09:30:25 WARNING <main> failed to load config (but `once` must not required conf): failed to load the config file: open /etc/mackerel-agent/mackerel-agent.conf: no such file or directory
{...}
[root@2fb5453b956e /]# echo $?
0
```