### PR TITLE
improve PATH handling

### DIFF
--- a/init_unix.go
+++ b/init_unix.go
@@ -5,7 +5,11 @@ package main
 import "os"
 
 func init() {
-	os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin:"+os.Getenv("PATH"))
+	if path := os.Getenv("PATH"); path != "" {
+		os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin:"+path)
+	} else {
+		os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin")
+	}
 	// prevent changing outputs of some command, e.g. ifconfig.
 	os.Setenv("LANG", "C")
 	os.Setenv("LC_ALL", "C")

--- a/init_windows.go
+++ b/init_windows.go
@@ -14,6 +14,10 @@ func init() {
 		if strings.Index(dir, ";") > -1 {
 			dir = `"` + dir + `"`
 		}
-		os.Setenv("PATH", dir+string(filepath.ListSeparator)+os.Getenv("PATH"))
+		if path := os.Getenv("PATH"); path != "" {
+			os.Setenv("PATH", dir+string(filepath.ListSeparator)+path)
+		} else {
+			os.Setenv("PATH", dir)
+		}
 	}
 }

--- a/init_windows.go
+++ b/init_windows.go
@@ -5,11 +5,15 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func init() {
 	if p, err := os.Executable(); err == nil {
-		os.Setenv("PATH", filepath.Dir(p)+
-			string(filepath.ListSeparator)+os.Getenv("PATH"))
+		dir := filepath.Dir(p)
+		if strings.Index(dir, ";") > -1 {
+			dir = `"` + dir + `"`
+		}
+		os.Setenv("PATH", dir+string(filepath.ListSeparator)+os.Getenv("PATH"))
 	}
 }

--- a/init_windows.go
+++ b/init_windows.go
@@ -11,7 +11,7 @@ import (
 func init() {
 	if p, err := os.Executable(); err == nil {
 		dir := filepath.Dir(p)
-		if strings.Index(dir, ";") > -1 {
+		if strings.ContainsRune(dir, ';') {
 			dir = `"` + dir + `"`
 		}
 		if path := os.Getenv("PATH"); path != "" {


### PR DESCRIPTION
- Make PATH not to end with `:`
- Consider path containing `;` in Windows

This is inspired from #499 , but not depending on external libraries.