### PR TITLE
Release version 0.54.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.54.1 (2018-03-28)
+
+* Support UUID in little-endian format on EC2 detection #496 (hayajo)
+* change the message level from WARNING to INFO when customIdentifier is not registered #493 (hayajo)
+
+
 ## 0.54.0 (2018-03-20)
 
 * fix isEC2 #494 (Songmu)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION = 0.54.0
+VERSION = 0.54.1
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.54.1-1.systemd) stable; urgency=low
+
+  * Support UUID in little-endian format on EC2 detection (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/496>
+  * change the message level from WARNING to INFO when customIdentifier is not registered (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/493>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 28 Mar 2018 15:35:56 +0900
+
 mackerel-agent (0.54.0-1.systemd) stable; urgency=low
 
   * fix isEC2 (by Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.54.1-1) stable; urgency=low
+
+  * Support UUID in little-endian format on EC2 detection (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/496>
+  * change the message level from WARNING to INFO when customIdentifier is not registered (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/493>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 28 Mar 2018 15:35:56 +0900
+
 mackerel-agent (0.54.0-1) stable; urgency=low
 
   * fix isEC2 (by Songmu)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,10 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Wed Mar 28 2018 <mackerel-developers@hatena.ne.jp> - 0.54.1
+- Support UUID in little-endian format on EC2 detection (by hayajo)
+- change the message level from WARNING to INFO when customIdentifier is not registered (by hayajo)
+
 * Tue Mar 20 2018 <mackerel-developers@hatena.ne.jp> - 0.54.0
 - fix isEC2 (by Songmu)
 - care `MemAvailable` in collecting metrics around memory on linux (by Songmu)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,10 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Mar 28 2018 <mackerel-developers@hatena.ne.jp> - 0.54.1
+- Support UUID in little-endian format on EC2 detection (by hayajo)
+- change the message level from WARNING to INFO when customIdentifier is not registered (by hayajo)
+
 * Tue Mar 20 2018 <mackerel-developers@hatena.ne.jp> - 0.54.0
 - fix isEC2 (by Songmu)
 - care `MemAvailable` in collecting metrics around memory on linux (by Songmu)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.54.0"
+const version = "0.54.1"
 
 var gitcommit string


### PR DESCRIPTION
- Support UUID in little-endian format on EC2 detection #496
- change the message level from WARNING to INFO when customIdentifier is not registered #493