### PR TITLE
change the message level from WARNING to INFO when customIdentifier is not registered

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -40,7 +40,14 @@ func prepareHost(conf *config.Config, ameta *AgentMeta, api *mackerel.API) (*mac
 
 	filterErrorForRetry := func(err error) error {
 		if err != nil {
-			logger.Warningf("%s", err.Error())
+			msg := err.Error()
+
+			switch err.(type) {
+			case *mackerel.InfoError:
+				logger.Infof("%s", msg)
+			default:
+				logger.Warningf("%s", msg)
+			}
 		}
 		if apiErr, ok := err.(*mackerel.Error); ok && apiErr.IsClientError() {
 			// don't retry when client error (APIKey error etc.) occurred

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -58,6 +58,21 @@ func apiError(code int, msg string) *Error {
 	}
 }
 
+// InfoError represents Error of log level INFO
+type InfoError struct {
+	Message string
+}
+
+func (e *InfoError) Error() string {
+	return e.Message
+}
+
+func infoError(msg string) *InfoError {
+	return &InfoError{
+		Message: msg,
+	}
+}
+
 // NewAPI creates a new instance of API.
 func NewAPI(rawurl string, apiKey string, verbose bool) (*API, error) {
 	u, err := url.Parse(rawurl)
@@ -170,7 +185,7 @@ func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*Host, erro
 	}
 
 	if len(data.Hosts) == 0 {
-		return nil, fmt.Errorf("no host was found for the custom identifier: %s", customIdentifier)
+		return nil, infoError(fmt.Sprintf("no host was found for the custom identifier: %s", customIdentifier))
 	}
 	return data.Hosts[0], err
 }

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -170,8 +170,7 @@ func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*Host, erro
 	}
 
 	if len(data.Hosts) == 0 {
-		logger.Infof("no host was found for the custom identifier: %s", customIdentifier)
-		return nil, err
+		return nil, fmt.Errorf("no host was found for the custom identifier: %s", customIdentifier)
 	}
 	return data.Hosts[0], err
 }

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -170,7 +170,8 @@ func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*Host, erro
 	}
 
 	if len(data.Hosts) == 0 {
-		return nil, fmt.Errorf("no host was found for the custom identifier: %s", customIdentifier)
+		logger.Infof("no host was found for the custom identifier: %s", customIdentifier)
+		return nil, err
 	}
 	return data.Hosts[0], err
 }

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -396,16 +396,24 @@ func TestFindHostByCustomIdentifier(t *testing.T) {
 			t.Error("request method should be GET but :", req.Method)
 		}
 
-		respJSON, _ := json.Marshal(map[string][]map[string]interface{}{
-			"hosts": {{
-				"id":               "9rxGOHfVF8F",
-				"CustomIdentifier": "foo-bar",
-				"name":             "mydb001",
-				"status":           "working",
-				"memo":             "memo",
-				"roles":            map[string][]string{"My-Service": {"db-master", "db-slave"}},
-			}},
-		})
+		var hosts []map[string]interface{}
+
+		customIdentifier := req.URL.Query().Get("customIdentifier")
+
+		if customIdentifier == "foo-bar" {
+			hosts = []map[string]interface{}{
+				{
+					"id":               "9rxGOHfVF8F",
+					"CustomIdentifier": "foo-bar",
+					"name":             "mydb001",
+					"status":           "working",
+					"memo":             "memo",
+					"roles":            map[string][]string{"My-Service": {"db-master", "db-slave"}},
+				},
+			}
+		}
+
+		respJSON, _ := json.Marshal(map[string]interface{}{"hosts": hosts})
 
 		res.Header()["Content-Type"] = []string{"application/json"}
 		fmt.Fprint(res, string(respJSON))
@@ -413,20 +421,39 @@ func TestFindHostByCustomIdentifier(t *testing.T) {
 	defer ts.Close()
 
 	api, _ := NewAPI(ts.URL, "dummy-key", false)
-	host, err := api.FindHostByCustomIdentifier("foo-bar")
 
-	if err != nil {
-		t.Error("err shoud be nil but: ", err)
+	var tests = []struct {
+		customIdentifier string
+		host             *Host
+	}{
+		{
+			customIdentifier: "foo-bar",
+			host: &Host{
+				ID:               "9rxGOHfVF8F",
+				Name:             "mydb001",
+				Type:             "",
+				Status:           "working",
+				CustomIdentifier: "foo-bar",
+			},
+		},
+		{
+			customIdentifier: "unregistered-custom_identifier",
+			host:             nil,
+		},
+		{
+			customIdentifier: "",
+			host:             nil,
+		},
 	}
 
-	if reflect.DeepEqual(host, &Host{
-		ID:               "9rxGOHfVF8F",
-		Name:             "mydb001",
-		Type:             "",
-		Status:           "working",
-		CustomIdentifier: "foo-bar",
-	}) != true {
-		t.Error("request sends json including memo but: ", host)
+	for _, tc := range tests {
+		host, err := api.FindHostByCustomIdentifier(tc.customIdentifier)
+		if err != nil {
+			t.Error("err shoud be nil but: ", err)
+		}
+		if reflect.DeepEqual(host, tc.host) != true {
+			t.Error("request sends json including memo but: ", host)
+		}
 	}
 }
 

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -425,6 +425,7 @@ func TestFindHostByCustomIdentifier(t *testing.T) {
 	var tests = []struct {
 		customIdentifier string
 		host             *Host
+		returnInfoError  bool
 	}{
 		{
 			customIdentifier: "foo-bar",
@@ -435,21 +436,30 @@ func TestFindHostByCustomIdentifier(t *testing.T) {
 				Status:           "working",
 				CustomIdentifier: "foo-bar",
 			},
+			returnInfoError: false,
 		},
 		{
 			customIdentifier: "unregistered-custom_identifier",
 			host:             nil,
+			returnInfoError:  true,
 		},
 		{
 			customIdentifier: "",
 			host:             nil,
+			returnInfoError:  true,
 		},
 	}
 
 	for _, tc := range tests {
 		host, err := api.FindHostByCustomIdentifier(tc.customIdentifier)
-		if err != nil {
-			t.Error("err shoud be nil but: ", err)
+		if tc.returnInfoError {
+			if _, ok := err.(*InfoError); !ok {
+				t.Error("err shoud be type of *InfoError but: ", reflect.TypeOf(err))
+			}
+		} else {
+			if err != nil {
+				t.Error("err shoud be nil but: ", err)
+			}
 		}
 		if reflect.DeepEqual(host, tc.host) != true {
 			t.Error("request sends json including memo but: ", host)


### PR DESCRIPTION
change the message level from WARNING to INFO when customIdentifier is not registered at the inital startup.

> ...
> mackerel-agent[3429]: 2018/03/19 15:16:26 WARNING <command> no host was found for the custom identifier: i-...
> ...