### PR TITLE
Release version 0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.56.0 (2018-07-25)
+
+* Fix starting order of Windows Service #506 (mattn)
+* Auto retire with shutdown on Windows #505 (mattn)
+* Use RunWithEnv instead of os.Setenv to avoid environment variable races #507 (itchyny)
+* Improve debug messages for check monitoring actions #510 (itchyny)
+* add mssql-plugin in windows msi #509 (daiksy)
+* Replace GCE metadata endpoint with absolute FQDN #508 (i2tsuki)
+
+
 ## 0.55.0 (2018-06-20)
 
 * improve PATH handling #501 (astj)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION = 0.55.0
+VERSION = 0.56.0
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.56.0-1.systemd) stable; urgency=low
+
+  * Fix starting order of Windows Service (by mattn)
+    <https://github.com/mackerelio/mackerel-agent/pull/506>
+  * Auto retire with shutdown on Windows (by mattn)
+    <https://github.com/mackerelio/mackerel-agent/pull/505>
+  * Use RunWithEnv instead of os.Setenv to avoid environment variable races (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/507>
+  * Improve debug messages for check monitoring actions (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/510>
+  * add mssql-plugin in windows msi (by daiksy)
+    <https://github.com/mackerelio/mackerel-agent/pull/509>
+  * Replace GCE metadata endpoint with absolute FQDN (by i2tsuki)
+    <https://github.com/mackerelio/mackerel-agent/pull/508>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 25 Jul 2018 12:44:33 +0900
+
 mackerel-agent (0.55.0-1.systemd) stable; urgency=low
 
   * improve PATH handling (by astj)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.56.0-1) stable; urgency=low
+
+  * Fix starting order of Windows Service (by mattn)
+    <https://github.com/mackerelio/mackerel-agent/pull/506>
+  * Auto retire with shutdown on Windows (by mattn)
+    <https://github.com/mackerelio/mackerel-agent/pull/505>
+  * Use RunWithEnv instead of os.Setenv to avoid environment variable races (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/507>
+  * Improve debug messages for check monitoring actions (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/510>
+  * add mssql-plugin in windows msi (by daiksy)
+    <https://github.com/mackerelio/mackerel-agent/pull/509>
+  * Replace GCE metadata endpoint with absolute FQDN (by i2tsuki)
+    <https://github.com/mackerelio/mackerel-agent/pull/508>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 25 Jul 2018 12:44:33 +0900
+
 mackerel-agent (0.55.0-1) stable; urgency=low
 
   * improve PATH handling (by astj)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,14 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Wed Jul 25 2018 <mackerel-developers@hatena.ne.jp> - 0.56.0
+- Fix starting order of Windows Service (by mattn)
+- Auto retire with shutdown on Windows (by mattn)
+- Use RunWithEnv instead of os.Setenv to avoid environment variable races (by itchyny)
+- Improve debug messages for check monitoring actions (by itchyny)
+- add mssql-plugin in windows msi (by daiksy)
+- Replace GCE metadata endpoint with absolute FQDN (by i2tsuki)
+
 * Wed Jun 20 2018 <mackerel-developers@hatena.ne.jp> - 0.55.0
 - improve PATH handling (by astj)
 - Build with Go 1.10 (by astj)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,14 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Jul 25 2018 <mackerel-developers@hatena.ne.jp> - 0.56.0
+- Fix starting order of Windows Service (by mattn)
+- Auto retire with shutdown on Windows (by mattn)
+- Use RunWithEnv instead of os.Setenv to avoid environment variable races (by itchyny)
+- Improve debug messages for check monitoring actions (by itchyny)
+- add mssql-plugin in windows msi (by daiksy)
+- Replace GCE metadata endpoint with absolute FQDN (by i2tsuki)
+
 * Wed Jun 20 2018 <mackerel-developers@hatena.ne.jp> - 0.55.0
 - improve PATH handling (by astj)
 - Build with Go 1.10 (by astj)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.55.0"
+const version = "0.56.0"
 
 var gitcommit string


### PR DESCRIPTION
- Fix starting order of Windows Service #506
- Auto retire with shutdown on Windows #505
- Use RunWithEnv instead of os.Setenv to avoid environment variable races #507
- Improve debug messages for check monitoring actions #510
- add mssql-plugin in windows msi #509
- Replace GCE metadata endpoint with absolute FQDN #508