### PR TITLE
Fix starting order of Windows Service

### DIFF
--- a/wix/mackerel-agent.wxs.template
+++ b/wix/mackerel-agent.wxs.template
@@ -13,7 +13,9 @@
           <Directory Id="INSTALLDIR" Name="mackerel-agent">
             <Component Id="ServiceWrapperExe">
               <File Id="MackerelAgentServiceExe" Name="wrapper.exe" DiskId="1" Source="..\build\wrapper.exe" KeyPath="yes"></File>
-              <ServiceInstall Id="ServiceInstaller" Type="ownProcess" Name="mackerel-agent" Description="Send metrics to https://mackerel.io" Account="[SERVICEACCOUNT]" Password="[SERVICEPASSWORD]" Start="auto" ErrorControl="normal" Vital="yes" Interactive="no"></ServiceInstall>
+              <ServiceInstall Id="ServiceInstaller" Type="ownProcess" Name="mackerel-agent" Description="Send metrics to https://mackerel.io" Account="[SERVICEACCOUNT]" Password="[SERVICEPASSWORD]" Start="auto" ErrorControl="normal" Vital="yes" Interactive="no">
+                <ServiceDependency Id="RPCSS"/>
+              </ServiceInstall>
               <ServiceControl Id="StartService" Start="install" Stop="both" Remove="uninstall" Name="mackerel-agent" Wait="yes"></ServiceControl>
             </Component>
             <Component Id="AgentExe">

--- a/wix/wrapper/install.go
+++ b/wix/wrapper/install.go
@@ -54,7 +54,11 @@ func installService(name, desc string) error {
 		s.Close()
 		return fmt.Errorf("service %s already exists", name)
 	}
-	s, err = m.CreateService(name, exepath, mgr.Config{DisplayName: desc}, "is", "auto-started")
+	config := mgr.Config {
+		DisplayName: desc,
+		Dependencies: []string{"RPCSS"},
+	}
+	s, err = m.CreateService(name, exepath, config, "is", "auto-started")
 	if err != nil {
 		return err
 	}

--- a/wix/wrapper/install.go
+++ b/wix/wrapper/install.go
@@ -54,8 +54,8 @@ func installService(name, desc string) error {
 		s.Close()
 		return fmt.Errorf("service %s already exists", name)
 	}
-	config := mgr.Config {
-		DisplayName: desc,
+	config := mgr.Config{
+		DisplayName:  desc,
 		Dependencies: []string{"RPCSS"},
 	}
 	s, err = m.CreateService(name, exepath, config, "is", "auto-started")


### PR DESCRIPTION
The service must be started after RPC service. On some environment, mackerel-agent service doesn't start while starting Windows. This change add depend on RPC service to add delay to start.