### PR TITLE
Fix EC2 check for KVM based EC2 instance (e.g. c5 instance)

### DIFF
--- a/spec/isec2_linux.go
+++ b/spec/isec2_linux.go
@@ -8,21 +8,32 @@ import (
 	"github.com/Songmu/retry"
 )
 
-// If the OS is Linux, check /sys/hypervisor/uuid file first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
-// ref. http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
+var uuidFiles = []string{
+	"/sys/hypervisor/uuid",
+	"/sys/devices/virtual/dmi/id/product_uuid",
+}
+
+// If the OS is Linux, check /sys/hypervisor/uuid and /sys/devices/virtual/dmi/id/product_uuid files first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
+// ref. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
 func isEC2() bool {
-	data, err := ioutil.ReadFile("/sys/hypervisor/uuid")
-	if err != nil {
+	for i, u := range uuidFiles {
+		data, err := ioutil.ReadFile(u)
+		if err != nil {
+			// Not EC2.
+			if i == len(uuidFiles)-1 {
+				return false
+			}
+			continue
+		}
 		// Not EC2.
-		return false
+		if !(strings.HasPrefix(string(data), "ec2") || strings.HasPrefix(string(data), "EC2")) {
+			return false
+		}
 	}
-	// Not EC2.
-	if !strings.HasPrefix(string(data), "ec2") {
-		return false
-	}
+
 	res := false
 	cl := httpCli()
-	err = retry.Retry(3, 2*time.Second, func() error {
+	err := retry.Retry(3, 2*time.Second, func() error {
 		// '/ami-id` is probably an AWS specific URL
 		resp, err := cl.Get(ec2BaseURL.String() + "/ami-id")
 		if err != nil {
@@ -37,5 +48,6 @@ func isEC2() bool {
 	if err == nil {
 		return res
 	}
+
 	return false
 }


### PR DESCRIPTION
- KVM based EC2 instance is not exists `/sys/hypervisor/uuid`.
- Fix to check `/sys/devices/virtual/dmi/id/product_uuid` when `/sys/hypervisor/uuid` does not exist.

ref. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
