### PR TITLE
[nit] Refactoring: deprecate connection config

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -26,6 +26,10 @@ var retryNum uint = 20
 var retryInterval = 3 * time.Second
 
 var (
+	postMetricsBufferSize = 6 * 60
+)
+
+var (
 	reportCheckDelaySeconds      = 1
 	reportCheckDelaySecondsMax   = 30
 	reportCheckRetryDelaySeconds = 30
@@ -198,7 +202,7 @@ func loop(app *App, termCh chan struct{}) error {
 	// Periodically update host specs.
 	go updateHostSpecsLoop(app, quit)
 
-	postQueue := make(chan *postValue, app.Config.Connection.PostMetricsBufferSize)
+	postQueue := make(chan *postValue, postMetricsBufferSize)
 	go enqueueLoop(app, postQueue, quit)
 
 	postDelaySeconds := delayByHost(app.Host)

--- a/command/command.go
+++ b/command/command.go
@@ -26,6 +26,7 @@ var retryNum uint = 20
 var retryInterval = 3 * time.Second
 
 var (
+	reportCheckDelaySecondsMax   = 30
 	reportCheckRetryDelaySeconds = 30
 	reportCheckBufferSize        = 6 * 60
 )
@@ -504,7 +505,7 @@ func runCheckersLoop(app *App, termCheckerCh <-chan struct{}, quit <-chan struct
 		reportCheckDelay := app.Config.Connection.ReportCheckDelaySeconds
 		// Extend the delay when there are lots of reports
 		if len(reports) > len(app.Agent.Checkers) {
-			reportCheckDelay = app.Config.Connection.ReportCheckDelaySecondsMax
+			reportCheckDelay = reportCheckDelaySecondsMax
 			logger.Debugf("RunChekcerLoop: Extend the delay to %d seconds. There are %d reports.", reportCheckDelay, len(reports))
 		}
 

--- a/command/command.go
+++ b/command/command.go
@@ -25,6 +25,8 @@ var metricsInterval = 60 * time.Second
 var retryNum uint = 20
 var retryInterval = 3 * time.Second
 
+var reportCheckBufferSize = 6 * 60
+
 // AgentMeta contains meta information about mackerel-agent
 type AgentMeta struct {
 	Version  string
@@ -458,8 +460,8 @@ func runChecker(checker *checks.Checker, checkReportCh chan *checks.Report, repo
 // the reports to Mackerel API.
 func runCheckersLoop(app *App, termCheckerCh <-chan struct{}, quit <-chan struct{}) {
 	// Do not block checking.
-	checkReportCh := make(chan *checks.Report, app.Config.Connection.ReportCheckBufferSize*len(app.Agent.Checkers))
-	reportImmediateCh := make(chan struct{}, app.Config.Connection.ReportCheckBufferSize*len(app.Agent.Checkers))
+	checkReportCh := make(chan *checks.Report, reportCheckBufferSize*len(app.Agent.Checkers))
+	reportImmediateCh := make(chan struct{}, reportCheckBufferSize*len(app.Agent.Checkers))
 
 	for _, checker := range app.Agent.Checkers {
 		go runChecker(checker, checkReportCh, reportImmediateCh, quit)

--- a/command/command.go
+++ b/command/command.go
@@ -26,9 +26,10 @@ var retryNum uint = 20
 var retryInterval = 3 * time.Second
 
 var (
-	postMetricsRetryDelaySeconds = 60
-	postMetricsRetryMax          = 60
-	postMetricsBufferSize        = 6 * 60
+	postMetricsDequeueDelaySeconds = 30
+	postMetricsRetryDelaySeconds   = 60
+	postMetricsRetryMax            = 60
+	postMetricsBufferSize          = 6 * 60
 )
 
 var (
@@ -277,7 +278,7 @@ func loop(app *App, termCh chan struct{}) error {
 			case loopStateFirst: // request immediately to create graph defs of host
 				// nop
 			case loopStateQueued:
-				delaySeconds = app.Config.Connection.PostMetricsDequeueDelaySeconds
+				delaySeconds = postMetricsDequeueDelaySeconds
 			case loopStateHadError:
 				// TODO: better interval calculation. exponential backoff or so.
 				delaySeconds = postMetricsRetryDelaySeconds

--- a/command/command.go
+++ b/command/command.go
@@ -26,8 +26,9 @@ var retryNum uint = 20
 var retryInterval = 3 * time.Second
 
 var (
-	postMetricsRetryMax   = 60
-	postMetricsBufferSize = 6 * 60
+	postMetricsRetryDelaySeconds = 60
+	postMetricsRetryMax          = 60
+	postMetricsBufferSize        = 6 * 60
 )
 
 var (
@@ -279,7 +280,7 @@ func loop(app *App, termCh chan struct{}) error {
 				delaySeconds = app.Config.Connection.PostMetricsDequeueDelaySeconds
 			case loopStateHadError:
 				// TODO: better interval calculation. exponential backoff or so.
-				delaySeconds = app.Config.Connection.PostMetricsRetryDelaySeconds
+				delaySeconds = postMetricsRetryDelaySeconds
 			case loopStateTerminating:
 				// dequeue and post every one second when terminating.
 				delaySeconds = 1

--- a/command/command.go
+++ b/command/command.go
@@ -26,6 +26,7 @@ var retryNum uint = 20
 var retryInterval = 3 * time.Second
 
 var (
+	postMetricsRetryMax   = 60
 	postMetricsBufferSize = 6 * 60
 )
 
@@ -328,7 +329,7 @@ func loop(app *App, termCh chan struct{}) error {
 						v.retryCnt++
 						// It is difficult to distinguish the error is server error or data error.
 						// So, if retryCnt exceeded the configured limit, postValue is considered invalid and abandoned.
-						if v.retryCnt > app.Config.Connection.PostMetricsRetryMax {
+						if v.retryCnt > postMetricsRetryMax {
 							json, err := json.Marshal(v.values)
 							if err != nil {
 								logger.Errorf("Something wrong with post values. marshaling failed.")

--- a/command/command.go
+++ b/command/command.go
@@ -26,17 +26,15 @@ var retryNum uint = 20
 var retryInterval = 3 * time.Second
 
 var (
-	postMetricsDequeueDelaySeconds = 30
-	postMetricsRetryDelaySeconds   = 60
-	postMetricsRetryMax            = 60
-	postMetricsBufferSize          = 6 * 60
-)
+	postMetricsDequeueDelaySeconds = 30     // Check the metric values queue for every 30 seconds
+	postMetricsRetryDelaySeconds   = 60     // Wait for one minute before retrying metric value posts
+	postMetricsRetryMax            = 60     // Retry up to 60 times (30s * 60 = 30min)
+	postMetricsBufferSize          = 6 * 60 // Keep metric values of 6 hours in the queue
 
-var (
-	reportCheckDelaySeconds      = 1
-	reportCheckDelaySecondsMax   = 30
-	reportCheckRetryDelaySeconds = 30
-	reportCheckBufferSize        = 6 * 60
+	reportCheckDelaySeconds      = 1      // Wait for a second before reporting the next check
+	reportCheckDelaySecondsMax   = 30     // Wait 30 seconds before reporting the next check when many reports in queue
+	reportCheckRetryDelaySeconds = 30     // Wait 30 seconds before retrying report the next check
+	reportCheckBufferSize        = 6 * 60 // Keep check reports of 6 hours in the queue
 )
 
 // AgentMeta contains meta information about mackerel-agent

--- a/command/command.go
+++ b/command/command.go
@@ -25,7 +25,10 @@ var metricsInterval = 60 * time.Second
 var retryNum uint = 20
 var retryInterval = 3 * time.Second
 
-var reportCheckBufferSize = 6 * 60
+var (
+	reportCheckRetryDelaySeconds = 30
+	reportCheckBufferSize        = 6 * 60
+)
 
 // AgentMeta contains meta information about mackerel-agent
 type AgentMeta struct {
@@ -532,10 +535,10 @@ func reportCheckMonitors(app *App, reports []*checks.Report) {
 			break
 		}
 
-		logger.Debugf("ReportCheckMonitors: Sleep %d seconds before reporting", app.Config.Connection.ReportCheckRetryDelaySeconds)
+		logger.Debugf("ReportCheckMonitors: Sleep %d seconds before reporting", reportCheckRetryDelaySeconds)
 
 		// retry until report succeeds
-		time.Sleep(time.Duration(app.Config.Connection.ReportCheckRetryDelaySeconds) * time.Second)
+		time.Sleep(time.Duration(reportCheckRetryDelaySeconds) * time.Second)
 	}
 }
 

--- a/command/command.go
+++ b/command/command.go
@@ -26,6 +26,7 @@ var retryNum uint = 20
 var retryInterval = 3 * time.Second
 
 var (
+	reportCheckDelaySeconds      = 1
 	reportCheckDelaySecondsMax   = 30
 	reportCheckRetryDelaySeconds = 30
 	reportCheckBufferSize        = 6 * 60
@@ -502,7 +503,7 @@ func runCheckersLoop(app *App, termCheckerCh <-chan struct{}, quit <-chan struct
 		const checkReportMaxSize = 10
 
 		// Do not report many times in a short time.
-		reportCheckDelay := app.Config.Connection.ReportCheckDelaySeconds
+		reportCheckDelay := reportCheckDelaySeconds
 		// Extend the delay when there are lots of reports
 		if len(reports) > len(app.Agent.Checkers) {
 			reportCheckDelay = reportCheckDelaySecondsMax

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -239,8 +239,8 @@ func TestLoop(t *testing.T) {
 		config.PostMetricsInterval = 10 * time.Second
 		ratio := config.PostMetricsInterval.Seconds() / originalPostMetricsInterval.Seconds()
 
-		conf.Connection.PostMetricsDequeueDelaySeconds =
-			int(float64(postMetricsRetryDelaySeconds) * ratio)
+		postMetricsDequeueDelaySeconds =
+			int(float64(postMetricsDequeueDelaySeconds) * ratio)
 		postMetricsRetryDelaySeconds =
 			int(float64(postMetricsRetryDelaySeconds) * ratio)
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -79,9 +79,8 @@ func newMockAPIServer(t *testing.T) (config.Config, map[string]func(*http.Reques
 	}
 
 	conf := config.Config{
-		Apibase:    ts.URL,
-		Root:       root,
-		Connection: config.DefaultConfig.Connection,
+		Apibase: ts.URL,
+		Root:    root,
 	}
 
 	return conf, mockHandlers, ts
@@ -370,7 +369,7 @@ func TestReportCheckMonitors(t *testing.T) {
 		defer ts.Close()
 
 		if testing.Short() {
-			conf.Connection.ReportCheckRetryDelaySeconds = 1
+			reportCheckRetryDelaySeconds = 1
 		}
 
 		postCount := 0
@@ -406,7 +405,7 @@ func TestReportCheckMonitors(t *testing.T) {
 			reportCheckMonitors(app, []*checks.Report{})
 		}()
 
-		time.Sleep(time.Duration(conf.Connection.ReportCheckRetryDelaySeconds) * 3 * time.Second)
+		time.Sleep(time.Duration(reportCheckRetryDelaySeconds) * 3 * time.Second)
 
 		mu.Lock()
 		defer mu.Unlock()

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -240,9 +240,9 @@ func TestLoop(t *testing.T) {
 		ratio := config.PostMetricsInterval.Seconds() / originalPostMetricsInterval.Seconds()
 
 		conf.Connection.PostMetricsDequeueDelaySeconds =
-			int(float64(config.DefaultConfig.Connection.PostMetricsRetryDelaySeconds) * ratio)
-		conf.Connection.PostMetricsRetryDelaySeconds =
-			int(float64(config.DefaultConfig.Connection.PostMetricsRetryDelaySeconds) * ratio)
+			int(float64(postMetricsRetryDelaySeconds) * ratio)
+		postMetricsRetryDelaySeconds =
+			int(float64(postMetricsRetryDelaySeconds) * ratio)
 
 		defer func() {
 			config.PostMetricsInterval = originalPostMetricsInterval

--- a/config/config.go
+++ b/config/config.go
@@ -41,8 +41,7 @@ func getAgentName() string {
 var DefaultConfig *Config
 
 var defaultConnectionConfig = ConnectionConfig{
-	PostMetricsDequeueDelaySeconds: 30,     // Check the metric values queue for every half minute
-	PostMetricsRetryDelaySeconds:   60,     // Wait a minute before retrying metric value posts
+	PostMetricsDequeueDelaySeconds: 30, // Check the metric values queue for every half minute
 }
 
 // CloudPlatform is an enum to represent which cloud platform the host is running on.
@@ -371,7 +370,6 @@ var PostMetricsInterval = 1 * time.Minute
 // ConnectionConfig XXX
 type ConnectionConfig struct {
 	PostMetricsDequeueDelaySeconds int // delay for dequeuing from buffer queue
-	PostMetricsRetryDelaySeconds   int // delay for retrying a request that caused errors
 }
 
 // HostStatus configure host status on agent start/stop

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,6 @@ var defaultConnectionConfig = ConnectionConfig{
 	ReportCheckDelaySeconds:        1,      // Wait a second before reporting the next check
 	ReportCheckDelaySecondsMax:     30,     // Wait 30 seconds before reporting the next check when many reports in queue
 	ReportCheckRetryDelaySeconds:   30,     // Wait 30 seconds before retrying report the next check
-	ReportCheckBufferSize:          6 * 60, // Keep check reports of 6 hours span in the queue
 }
 
 // CloudPlatform is an enum to represent which cloud platform the host is running on.
@@ -383,7 +382,6 @@ type ConnectionConfig struct {
 	ReportCheckDelaySeconds        int // delay for request reports
 	ReportCheckDelaySecondsMax     int // max delay for request reports
 	ReportCheckRetryDelaySeconds   int // delay for retrying a request that caused errors
-	ReportCheckBufferSize          int // max numbers of requests stored in buffer queue.
 }
 
 // HostStatus configure host status on agent start/stop

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,6 @@ var DefaultConfig *Config
 var defaultConnectionConfig = ConnectionConfig{
 	PostMetricsDequeueDelaySeconds: 30,     // Check the metric values queue for every half minute
 	PostMetricsRetryDelaySeconds:   60,     // Wait a minute before retrying metric value posts
-	PostMetricsRetryMax:            60,     // Retry up to 60 times (30s * 60 = 30min)
 }
 
 // CloudPlatform is an enum to represent which cloud platform the host is running on.
@@ -373,7 +372,6 @@ var PostMetricsInterval = 1 * time.Minute
 type ConnectionConfig struct {
 	PostMetricsDequeueDelaySeconds int // delay for dequeuing from buffer queue
 	PostMetricsRetryDelaySeconds   int // delay for retrying a request that caused errors
-	PostMetricsRetryMax            int // max numbers of retries for a request that causes errors
 }
 
 // HostStatus configure host status on agent start/stop

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,6 @@ var defaultConnectionConfig = ConnectionConfig{
 	PostMetricsBufferSize:          6 * 60, // Keep metric values of 6 hours span in the queue
 	ReportCheckDelaySeconds:        1,      // Wait a second before reporting the next check
 	ReportCheckDelaySecondsMax:     30,     // Wait 30 seconds before reporting the next check when many reports in queue
-	ReportCheckRetryDelaySeconds:   30,     // Wait 30 seconds before retrying report the next check
 }
 
 // CloudPlatform is an enum to represent which cloud platform the host is running on.
@@ -381,7 +380,6 @@ type ConnectionConfig struct {
 	PostMetricsBufferSize          int // max numbers of requests stored in buffer queue.
 	ReportCheckDelaySeconds        int // delay for request reports
 	ReportCheckDelaySecondsMax     int // max delay for request reports
-	ReportCheckRetryDelaySeconds   int // delay for retrying a request that caused errors
 }
 
 // HostStatus configure host status on agent start/stop

--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,6 @@ var defaultConnectionConfig = ConnectionConfig{
 	PostMetricsRetryMax:            60,     // Retry up to 60 times (30s * 60 = 30min)
 	PostMetricsBufferSize:          6 * 60, // Keep metric values of 6 hours span in the queue
 	ReportCheckDelaySeconds:        1,      // Wait a second before reporting the next check
-	ReportCheckDelaySecondsMax:     30,     // Wait 30 seconds before reporting the next check when many reports in queue
 }
 
 // CloudPlatform is an enum to represent which cloud platform the host is running on.
@@ -379,7 +378,6 @@ type ConnectionConfig struct {
 	PostMetricsRetryMax            int // max numbers of retries for a request that causes errors
 	PostMetricsBufferSize          int // max numbers of requests stored in buffer queue.
 	ReportCheckDelaySeconds        int // delay for request reports
-	ReportCheckDelaySecondsMax     int // max delay for request reports
 }
 
 // HostStatus configure host status on agent start/stop

--- a/config/config.go
+++ b/config/config.go
@@ -40,9 +40,7 @@ func getAgentName() string {
 // DefaultConfig stores standard settings for each environment
 var DefaultConfig *Config
 
-var defaultConnectionConfig = ConnectionConfig{
-	PostMetricsDequeueDelaySeconds: 30, // Check the metric values queue for every half minute
-}
+var defaultConnectionConfig = ConnectionConfig{}
 
 // CloudPlatform is an enum to represent which cloud platform the host is running on.
 type CloudPlatform int
@@ -369,7 +367,6 @@ var PostMetricsInterval = 1 * time.Minute
 
 // ConnectionConfig XXX
 type ConnectionConfig struct {
-	PostMetricsDequeueDelaySeconds int // delay for dequeuing from buffer queue
 }
 
 // HostStatus configure host status on agent start/stop

--- a/config/config.go
+++ b/config/config.go
@@ -40,8 +40,6 @@ func getAgentName() string {
 // DefaultConfig stores standard settings for each environment
 var DefaultConfig *Config
 
-var defaultConnectionConfig = ConnectionConfig{}
-
 // CloudPlatform is an enum to represent which cloud platform the host is running on.
 type CloudPlatform int
 
@@ -104,8 +102,7 @@ type Config struct {
 	Roles         []string
 	Verbose       bool
 	Silent        bool
-	Diagnostic    bool `toml:"diagnostic"`
-	Connection    ConnectionConfig
+	Diagnostic    bool          `toml:"diagnostic"`
 	DisplayName   string        `toml:"display_name"`
 	HostStatus    HostStatus    `toml:"host_status"`
 	Filesystems   Filesystems   `toml:"filesystems"`
@@ -365,10 +362,6 @@ func (cc CommandConfig) parse() (cmd *Command, err error) {
 // PostMetricsInterval XXX
 var PostMetricsInterval = 1 * time.Minute
 
-// ConnectionConfig XXX
-type ConnectionConfig struct {
-}
-
 // HostStatus configure host status on agent start/stop
 type HostStatus struct {
 	OnStart string `toml:"on_start"`
@@ -436,7 +429,6 @@ func LoadConfig(conffile string) (*Config, error) {
 	if config.Diagnostic == false {
 		config.Diagnostic = DefaultConfig.Diagnostic
 	}
-	config.Connection = DefaultConfig.Connection
 
 	return config, err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,6 @@ var defaultConnectionConfig = ConnectionConfig{
 	PostMetricsDequeueDelaySeconds: 30,     // Check the metric values queue for every half minute
 	PostMetricsRetryDelaySeconds:   60,     // Wait a minute before retrying metric value posts
 	PostMetricsRetryMax:            60,     // Retry up to 60 times (30s * 60 = 30min)
-	PostMetricsBufferSize:          6 * 60, // Keep metric values of 6 hours span in the queue
 }
 
 // CloudPlatform is an enum to represent which cloud platform the host is running on.
@@ -375,7 +374,6 @@ type ConnectionConfig struct {
 	PostMetricsDequeueDelaySeconds int // delay for dequeuing from buffer queue
 	PostMetricsRetryDelaySeconds   int // delay for retrying a request that caused errors
 	PostMetricsRetryMax            int // max numbers of retries for a request that causes errors
-	PostMetricsBufferSize          int // max numbers of requests stored in buffer queue.
 }
 
 // HostStatus configure host status on agent start/stop

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,6 @@ var defaultConnectionConfig = ConnectionConfig{
 	PostMetricsRetryDelaySeconds:   60,     // Wait a minute before retrying metric value posts
 	PostMetricsRetryMax:            60,     // Retry up to 60 times (30s * 60 = 30min)
 	PostMetricsBufferSize:          6 * 60, // Keep metric values of 6 hours span in the queue
-	ReportCheckDelaySeconds:        1,      // Wait a second before reporting the next check
 }
 
 // CloudPlatform is an enum to represent which cloud platform the host is running on.
@@ -377,7 +376,6 @@ type ConnectionConfig struct {
 	PostMetricsRetryDelaySeconds   int // delay for retrying a request that caused errors
 	PostMetricsRetryMax            int // max numbers of retries for a request that causes errors
 	PostMetricsBufferSize          int // max numbers of requests stored in buffer queue.
-	ReportCheckDelaySeconds        int // delay for request reports
 }
 
 // HostStatus configure host status on agent start/stop

--- a/config/config_darwin.go
+++ b/config/config_darwin.go
@@ -8,10 +8,9 @@ import (
 func init() {
 	mackerelRoot := filepath.Join(os.Getenv("HOME"), "Library", getAgentName())
 	DefaultConfig = &Config{
-		Apibase:    getApibase(),
-		Root:       mackerelRoot,
-		Pidfile:    filepath.Join(mackerelRoot, "pid"),
-		Conffile:   filepath.Join(mackerelRoot, getAgentName()+".conf"),
-		Connection: defaultConnectionConfig,
+		Apibase:  getApibase(),
+		Root:     mackerelRoot,
+		Pidfile:  filepath.Join(mackerelRoot, "pid"),
+		Conffile: filepath.Join(mackerelRoot, getAgentName()+".conf"),
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -117,10 +117,6 @@ func TestLoadConfig(t *testing.T) {
 	if config.Connection.ReportCheckRetryDelaySeconds != 30 {
 		t.Errorf("should be 30 but got: %d", config.Connection.ReportCheckRetryDelaySeconds)
 	}
-
-	if config.Connection.ReportCheckBufferSize != 360 {
-		t.Errorf("should be 360 but got: %d", config.Connection.ReportCheckBufferSize)
-	}
 }
 
 var sampleConfigWithHostStatus = `

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -113,10 +113,6 @@ func TestLoadConfig(t *testing.T) {
 	if config.Connection.ReportCheckDelaySecondsMax != 30 {
 		t.Errorf("should be 30 but got: %d", config.Connection.ReportCheckDelaySecondsMax)
 	}
-
-	if config.Connection.ReportCheckRetryDelaySeconds != 30 {
-		t.Errorf("should be 30 but got: %d", config.Connection.ReportCheckRetryDelaySeconds)
-	}
 }
 
 var sampleConfigWithHostStatus = `

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -101,10 +101,6 @@ func TestLoadConfig(t *testing.T) {
 	if config.Connection.PostMetricsRetryDelaySeconds != 60 {
 		t.Errorf("should be 60 but got: %d", config.Connection.PostMetricsRetryDelaySeconds)
 	}
-
-	if config.Connection.PostMetricsRetryMax != 60 {
-		t.Errorf("should be 60 but got: %d", config.Connection.PostMetricsRetryMax)
-	}
 }
 
 var sampleConfigWithHostStatus = `

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,10 +109,6 @@ func TestLoadConfig(t *testing.T) {
 	if config.Connection.ReportCheckDelaySeconds != 1 {
 		t.Errorf("should be 1 but got: %d", config.Connection.ReportCheckDelaySeconds)
 	}
-
-	if config.Connection.ReportCheckDelaySecondsMax != 30 {
-		t.Errorf("should be 30 but got: %d", config.Connection.ReportCheckDelaySecondsMax)
-	}
 }
 
 var sampleConfigWithHostStatus = `

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -105,10 +105,6 @@ func TestLoadConfig(t *testing.T) {
 	if config.Connection.PostMetricsRetryMax != 60 {
 		t.Errorf("should be 60 but got: %d", config.Connection.PostMetricsRetryMax)
 	}
-
-	if config.Connection.ReportCheckDelaySeconds != 1 {
-		t.Errorf("should be 1 but got: %d", config.Connection.ReportCheckDelaySeconds)
-	}
 }
 
 var sampleConfigWithHostStatus = `

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,10 +93,6 @@ func TestLoadConfig(t *testing.T) {
 	if config.Filesystems.UseMountpoint != false {
 		t.Error("should be false (default value should be used)")
 	}
-
-	if config.Connection.PostMetricsDequeueDelaySeconds != 30 {
-		t.Errorf("should be 30 but got: %d", config.Connection.PostMetricsDequeueDelaySeconds)
-	}
 }
 
 var sampleConfigWithHostStatus = `

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -97,10 +97,6 @@ func TestLoadConfig(t *testing.T) {
 	if config.Connection.PostMetricsDequeueDelaySeconds != 30 {
 		t.Errorf("should be 30 but got: %d", config.Connection.PostMetricsDequeueDelaySeconds)
 	}
-
-	if config.Connection.PostMetricsRetryDelaySeconds != 60 {
-		t.Errorf("should be 60 but got: %d", config.Connection.PostMetricsRetryDelaySeconds)
-	}
 }
 
 var sampleConfigWithHostStatus = `

--- a/config/config_unix.go
+++ b/config/config_unix.go
@@ -7,10 +7,9 @@ import "fmt"
 func init() {
 	agentName := getAgentName()
 	DefaultConfig = &Config{
-		Apibase:    getApibase(),
-		Root:       fmt.Sprintf("/var/lib/%s", agentName),
-		Pidfile:    fmt.Sprintf("/var/run/%s.pid", agentName),
-		Conffile:   fmt.Sprintf("/etc/%[1]s/%[1]s.conf", agentName),
-		Connection: defaultConnectionConfig,
+		Apibase:  getApibase(),
+		Root:     fmt.Sprintf("/var/lib/%s", agentName),
+		Pidfile:  fmt.Sprintf("/var/run/%s.pid", agentName),
+		Conffile: fmt.Sprintf("/etc/%[1]s/%[1]s.conf", agentName),
 	}
 }

--- a/config/config_windows.go
+++ b/config/config_windows.go
@@ -14,10 +14,9 @@ func init() {
 	execDir := filepath.Dir(path)
 	agentName := getAgentName()
 	DefaultConfig = &Config{
-		Apibase:    getApibase(),
-		Root:       execDir,
-		Pidfile:    filepath.Join(execDir, agentName+".pid"),
-		Conffile:   filepath.Join(execDir, agentName+".conf"),
-		Connection: defaultConnectionConfig,
+		Apibase:  getApibase(),
+		Root:     execDir,
+		Pidfile:  filepath.Join(execDir, agentName+".pid"),
+		Conffile: filepath.Join(execDir, agentName+".conf"),
 	}
 }


### PR DESCRIPTION
This is a refactoring pull request. Move connection constants to local variables and remove the ConnectionConfig struct.