### PR TITLE
more robust PATH handling

### DIFF
--- a/init_unix.go
+++ b/init_unix.go
@@ -2,10 +2,22 @@
 
 package main
 
-import "os"
+import (
+	"os"
+
+	"gopkg.in/pathlist.v0"
+	"gopkg.in/pathlist.v0/env"
+)
 
 func init() {
-	os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin:"+os.Getenv("PATH"))
+	prependTo := func(list pathlist.List, dir string) pathlist.List {
+		return pathlist.Must(pathlist.PrependTo(list, dir))
+	}
+	list := prependTo(env.Path(), "/usr/bin")
+	list = prependTo(list, "/bin")
+	list = prependTo(list, "/usr/sbin")
+	list = prependTo(list, "/sbin")
+	env.SetPath(list)
 	// prevent changing outputs of some command, e.g. ifconfig.
 	os.Setenv("LANG", "C")
 	os.Setenv("LC_ALL", "C")

--- a/init_unix.go
+++ b/init_unix.go
@@ -10,14 +10,8 @@ import (
 )
 
 func init() {
-	prependTo := func(list pathlist.List, dir string) pathlist.List {
-		return pathlist.Must(pathlist.PrependTo(list, dir))
-	}
-	list := prependTo(env.Path(), "/usr/bin")
-	list = prependTo(list, "/bin")
-	list = prependTo(list, "/usr/sbin")
-	list = prependTo(list, "/sbin")
-	env.SetPath(list)
+	env.SetPath(pathlist.Must(pathlist.PrependTo(env.Path(),
+		"/sbin", "/usr/sbin", "/bin", "/usr/bin")))
 	// prevent changing outputs of some command, e.g. ifconfig.
 	os.Setenv("LANG", "C")
 	os.Setenv("LC_ALL", "C")

--- a/init_windows.go
+++ b/init_windows.go
@@ -5,11 +5,13 @@ package main
 import (
 	"os"
 	"path/filepath"
+
+	"gopkg.in/pathlist.v0"
+	"gopkg.in/pathlist.v0/env"
 )
 
 func init() {
 	if p, err := os.Executable(); err == nil {
-		os.Setenv("PATH", filepath.Dir(p)+
-			string(filepath.ListSeparator)+os.Getenv("PATH"))
+		env.SetPath(pathlist.Must(pathlist.PrependTo(env.Path(), filepath.Dir(p))))
 	}
 }


### PR DESCRIPTION
init_*.go is concatenating path lists and directory names using simple string operations. This is not always correct and can in some situations lead to security issues.

More specifically, on Windows, when the executable path contains a semicolon ";", instead of adding the directory to the list, it adds two unrelated directories to the list, which is both incorrect and potentially unsecure. On Unix, if the user unsets PATH for extra security, the program sets it to "/sbin:/usr/sbin:/bin:/usr/bin:" (note the colon at the end), which includes the current working directory at the end, that was probably not intended, and again potentially unsecure.

Shameless plug: both issues can be avoided by using gopkg.in/pathlist.v0 which was designed to prevent these kinds of issues. See https://godoc.org/gopkg.in/pathlist.v0 for detailed explanation.

Implementation note: In both cases it's safe to use pathlist.Must in this situation: on Windows it only panics if the directory name is quoted but the result from os.Executable() should be raw (unquoted) filepath, and on Linux it only panics if the directory name contains the separator ":" (which is a valid character in directory names on Unix, but such directories cannot be added to PATH).