### PR TITLE
Release version 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.51.0 (2018-01-23)
+
+* Fix metric values of pagefile total and pagefile free on Windows #456 (itchyny)
+* update rpm-v2 task for building Amazon Linux 2 package #475 (hayajo)
+* Care plugins that handle timeout signal(SIGTERM) #476 (Songmu)
+
+
 ## 0.50.1 (2018-01-15)
 
 * Add mkr to dependencies to include it into windows msi #478 (shibayu36)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION = 0.50.1
+VERSION = 0.51.0
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent (0.51.0-1.systemd) stable; urgency=low
+
+  * Fix metric values of pagefile total and pagefile free on Windows (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/456>
+  * update rpm-v2 task for building Amazon Linux 2 package (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/475>
+  * Care plugins that handle timeout signal(SIGTERM) (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/476>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 23 Jan 2018 11:18:21 +0900
+
 mackerel-agent (0.50.1-1.systemd) stable; urgency=low
 
   * Add mkr to dependencies to include it into windows msi (by shibayu36)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent (0.51.0-1) stable; urgency=low
+
+  * Fix metric values of pagefile total and pagefile free on Windows (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/456>
+  * update rpm-v2 task for building Amazon Linux 2 package (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/475>
+  * Care plugins that handle timeout signal(SIGTERM) (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/476>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 23 Jan 2018 11:18:21 +0900
+
 mackerel-agent (0.50.1-1) stable; urgency=low
 
   * Add mkr to dependencies to include it into windows msi (by shibayu36)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,11 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Tue Jan 23 2018 <mackerel-developers@hatena.ne.jp> - 0.51.0
+- Fix metric values of pagefile total and pagefile free on Windows (by itchyny)
+- update rpm-v2 task for building Amazon Linux 2 package (by hayajo)
+- Care plugins that handle timeout signal(SIGTERM) (by Songmu)
+
 * Mon Jan 15 2018 <mackerel-developers@hatena.ne.jp> - 0.50.1
 - Add mkr to dependencies to include it into windows msi (by shibayu36)
 

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,11 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Tue Jan 23 2018 <mackerel-developers@hatena.ne.jp> - 0.51.0
+- Fix metric values of pagefile total and pagefile free on Windows (by itchyny)
+- update rpm-v2 task for building Amazon Linux 2 package (by hayajo)
+- Care plugins that handle timeout signal(SIGTERM) (by Songmu)
+
 * Mon Jan 15 2018 <mackerel-developers@hatena.ne.jp> - 0.50.1
 - Add mkr to dependencies to include it into windows msi (by shibayu36)
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.50.1"
+const version = "0.51.0"
 
 var gitcommit string


### PR DESCRIPTION
- Fix metric values of pagefile total and pagefile free on Windows #456
- update rpm-v2 task for building Amazon Linux 2 package #475
- Care plugins that handle timeout signal(SIGTERM) #476