### PR TITLE
Replace GCE metadata endpoint with absolute FQDN

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -41,7 +41,7 @@ var ec2BaseURL, gceMetaURL, azureVMBaseURL *url.URL
 
 func init() {
 	ec2BaseURL, _ = url.Parse("http://169.254.169.254/latest/meta-data")
-	gceMetaURL, _ = url.Parse("http://metadata.google.internal/computeMetadata/v1/?recursive=true")
+	gceMetaURL, _ = url.Parse("http://metadata.google.internal./computeMetadata/v1/?recursive=true")
 	azureVMBaseURL, _ = url.Parse("http://169.254.169.254/metadata/instance")
 }
 

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -70,7 +70,7 @@ func TestCloudGenerate(t *testing.T) {
 }
 
 func TestGCEGenerate(t *testing.T) {
-	// curl "http://metadata.google.internal/computeMetadata/v1/?recursive=true" -H "Metadata-Flavor: Google"
+	// curl "http://metadata.google.internal./computeMetadata/v1/?recursive=true" -H "Metadata-Flavor: Google"
 	sampleJSON := []byte(`{
 	  "instance": {
 		"attributes": {},


### PR DESCRIPTION
The internal domain is not a TLD. If domain is specified in /etc/resolv.conf, name resolution will be performed as a subdomain of that domain. Therefore, it is necessary to write absolute FQDN in GCE Metadata endpoint.