### PR TITLE
Release version 0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.54.0 (2018-03-20)
+
+* fix isEC2 #494 (Songmu)
+* care `MemAvailable` in collecting metrics around memory on linux #491 (Songmu)
+
+
 ## 0.53.0 (2018-03-15)
 
 * Stop collecting memory.available for now #490 (Songmu)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION = 0.53.0
+VERSION = 0.54.0
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.54.0-1.systemd) stable; urgency=low
+
+  * fix isEC2 (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/494>
+  * care `MemAvailable` in collecting metrics around memory on linux (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/491>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 20 Mar 2018 11:59:20 +0900
+
 mackerel-agent (0.53.0-1.systemd) stable; urgency=low
 
   * Stop collecting memory.available for now (by Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.54.0-1) stable; urgency=low
+
+  * fix isEC2 (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/494>
+  * care `MemAvailable` in collecting metrics around memory on linux (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent/pull/491>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 20 Mar 2018 11:59:20 +0900
+
 mackerel-agent (0.53.0-1) stable; urgency=low
 
   * Stop collecting memory.available for now (by Songmu)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,10 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Tue Mar 20 2018 <mackerel-developers@hatena.ne.jp> - 0.54.0
+- fix isEC2 (by Songmu)
+- care `MemAvailable` in collecting metrics around memory on linux (by Songmu)
+
 * Thu Mar 15 2018 <mackerel-developers@hatena.ne.jp> - 0.53.0
 - Stop collecting memory.available for now (by Songmu)
 - omit `/Volumes/` from collected `df` values on darwin (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,10 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Tue Mar 20 2018 <mackerel-developers@hatena.ne.jp> - 0.54.0
+- fix isEC2 (by Songmu)
+- care `MemAvailable` in collecting metrics around memory on linux (by Songmu)
+
 * Thu Mar 15 2018 <mackerel-developers@hatena.ne.jp> - 0.53.0
 - Stop collecting memory.available for now (by Songmu)
 - omit `/Volumes/` from collected `df` values on darwin (by Songmu)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.53.0"
+const version = "0.54.0"
 
 var gitcommit string


### PR DESCRIPTION
- fix isEC2 #494
- care `MemAvailable` in collecting metrics around memory on linux #491