### PR TITLE
Stop collecting memory.available for now

### DIFF
--- a/metrics/linux/memory.go
+++ b/metrics/linux/memory.go
@@ -36,7 +36,6 @@ func (g *MemoryGenerator) Generate() (metrics.Values, error) {
 	ret := map[string]float64{
 		"memory.total":       float64(memory.Total),
 		"memory.used":        float64(memory.Total - memory.Free - memory.Buffers - memory.Cached),
-		"memory.available":   float64(memory.Available),
 		"memory.buffers":     float64(memory.Buffers),
 		"memory.cached":      float64(memory.Cached),
 		"memory.free":        float64(memory.Free),


### PR DESCRIPTION
I know that `MemAvailable` is a correct memory available space. But if we collect it with `cached`, `buffers`, and `free` at the same time and display them on the stacking graph, it will be strange, so stop collecting it once.