### PR TITLE
[windows] Add timeout to WMI query for disk metrics

### DIFF
--- a/metrics/windows/disk.go
+++ b/metrics/windows/disk.go
@@ -3,7 +3,6 @@
 package windows
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -58,8 +57,6 @@ func (g *DiskGenerator) Generate() (metrics.Values, error) {
 const queryWmiTimeout = 30 * time.Second
 
 func (g *DiskGenerator) queryWmiWithTimeout() ([]win32PerfFormattedDataPerfDiskPhysicalDisk, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), queryWmiTimeout)
-	defer cancel()
 	errCh := make(chan error)
 	recordsCh := make(chan []win32PerfFormattedDataPerfDiskPhysicalDisk)
 	go func() {
@@ -71,7 +68,7 @@ func (g *DiskGenerator) queryWmiWithTimeout() ([]win32PerfFormattedDataPerfDiskP
 		recordsCh <- records
 	}()
 	select {
-	case <-ctx.Done():
+	case <-time.After(queryWmiTimeout):
 		return nil, errors.New("Timeouted while retrieving disk metrics")
 	case err := <-errCh:
 		return nil, err

--- a/metrics/windows/disk.go
+++ b/metrics/windows/disk.go
@@ -66,6 +66,7 @@ func (g *DiskGenerator) queryWmiWithTimeout() ([]win32PerfFormattedDataPerfDiskP
 		var records []win32PerfFormattedDataPerfDiskPhysicalDisk
 		if err := wmi.Query("SELECT * FROM Win32_PerfFormattedData_PerfDisk_LogicalDisk ", &records); err != nil {
 			errCh <- err
+			return
 		}
 		recordsCh <- records
 	}()

--- a/metrics/windows/disk.go
+++ b/metrics/windows/disk.go
@@ -3,6 +3,8 @@
 package windows
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -33,8 +35,7 @@ type win32PerfFormattedDataPerfDiskPhysicalDisk struct {
 func (g *DiskGenerator) Generate() (metrics.Values, error) {
 	time.Sleep(g.Interval)
 
-	var records []win32PerfFormattedDataPerfDiskPhysicalDisk
-	err := wmi.Query("SELECT * FROM Win32_PerfFormattedData_PerfDisk_LogicalDisk ", &records)
+	records, err := g.queryWmiWithTimeout()
 	if err != nil {
 		return nil, err
 	}
@@ -52,4 +53,28 @@ func (g *DiskGenerator) Generate() (metrics.Values, error) {
 	}
 	diskLogger.Debugf("%q", results)
 	return results, nil
+}
+
+const queryWmiTimeout = 30 * time.Second
+
+func (g *DiskGenerator) queryWmiWithTimeout() ([]win32PerfFormattedDataPerfDiskPhysicalDisk, error) {
+	ctx, cancel := context.WithTimeout(context.TODO(), queryWmiTimeout)
+	defer cancel()
+	errCh := make(chan error)
+	recordsCh := make(chan []win32PerfFormattedDataPerfDiskPhysicalDisk)
+	go func() {
+		var records []win32PerfFormattedDataPerfDiskPhysicalDisk
+		if err := wmi.Query("SELECT * FROM Win32_PerfFormattedData_PerfDisk_LogicalDisk ", &records); err != nil {
+			errCh <- err
+		}
+		recordsCh <- records
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, errors.New("Timeouted while retrieving disk metrics")
+	case err := <-errCh:
+		return nil, err
+	case records := <-recordsCh:
+		return records, nil
+	}
 }


### PR DESCRIPTION
wmi query sometimes hangs, therefore add timeout for safety.