### PR TITLE
Release version 0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.53.0 (2018-03-15)
+
+* Stop collecting memory.available for now #490 (Songmu)
+* omit `/Volumes/` from collected `df` values on darwin #489 (Songmu)
+* Enhance diagnostic mode #486 (Songmu)
+* Fix EC2 check for KVM based EC2 instance (e.g. c5 instance) #488 (hayajo)
+
+
 ## 0.52.1 (2018-03-01)
 
 * context support in cmdutil #485 (Songmu)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION = 0.52.1
+VERSION = 0.53.0
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,16 @@
+mackerel-agent (0.53.0-1.systemd) stable; urgency=low
+
+  * Stop collecting memory.available for now (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/490>
+  * omit `/Volumes/` from collected `df` values on darwin (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/489>
+  * Enhance diagnostic mode (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/486>
+  * Fix EC2 check for KVM based EC2 instance (e.g. c5 instance) (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/488>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 15 Mar 2018 10:29:20 +0900
+
 mackerel-agent (0.52.1-1.systemd) stable; urgency=low
 
   * context support in cmdutil (by Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,16 @@
+mackerel-agent (0.53.0-1) stable; urgency=low
+
+  * Stop collecting memory.available for now (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/490>
+  * omit `/Volumes/` from collected `df` values on darwin (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/489>
+  * Enhance diagnostic mode (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/486>
+  * Fix EC2 check for KVM based EC2 instance (e.g. c5 instance) (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/488>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 15 Mar 2018 10:29:20 +0900
+
 mackerel-agent (0.52.1-1) stable; urgency=low
 
   * context support in cmdutil (by Songmu)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,12 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Thu Mar 15 2018 <mackerel-developers@hatena.ne.jp> - 0.53.0
+- Stop collecting memory.available for now (by Songmu)
+- omit `/Volumes/` from collected `df` values on darwin (by Songmu)
+- Enhance diagnostic mode (by Songmu)
+- Fix EC2 check for KVM based EC2 instance (e.g. c5 instance) (by hayajo)
+
 * Thu Mar 01 2018 <mackerel-developers@hatena.ne.jp> - 0.52.1
 - context support in cmdutil (by Songmu)
 - Improve error handling when executing commands (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,12 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Thu Mar 15 2018 <mackerel-developers@hatena.ne.jp> - 0.53.0
+- Stop collecting memory.available for now (by Songmu)
+- omit `/Volumes/` from collected `df` values on darwin (by Songmu)
+- Enhance diagnostic mode (by Songmu)
+- Fix EC2 check for KVM based EC2 instance (e.g. c5 instance) (by hayajo)
+
 * Thu Mar 01 2018 <mackerel-developers@hatena.ne.jp> - 0.52.1
 - context support in cmdutil (by Songmu)
 - Improve error handling when executing commands (by Songmu)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.52.1"
+const version = "0.53.0"
 
 var gitcommit string


### PR DESCRIPTION
- Stop collecting memory.available for now #490
- omit `/Volumes/` from collected `df` values on darwin #489
- Enhance diagnostic mode #486
- Fix EC2 check for KVM based EC2 instance (e.g. c5 instance) #488