### PR TITLE
[nit] Refactoring: spec generator returns structs of HostMeta of mackerel-client-go

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -576,9 +576,9 @@ func collectHostSpecs(conf *config.Config, ameta *AgentMeta) (mackerel.HostSpec,
 		return mackerel.HostSpec{}, fmt.Errorf("failed to collect interfaces: %s", err.Error())
 	}
 
-	meta["agent-version"] = ameta.Version
-	meta["agent-revision"] = ameta.Revision
-	meta["agent-name"] = buildUA(ameta.Version, ameta.Revision)
+	meta.AgentVersion = ameta.Version
+	meta.AgentRevision = ameta.Revision
+	meta.AgentName = buildUA(ameta.Version, ameta.Revision)
 
 	checks := []mackerel.CheckConfig{}
 	for name, checkPlugin := range conf.CheckPlugins {

--- a/command/command.go
+++ b/command/command.go
@@ -600,13 +600,6 @@ func collectHostSpecs(conf *config.Config, ameta *AgentMeta) (mackerel.HostSpec,
 	}, nil
 }
 
-func fillUpSpecMeta(meta map[string]interface{}, ver, rev string) map[string]interface{} {
-	meta["agent-version"] = ver
-	meta["agent-revision"] = rev
-	meta["agent-name"] = buildUA(ver, rev)
-	return meta
-}
-
 // UpdateHostSpecs updates the host information that is already registered on Mackerel.
 func (app *App) UpdateHostSpecs() {
 	logger.Debugf("Updating host specs...")

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -200,8 +200,20 @@ func TestCollectHostSpecs(t *testing.T) {
 		t.Error("hostname should not be empty")
 	}
 
-	if _, ok := hostSpec.Meta["cpu"]; !ok {
+	if len(hostSpec.Meta.CPU) == 0 {
 		t.Error("meta.cpu should exist")
+	}
+
+	if len(hostSpec.Meta.Memory) == 0 {
+		t.Error("meta.memory should exist")
+	}
+
+	if len(hostSpec.Meta.Filesystem) == 0 {
+		t.Error("meta.filesystem should exist")
+	}
+
+	if len(hostSpec.Meta.Kernel) == 0 {
+		t.Error("meta.kernel should exist")
 	}
 }
 

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	mkr "github.com/mackerelio/mackerel-client-go"
 )
 
 func TestNewAPI(t *testing.T) {
@@ -90,7 +92,7 @@ func TestCreateHost(t *testing.T) {
 			Name          string              `json:"name"`
 			Type          string              `json:"type"`
 			Status        string              `json:"status"`
-			Meta          map[string]string   `json:"meta"`
+			Meta          mkr.HostMeta        `json:"meta"`
 			Interfaces    []map[string]string `json:"interfaces"`
 			RoleFullnames []string            `json:"roleFullnames"`
 		}
@@ -100,8 +102,8 @@ func TestCreateHost(t *testing.T) {
 			t.Fatal("request content should be decoded as json", content)
 		}
 
-		if data.Meta["memo"] != "hello" {
-			t.Error("request sends json including memo but: ", data)
+		if data.Meta.AgentName != "mackerel-agent" {
+			t.Error("request sends json including agent-name but: ", data)
 		}
 
 		if len(data.Interfaces) == 0 {
@@ -140,8 +142,8 @@ func TestCreateHost(t *testing.T) {
 	})
 	hostSpec := HostSpec{
 		Name: "dummy",
-		Meta: map[string]interface{}{
-			"memo": "hello",
+		Meta: mkr.HostMeta{
+			AgentName: "mackerel-agent",
 		},
 		Interfaces:       interfaces,
 		RoleFullnames:    []string{"My-Service:app-default"},
@@ -180,7 +182,7 @@ func TestCreateHostWithNilArgs(t *testing.T) {
 			Name          string              `json:"name"`
 			Type          string              `json:"type"`
 			Status        string              `json:"status"`
-			Meta          map[string]string   `json:"meta"`
+			Meta          mkr.HostMeta        `json:"meta"`
 			Interfaces    []map[string]string `json:"interfaces"`
 			RoleFullnames []string            `json:"roleFullnames"`
 		}
@@ -234,7 +236,7 @@ func TestUpdateHost(t *testing.T) {
 			Name          string              `json:"name"`
 			Type          string              `json:"type"`
 			Status        string              `json:"status"`
-			Meta          map[string]string   `json:"meta"`
+			Meta          mkr.HostMeta        `json:"meta"`
 			Interfaces    []map[string]string `json:"interfaces"`
 			RoleFullnames []string            `json:"roleFullnames"`
 			Checks        []string            `json:"checks"`
@@ -245,8 +247,8 @@ func TestUpdateHost(t *testing.T) {
 			t.Fatal("request content should be decoded as json", content)
 		}
 
-		if data.Meta["memo"] != "hello" {
-			t.Error("request sends json including memo but: ", data)
+		if data.Meta.AgentName != "mackerel-agent" {
+			t.Error("request sends json including agent-name but: ", data)
 		}
 
 		if len(data.Interfaces) == 0 {
@@ -284,8 +286,8 @@ func TestUpdateHost(t *testing.T) {
 
 	hostSpec := HostSpec{
 		Name: "dummy",
-		Meta: map[string]interface{}{
-			"memo": "hello",
+		Meta: mkr.HostMeta{
+			AgentName: "mackerel-agent",
 		},
 		Interfaces:    interfaces,
 		RoleFullnames: []string{"My-Service:app-default"},

--- a/mackerel/host.go
+++ b/mackerel/host.go
@@ -1,5 +1,7 @@
 package mackerel
 
+import mkr "github.com/mackerelio/mackerel-client-go"
+
 // Host XXX
 type Host struct {
 	ID               string `json:"id"`
@@ -17,11 +19,11 @@ type CheckConfig struct {
 
 // HostSpec is host specifications sent Mackerel server per hour
 type HostSpec struct {
-	Name             string                 `json:"name"`
-	Meta             map[string]interface{} `json:"meta"`
-	Interfaces       interface{}            `json:"interfaces"`
-	RoleFullnames    []string               `json:"roleFullnames"`
-	Checks           []CheckConfig          `json:"checks"`
-	DisplayName      string                 `json:"displayName,omitempty"`
-	CustomIdentifier string                 `json:"customIdentifier,omitempty"`
+	Name             string        `json:"name"`
+	Meta             mkr.HostMeta  `json:"meta"`
+	Interfaces       interface{}   `json:"interfaces"`
+	RoleFullnames    []string      `json:"roleFullnames"`
+	Checks           []CheckConfig `json:"checks"`
+	DisplayName      string        `json:"displayName,omitempty"`
+	CustomIdentifier string        `json:"customIdentifier,omitempty"`
 }

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
+
 	"github.com/mackerelio/mackerel-agent/config"
 )
 
@@ -28,11 +30,6 @@ type CloudGenerator struct {
 type CloudMetaGenerator interface {
 	Generate() (interface{}, error)
 	SuggestCustomIdentifier() (string, error)
-}
-
-// Key is a root key for the generator.
-func (g *CloudGenerator) Key() string {
-	return "cloud"
 }
 
 var cloudLogger = logging.GetLogger("spec.cloud")
@@ -172,11 +169,7 @@ func (g *EC2Generator) Generate() (interface{}, error) {
 		}
 	}
 
-	results := make(map[string]interface{})
-	results["provider"] = "ec2"
-	results["metadata"] = metadata
-
-	return results, nil
+	return &mackerel.Cloud{Provider: "ec2", MetaData: metadata}, nil
 }
 
 // SuggestCustomIdentifier suggests the identifier of the EC2 instance
@@ -257,12 +250,8 @@ func (g gceMeta) toGeneratorMeta() map[string]string {
 	return meta
 }
 
-func (g gceMeta) toGeneratorResults() interface{} {
-	results := make(map[string]interface{})
-	results["provider"] = "gce"
-	results["metadata"] = g.toGeneratorMeta()
-
-	return results
+func (g gceMeta) toGeneratorResults() *mackerel.Cloud {
+	return &mackerel.Cloud{Provider: "gce", MetaData: g.toGeneratorMeta()}
 }
 
 // SuggestCustomIdentifier for GCE is not implemented yet
@@ -296,11 +285,7 @@ func (g *AzureVMGenerator) Generate() (interface{}, error) {
 	metadata = retrieveAzureVMMetadata(metadata, g.baseURL.String(), "/compute/", metadataComputeKeys)
 	metadata = retrieveAzureVMMetadata(metadata, g.baseURL.String(), "/network/interface/0/ipv4/ipAddress/0/", ipAddressKeys)
 
-	results := make(map[string]interface{})
-	results["provider"] = "AzureVM"
-	results["metadata"] = metadata
-
-	return results, nil
+	return &mackerel.Cloud{Provider: "AzureVM", MetaData: metadata}, nil
 }
 
 func retrieveAzureVMMetadata(metadataMap map[string]string, baseURL string, urlSuffix string, keys map[string]string) map[string]string {

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/mackerelio/mackerel-client-go"
+
 	"github.com/mackerelio/mackerel-agent/config"
 )
 
@@ -32,19 +34,14 @@ func TestCloudGenerate(t *testing.T) {
 		t.Errorf("should not raise error: %s", err)
 	}
 
-	cloud, typeOk := value.(map[string]interface{})
+	cloud, typeOk := value.(*mackerel.Cloud)
 	if !typeOk {
-		t.Errorf("value should be map. %+v", value)
+		t.Errorf("value should be *mackerel.Cloud. %+v", value)
 	}
 
-	value, ok := cloud["metadata"]
-	if !ok {
-		t.Error("results should have metadata.")
-	}
-
-	metadata, typeOk := value.(map[string]string)
+	metadata, typeOk := cloud.MetaData.(map[string]string)
 	if !typeOk {
-		t.Errorf("v should be map. %+v", value)
+		t.Errorf("MetaData should be map. %+v", cloud.MetaData)
 	}
 
 	if len(metadata["instance-id"]) == 0 {

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -12,14 +12,6 @@ import (
 	"github.com/mackerelio/mackerel-agent/config"
 )
 
-func TestCloudKey(t *testing.T) {
-	g := &CloudGenerator{}
-
-	if g.Key() != "cloud" {
-		t.Error("key should be cloud")
-	}
-}
-
 func TestCloudGenerate(t *testing.T) {
 	handler := func(res http.ResponseWriter, req *http.Request) {
 		fmt.Fprint(res, "i-4f90d537")

--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -10,15 +10,11 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
-// CPUGenerator Collects CPU specs
+// CPUGenerator collects CPU specs
 type CPUGenerator struct {
-}
-
-// Key XXX
-func (g *CPUGenerator) Key() string {
-	return "cpu"
 }
 
 var cpuLogger = logging.GetLogger("spec.cpu")
@@ -101,7 +97,7 @@ func (g *CPUGenerator) Generate() (interface{}, error) {
 		cpuLogger.Errorf("Failed: %s", err)
 		return nil, err
 	}
-	results := make([]cpuSpec, *cpuCount)
+	results := make(mackerel.CPU, *cpuCount)
 	for i := 0; i < *cpuCount; i++ {
 		results[i] = cpuInfo
 	}

--- a/spec/darwin/cpu_test.go
+++ b/spec/darwin/cpu_test.go
@@ -2,7 +2,11 @@
 
 package darwin
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
 
 func TestCPUGenerator_Generate(t *testing.T) {
 	g := &CPUGenerator{}
@@ -12,9 +16,9 @@ func TestCPUGenerator_Generate(t *testing.T) {
 		t.Errorf("Generate() must not fail: %s", err)
 	}
 
-	cpus, ok := result.([]cpuSpec)
+	cpus, ok := result.(mackerel.CPU)
 	if !ok {
-		t.Fatalf("the result must be of type []cpuSpec: %T", result)
+		t.Fatalf("the result must be of type mackerel.CPU: %T", result)
 	}
 
 	if len(cpus) == 0 {

--- a/spec/darwin/interface.go
+++ b/spec/darwin/interface.go
@@ -17,11 +17,6 @@ import (
 type InterfaceGenerator struct {
 }
 
-// Key XXX
-func (g *InterfaceGenerator) Key() string {
-	return "interface"
-}
-
 var interfaceLogger = logging.GetLogger("spec.interface")
 
 // Generate XXX

--- a/spec/darwin/interface_test.go
+++ b/spec/darwin/interface_test.go
@@ -6,14 +6,6 @@ import (
 	"testing"
 )
 
-func TestInterfaceKey(t *testing.T) {
-	g := &InterfaceGenerator{}
-
-	if g.Key() != "interface" {
-		t.Error("key should be interface")
-	}
-}
-
 func TestInterfaceGenerate(t *testing.T) {
 	g := &InterfaceGenerator{}
 	value, err := g.Generate()

--- a/spec/darwin/kernel.go
+++ b/spec/darwin/kernel.go
@@ -7,15 +7,11 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 // KernelGenerator Generates specs about the kernel.
 type KernelGenerator struct {
-}
-
-// Key XXX
-func (g *KernelGenerator) Key() string {
-	return "kernel"
 }
 
 var kernelLogger = logging.GetLogger("spec.kernel")
@@ -35,7 +31,7 @@ func (g *KernelGenerator) Generate() (interface{}, error) {
 	}
 
 	// +1 is for `name`
-	results := make(map[string]string, len(commands)+1)
+	results := make(mackerel.Kernel, len(commands)+1)
 
 	for field, commandAndArgs := range commands {
 		out, err := exec.Command(commandAndArgs[0], commandAndArgs[1:]...).Output()

--- a/spec/darwin/kernel_test.go
+++ b/spec/darwin/kernel_test.go
@@ -2,7 +2,11 @@
 
 package darwin
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
 
 func TestKernelGenerator_Generate(t *testing.T) {
 	g := &KernelGenerator{}
@@ -12,9 +16,9 @@ func TestKernelGenerator_Generate(t *testing.T) {
 		t.Errorf("Generate() must not fail: %s", err)
 	}
 
-	kernel, ok := result.(map[string]string)
+	kernel, ok := result.(mackerel.Kernel)
 	if !ok {
-		t.Fatalf("the result must be of type map[string]string: %t", result)
+		t.Fatalf("the result must be of type mackerel.Kernel: %t", result)
 	}
 
 	_, osExists := kernel["os"]

--- a/spec/darwin/memory.go
+++ b/spec/darwin/memory.go
@@ -9,15 +9,11 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 // MemoryGenerator collects the host's memory specs.
 type MemoryGenerator struct {
-}
-
-// Key XXX
-func (g *MemoryGenerator) Key() string {
-	return "memory"
 }
 
 var memoryLogger = logging.GetLogger("spec.memory")
@@ -28,7 +24,7 @@ const bytesInKibibytes = 1024
 // The returned spec must have below:
 // - total (in "###kB" format, Kibibytes)
 func (g *MemoryGenerator) Generate() (interface{}, error) {
-	spec := map[string]string{}
+	spec := make(mackerel.Memory)
 
 	cmd := exec.Command("sysctl", "-n", "hw.memsize")
 	outputBytes, err := cmd.Output()

--- a/spec/darwin/memory_test.go
+++ b/spec/darwin/memory_test.go
@@ -5,6 +5,8 @@ package darwin
 import (
 	"regexp"
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestMemoryGenerator_Generate(t *testing.T) {
@@ -15,7 +17,7 @@ func TestMemoryGenerator_Generate(t *testing.T) {
 		t.Errorf("Generate() must not fail: %s", err)
 	}
 
-	memorySpecs := result.(map[string]string)
+	memorySpecs := result.(mackerel.Memory)
 	totalMemory, ok := memorySpecs["total"]
 	if !ok {
 		t.Error("'total' key must exist")

--- a/spec/filesystem.go
+++ b/spec/filesystem.go
@@ -5,25 +5,22 @@ package spec
 import (
 	"fmt"
 
+	"github.com/mackerelio/mackerel-client-go"
+
 	"github.com/mackerelio/mackerel-agent/util"
 )
 
-// FilesystemGenerator generator for filesystems implements spec.Generator interface
+// FilesystemGenerator generates filesystem spec.
 type FilesystemGenerator struct {
 }
 
-// Key key name of the generator for satisfying spec.Generator interface
-func (g *FilesystemGenerator) Key() string {
-	return "filesystem"
-}
-
-// Generate specs of filesystems
+// Generate specs of filesystems.
 func (g *FilesystemGenerator) Generate() (interface{}, error) {
 	filesystems, err := util.CollectDfValues()
 	if err != nil {
 		return nil, err
 	}
-	ret := make(map[string]map[string]interface{})
+	ret := make(mackerel.FileSystem)
 	for _, v := range filesystems {
 		ret[v.Name] = map[string]interface{}{
 			"kb_size":      v.Blocks,

--- a/spec/filesystem_test.go
+++ b/spec/filesystem_test.go
@@ -4,14 +4,6 @@ package spec
 
 import "testing"
 
-func TestFilesystemGenerator(t *testing.T) {
-	g := &FilesystemGenerator{}
-
-	if g.Key() != "filesystem" {
-		t.Error("key should be 'filesystem'")
-	}
-}
-
 func TestFilesystemGenerate(t *testing.T) {
 	g := &FilesystemGenerator{}
 

--- a/spec/filesystem_test.go
+++ b/spec/filesystem_test.go
@@ -2,7 +2,11 @@
 
 package spec
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
 
 func TestFilesystemGenerate(t *testing.T) {
 	g := &FilesystemGenerator{}
@@ -12,8 +16,8 @@ func TestFilesystemGenerate(t *testing.T) {
 		t.Skipf("Generate() failed: %s", err)
 	}
 
-	_, resultTypeOk := result.(map[string]map[string]interface{})
+	_, resultTypeOk := result.(mackerel.FileSystem)
 	if !resultTypeOk {
-		t.Errorf("Return type of Generate() shuold be map[string]map[string]interface{}")
+		t.Errorf("Return type of Generate() shuold be mackerel.FileSystem")
 	}
 }

--- a/spec/freebsd/cpu.go
+++ b/spec/freebsd/cpu.go
@@ -6,15 +6,11 @@ import (
 	"os/exec"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
-// CPUGenerator Collects CPU specs
+// CPUGenerator collects CPU specs
 type CPUGenerator struct {
-}
-
-// Key XXX
-func (g *CPUGenerator) Key() string {
-	return "cpu"
 }
 
 var cpuLogger = logging.GetLogger("spec.cpu")
@@ -44,7 +40,7 @@ func (g *CPUGenerator) Generate() (interface{}, error) {
 		return nil, err
 	}
 
-	return []cpuSpec{
+	return mackerel.CPU{
 		{"model_name": string(brandBytes)},
 	}, nil
 }

--- a/spec/freebsd/cpu_test.go
+++ b/spec/freebsd/cpu_test.go
@@ -2,7 +2,11 @@
 
 package freebsd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
 
 func TestCPUGenerator_Generate(t *testing.T) {
 	g := &CPUGenerator{}
@@ -12,9 +16,9 @@ func TestCPUGenerator_Generate(t *testing.T) {
 		t.Errorf("Generate() must not fail: %s", err)
 	}
 
-	cpus, ok := result.([]cpuSpec)
+	cpus, ok := result.(mackerel.CPU)
 	if !ok {
-		t.Fatalf("the result must be of type []cpuSpec: %T", result)
+		t.Fatalf("the result must be of type mackerel.CPU: %T", result)
 	}
 
 	if len(cpus) == 0 {

--- a/spec/freebsd/interface.go
+++ b/spec/freebsd/interface.go
@@ -8,11 +8,6 @@ import "github.com/mackerelio/mackerel-agent/spec"
 type InterfaceGenerator struct {
 }
 
-// Key XXX
-func (g *InterfaceGenerator) Key() string {
-	return "interface"
-}
-
 // Generate XXX
 func (g *InterfaceGenerator) Generate() ([]spec.NetInterface, error) {
 	// TODO

--- a/spec/freebsd/kernel.go
+++ b/spec/freebsd/kernel.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 // KernelGenerator Generates specs about the kernel.
@@ -17,11 +18,6 @@ import (
 // - machine: the machine hardware name ("i686")
 // - os:      the operating system name ("GNU/Linux")
 type KernelGenerator struct {
-}
-
-// Key XXX
-func (g *KernelGenerator) Key() string {
-	return "kernel"
 }
 
 var kernelLogger = logging.GetLogger("spec.kernel")
@@ -35,7 +31,7 @@ func (g *KernelGenerator) Generate() (interface{}, error) {
 		"os":      {"-s"},
 	}
 
-	results := make(map[string]string, len(unameArgs)+1)
+	results := make(mackerel.Kernel, len(unameArgs)+1)
 
 	for field, args := range unameArgs {
 		out, err := exec.Command("/usr/bin/uname", args...).Output()

--- a/spec/freebsd/kernel_test.go
+++ b/spec/freebsd/kernel_test.go
@@ -2,7 +2,11 @@
 
 package freebsd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
 
 func TestKernelGenerator_Generate(t *testing.T) {
 	g := &KernelGenerator{}
@@ -12,9 +16,9 @@ func TestKernelGenerator_Generate(t *testing.T) {
 		t.Errorf("Generate() must not fail: %s", err)
 	}
 
-	kernel, ok := result.(map[string]string)
+	kernel, ok := result.(mackerel.Kernel)
 	if !ok {
-		t.Fatalf("the result must be of type map[string]string: %t", result)
+		t.Fatalf("the result must be of type mackerel.Kernel: %t", result)
 	}
 
 	_, osExists := kernel["os"]

--- a/spec/freebsd/memory.go
+++ b/spec/freebsd/memory.go
@@ -9,15 +9,11 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 // MemoryGenerator collects the host's memory specs.
 type MemoryGenerator struct {
-}
-
-// Key XXX
-func (g *MemoryGenerator) Key() string {
-	return "memory"
 }
 
 var memoryLogger = logging.GetLogger("spec.memory")
@@ -28,7 +24,7 @@ const bytesInKibibytes = 1024
 // The returned spec must have below:
 // - total (in "###kB" format, Kibibytes)
 func (g *MemoryGenerator) Generate() (interface{}, error) {
-	spec := map[string]string{}
+	spec := make(mackerel.Memory)
 
 	cmd := exec.Command("sysctl", "-n", "hw.physmem")
 	outputBytes, err := cmd.Output()

--- a/spec/freebsd/memory_test.go
+++ b/spec/freebsd/memory_test.go
@@ -5,6 +5,8 @@ package freebsd
 import (
 	"regexp"
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestMemoryGenerator_Generate(t *testing.T) {
@@ -15,7 +17,7 @@ func TestMemoryGenerator_Generate(t *testing.T) {
 		t.Errorf("Generate() must not fail: %s", err)
 	}
 
-	memorySpecs := result.(map[string]string)
+	memorySpecs := result.(mackerel.Memory)
 	totalMemory, ok := memorySpecs["total"]
 	if !ok {
 		t.Error("'total' key must exist")

--- a/spec/linux/block_device.go
+++ b/spec/linux/block_device.go
@@ -9,15 +9,11 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 // BlockDeviceGenerator XXX
 type BlockDeviceGenerator struct {
-}
-
-// Key XXX
-func (g *BlockDeviceGenerator) Key() string {
-	return "block_device"
 }
 
 var blockDeviceLogger = logging.GetLogger("spec.block_device")
@@ -35,7 +31,7 @@ func (g *BlockDeviceGenerator) Generate() (interface{}, error) {
 		return nil, err
 	}
 
-	results := make(map[string]map[string]interface{})
+	results := make(mackerel.BlockDevice)
 
 	for _, fileInfo := range fileInfos {
 		deviceName := fileInfo.Name()

--- a/spec/linux/block_device_test.go
+++ b/spec/linux/block_device_test.go
@@ -5,6 +5,8 @@ package linux
 import (
 	"regexp"
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func hasValidBlockDeviceValueForKey(t *testing.T, deviceInfo map[string]interface{}, key string) {
@@ -23,9 +25,9 @@ func TestBlockDeviceGenerate(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	blockDevice, typeOk := value.(map[string]map[string]interface{})
+	blockDevice, typeOk := value.(mackerel.BlockDevice)
 	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
+		t.Errorf("value should be mackerel.BlockDevice. %+v", value)
 	}
 
 	sda, ok := blockDevice["sda"]

--- a/spec/linux/block_device_test.go
+++ b/spec/linux/block_device_test.go
@@ -7,14 +7,6 @@ import (
 	"testing"
 )
 
-func TestBlockDeviceGenerator(t *testing.T) {
-	g := &BlockDeviceGenerator{}
-
-	if g.Key() != "block_device" {
-		t.Error("key should be block_device")
-	}
-}
-
 func hasValidBlockDeviceValueForKey(t *testing.T, deviceInfo map[string]interface{}, key string) {
 	if value, ok := deviceInfo[key]; !ok {
 		t.Errorf("value of %s should be retrieved but none", key)

--- a/spec/linux/cpu.go
+++ b/spec/linux/cpu.go
@@ -9,15 +9,11 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
-// CPUGenerator Collects CPU specs
+// CPUGenerator collects CPU specs
 type CPUGenerator struct {
-}
-
-// Key return "cpu"
-func (g *CPUGenerator) Key() string {
-	return "cpu"
 }
 
 var cpuLogger = logging.GetLogger("spec.cpu")
@@ -25,7 +21,7 @@ var cpuLogger = logging.GetLogger("spec.cpu")
 func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
 	scanner := bufio.NewScanner(file)
 
-	var results []map[string]interface{}
+	var results mackerel.CPU
 	var cur map[string]interface{}
 	var modelName string
 

--- a/spec/linux/cpu_test.go
+++ b/spec/linux/cpu_test.go
@@ -7,14 +7,6 @@ import (
 	"testing"
 )
 
-func TestCPUKey(t *testing.T) {
-	g := &CPUGenerator{}
-
-	if g.Key() != "cpu" {
-		t.Error("key should be cpu")
-	}
-}
-
 func TestCPUGenerate(t *testing.T) {
 	g := &CPUGenerator{}
 	value, err := g.Generate()

--- a/spec/linux/cpu_test.go
+++ b/spec/linux/cpu_test.go
@@ -5,6 +5,8 @@ package linux
 import (
 	"bytes"
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestCPUGenerate(t *testing.T) {
@@ -14,9 +16,9 @@ func TestCPUGenerate(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	cpu, typeOk := value.([]map[string]interface{})
+	cpu, typeOk := value.(mackerel.CPU)
 	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
+		t.Errorf("value should be mackerel.CPU. %+v", value)
 	}
 
 	if len(cpu) == 0 {
@@ -120,9 +122,9 @@ power management:`
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	cpus, typeOk := value.([]map[string]interface{})
+	cpus, typeOk := value.(mackerel.CPU)
 	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
+		t.Errorf("value should be mackerel.CPU. %+v", value)
 	}
 
 	if len(cpus) != 2 {
@@ -198,9 +200,9 @@ Revision        : 1a01040`
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	cpus, typeOk := value.([]map[string]interface{})
+	cpus, typeOk := value.(mackerel.CPU)
 	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
+		t.Errorf("value should be mackerel.CPU. %+v", value)
 	}
 
 	if len(cpus) != 4 {
@@ -249,9 +251,9 @@ Serial          : 0000000000000000`
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	cpus, typeOk := value.([]map[string]interface{})
+	cpus, typeOk := value.(mackerel.CPU)
 	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
+		t.Errorf("value should be mackerel.CPU. %+v", value)
 	}
 
 	if len(cpus) != 4 {
@@ -289,9 +291,9 @@ Serial          : 0000000000000000`
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	cpus, typeOk := value.([]map[string]interface{})
+	cpus, typeOk := value.(mackerel.CPU)
 	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
+		t.Errorf("value should be mackerel.CPU. %+v", value)
 	}
 
 	if len(cpus) != 1 {

--- a/spec/linux/interface.go
+++ b/spec/linux/interface.go
@@ -15,11 +15,6 @@ import (
 type InterfaceGenerator struct {
 }
 
-// Key XXX
-func (g *InterfaceGenerator) Key() string {
-	return "interface"
-}
-
 var interfaceLogger = logging.GetLogger("spec.interface")
 
 // Generate XXX

--- a/spec/linux/interface_test.go
+++ b/spec/linux/interface_test.go
@@ -7,14 +7,6 @@ import (
 	"testing"
 )
 
-func TestInterfaceKey(t *testing.T) {
-	g := &InterfaceGenerator{}
-
-	if g.Key() != "interface" {
-		t.Error("key should be interface")
-	}
-}
-
 func TestInterfaceGenerate(t *testing.T) {
 	g := &InterfaceGenerator{}
 	value, err := g.Generate()

--- a/spec/linux/kernel.go
+++ b/spec/linux/kernel.go
@@ -7,16 +7,12 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 	"github.com/shirou/gopsutil/host"
 )
 
 // KernelGenerator XXX
 type KernelGenerator struct {
-}
-
-// Key XXX
-func (g *KernelGenerator) Key() string {
-	return "kernel"
 }
 
 var kernelLogger = logging.GetLogger("spec.kernel")
@@ -31,7 +27,7 @@ func (g *KernelGenerator) Generate() (interface{}, error) {
 		"os":      {"uname", "-o"},
 	}
 
-	results := make(map[string]string)
+	results := make(mackerel.Kernel)
 	for key, command := range commands {
 		out, err := exec.Command(command[0], command[1]).Output()
 		if err != nil {

--- a/spec/linux/kernel_test.go
+++ b/spec/linux/kernel_test.go
@@ -6,14 +6,6 @@ import (
 	"testing"
 )
 
-func TestKernelKey(t *testing.T) {
-	g := &KernelGenerator{}
-
-	if g.Key() != "kernel" {
-		t.Error("key should be kernel")
-	}
-}
-
 func TestKernelGenerate(t *testing.T) {
 	g := &KernelGenerator{}
 	value, err := g.Generate()

--- a/spec/linux/kernel_test.go
+++ b/spec/linux/kernel_test.go
@@ -4,6 +4,8 @@ package linux
 
 import (
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestKernelGenerate(t *testing.T) {
@@ -13,9 +15,9 @@ func TestKernelGenerate(t *testing.T) {
 		t.Errorf("should not raise error: %s", err)
 	}
 
-	kernel, typeOk := value.(map[string]string)
+	kernel, typeOk := value.(mackerel.Kernel)
 	if !typeOk {
-		t.Errorf("value should be map. %+v", value)
+		t.Errorf("value should be mackerel.Kernel. %+v", value)
 	}
 
 	if len(kernel["name"]) == 0 {

--- a/spec/linux/memory.go
+++ b/spec/linux/memory.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 var memItems = map[string]string{
@@ -46,11 +47,6 @@ var memItems = map[string]string{
 type MemoryGenerator struct {
 }
 
-// Key XXX
-func (g *MemoryGenerator) Key() string {
-	return "memory"
-}
-
 var memoryLogger = logging.GetLogger("spec.memory")
 
 // Generate XXX
@@ -64,10 +60,10 @@ func (g *MemoryGenerator) Generate() (interface{}, error) {
 	return generateMemorySpec(file)
 }
 
-func generateMemorySpec(out io.Reader) (map[string]string, error) {
+func generateMemorySpec(out io.Reader) (mackerel.Memory, error) {
 	scanner := bufio.NewScanner(out)
 
-	result := make(map[string]string)
+	result := make(mackerel.Memory)
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
 		if len(fields) < 2 {

--- a/spec/linux/memory_test.go
+++ b/spec/linux/memory_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestMemoryGenerator(t *testing.T) {
@@ -15,9 +17,9 @@ func TestMemoryGenerator(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	memory, typeOk := value.(map[string]string)
+	memory, typeOk := value.(mackerel.Memory)
 	if !typeOk {
-		t.Errorf("value should be map. %+v", value)
+		t.Errorf("value should be mackerel.Memory. %+v", value)
 	}
 
 	memItemKeys := []string{
@@ -104,7 +106,7 @@ DirectMap1G:    12582912 kB
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
-	expected := map[string]string{
+	expected := mackerel.Memory{
 		"total":            "15434208kB",
 		"free":             "3009856kB",
 		"buffers":          "443104kB",

--- a/spec/linux/memory_test.go
+++ b/spec/linux/memory_test.go
@@ -8,14 +8,6 @@ import (
 	"testing"
 )
 
-func TestMemoryKey(t *testing.T) {
-	g := &MemoryGenerator{}
-
-	if g.Key() != "memory" {
-		t.Error("key should be memory")
-	}
-}
-
 func TestMemoryGenerator(t *testing.T) {
 	g := &MemoryGenerator{}
 	value, err := g.Generate()

--- a/spec/net_interface.go
+++ b/spec/net_interface.go
@@ -74,6 +74,5 @@ func (ifs NetInterfaces) AppendIPv6Address(name, addr string) {
 
 // InterfaceGenerator retrieve network informations
 type InterfaceGenerator interface {
-	Key() string
 	Generate() ([]NetInterface, error)
 }

--- a/spec/netbsd/cpu.go
+++ b/spec/netbsd/cpu.go
@@ -6,15 +6,11 @@ import (
 	"os/exec"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 // CPUGenerator Collects CPU specs
 type CPUGenerator struct {
-}
-
-// Key XXX
-func (g *CPUGenerator) Key() string {
-	return "cpu"
 }
 
 var cpuLogger = logging.GetLogger("spec.cpu")
@@ -44,7 +40,7 @@ func (g *CPUGenerator) Generate() (interface{}, error) {
 		return nil, err
 	}
 
-	return []cpuSpec{
+	return mackerel.CPU{
 		{"model_name": string(brandBytes)},
 	}, nil
 }

--- a/spec/netbsd/cpu_test.go
+++ b/spec/netbsd/cpu_test.go
@@ -2,7 +2,11 @@
 
 package netbsd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
 
 func TestCPUGenerator_Generate(t *testing.T) {
 	g := &CPUGenerator{}
@@ -12,9 +16,9 @@ func TestCPUGenerator_Generate(t *testing.T) {
 		t.Errorf("Generate() must not fail: %s", err)
 	}
 
-	cpus, ok := result.([]cpuSpec)
+	cpus, ok := result.(mackerel.CPU)
 	if !ok {
-		t.Fatalf("the result must be of type []cpuSpec: %T", result)
+		t.Fatalf("the result must be of type mackerel.CPU: %T", result)
 	}
 
 	if len(cpus) == 0 {

--- a/spec/netbsd/interface.go
+++ b/spec/netbsd/interface.go
@@ -8,11 +8,6 @@ import "github.com/mackerelio/mackerel-agent/spec"
 type InterfaceGenerator struct {
 }
 
-// Key XXX
-func (g *InterfaceGenerator) Key() string {
-	return "interface"
-}
-
 // Generate XXX
 func (g *InterfaceGenerator) Generate() ([]spec.NetInterface, error) {
 	// TODO

--- a/spec/netbsd/kernel.go
+++ b/spec/netbsd/kernel.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 // KernelGenerator Generates specs about the kernel.
@@ -17,11 +18,6 @@ import (
 // - machine: the machine hardware name ("i686")
 // - os:      the operating system name ("GNU/Linux")
 type KernelGenerator struct {
-}
-
-// Key XXX
-func (g *KernelGenerator) Key() string {
-	return "kernel"
 }
 
 var kernelLogger = logging.GetLogger("spec.kernel")
@@ -35,7 +31,7 @@ func (g *KernelGenerator) Generate() (interface{}, error) {
 		"os":      {"-s"},
 	}
 
-	results := make(map[string]string, len(unameArgs)+1)
+	results := make(mackerel.Kernel, len(unameArgs)+1)
 
 	for field, args := range unameArgs {
 		out, err := exec.Command("/usr/bin/uname", args...).Output()

--- a/spec/netbsd/kernel_test.go
+++ b/spec/netbsd/kernel_test.go
@@ -2,7 +2,11 @@
 
 package netbsd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
 
 func TestKernelGenerator_Generate(t *testing.T) {
 	g := &KernelGenerator{}
@@ -12,9 +16,9 @@ func TestKernelGenerator_Generate(t *testing.T) {
 		t.Errorf("Generate() must not fail: %s", err)
 	}
 
-	kernel, ok := result.(map[string]string)
+	kernel, ok := result.(mackerel.Kernel)
 	if !ok {
-		t.Fatalf("the result must be of type map[string]string: %t", result)
+		t.Fatalf("the result must be of type mackerel.Kernel: %t", result)
 	}
 
 	_, osExists := kernel["os"]

--- a/spec/netbsd/memory.go
+++ b/spec/netbsd/memory.go
@@ -9,15 +9,11 @@ import (
 	"strings"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 // MemoryGenerator collects the host's memory specs.
 type MemoryGenerator struct {
-}
-
-// Key XXX
-func (g *MemoryGenerator) Key() string {
-	return "memory"
 }
 
 var memoryLogger = logging.GetLogger("spec.memory")
@@ -28,7 +24,7 @@ const bytesInKibibytes = 1024
 // The returned spec must have below:
 // - total (in "###kB" format, Kibibytes)
 func (g *MemoryGenerator) Generate() (interface{}, error) {
-	spec := map[string]string{}
+	spec := make(mackerel.Memory)
 
 	cmd := exec.Command("sysctl", "-n", "hw.physmem64")
 	outputBytes, err := cmd.Output()

--- a/spec/netbsd/memory_test.go
+++ b/spec/netbsd/memory_test.go
@@ -5,6 +5,8 @@ package netbsd
 import (
 	"regexp"
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestMemoryGenerator_Generate(t *testing.T) {
@@ -15,7 +17,7 @@ func TestMemoryGenerator_Generate(t *testing.T) {
 		t.Errorf("Generate() must not fail: %s", err)
 	}
 
-	memorySpecs := result.(map[string]string)
+	memorySpecs := result.(mackerel.Memory)
 	totalMemory, ok := memorySpecs["total"]
 	if !ok {
 		t.Error("'total' key must exist")

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -2,26 +2,40 @@ package spec
 
 import (
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 var logger = logging.GetLogger("spec")
 
 // Generator interface for generating spec values
 type Generator interface {
-	Key() string
 	Generate() (interface{}, error)
 }
 
 // Collect spec values
-func Collect(specGenerators []Generator) map[string]interface{} {
-	specs := make(map[string]interface{})
+func Collect(specGenerators []Generator) mackerel.HostMeta {
+	var specs mackerel.HostMeta
 	for _, g := range specGenerators {
 		value, err := g.Generate()
 		if err != nil {
 			logger.Warningf("Failed to collect meta in %T (skip this spec): %s", g, err.Error())
 			continue
 		}
-		specs[g.Key()] = value
+		switch v := value.(type) {
+		case mackerel.BlockDevice:
+			specs.BlockDevice = v
+		case mackerel.CPU:
+			specs.CPU = v
+		case mackerel.FileSystem:
+			specs.Filesystem = v
+		case mackerel.Kernel:
+			specs.Kernel = v
+		case mackerel.Memory:
+			specs.Memory = v
+		case *mackerel.Cloud:
+			specs.Cloud = v
+		default:
+		}
 	}
 	return specs
 }

--- a/spec/spec_test.go
+++ b/spec/spec_test.go
@@ -3,41 +3,41 @@ package spec
 import (
 	"fmt"
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
-type testStructOK struct{}
+type testCPUGenerator struct{}
 
-func (tok *testStructOK) Key() string {
-	return "ok"
+func (g *testCPUGenerator) Generate() (interface{}, error) {
+	return mackerel.CPU{{"cores": "2"}}, nil
 }
 
-func (tok *testStructOK) Generate() (interface{}, error) {
-	return 15, nil
+type testKernelGenerator struct{}
+
+func (g *testKernelGenerator) Generate() (interface{}, error) {
+	return mackerel.Kernel{"name": "Linux"}, nil
 }
 
-type testStructErr struct{}
+type testErrorGenerator struct{}
 
-func (tok *testStructErr) Key() string {
-	return "error"
-}
-
-func (tok *testStructErr) Generate() (interface{}, error) {
+func (g *testErrorGenerator) Generate() (interface{}, error) {
 	return nil, fmt.Errorf("error")
 }
 
 func TestCollect(t *testing.T) {
 	generators := []Generator{
-		&testStructOK{},
-		&testStructErr{},
+		&testCPUGenerator{},
+		&testKernelGenerator{},
+		&testErrorGenerator{},
 	}
 	specs := Collect(generators)
 
-	if specs["ok"] != 15 {
-		t.Error("metric value of ok should be 15")
+	if len(specs.CPU) != 1 {
+		t.Error("cpu spec should be collected")
 	}
 
-	_, ok := specs["error"]
-	if ok {
-		t.Error("when error, metric should not be collected")
+	if len(specs.Kernel) != 1 {
+		t.Error("kernel spec should be collected")
 	}
 }

--- a/spec/windows/block_device.go
+++ b/spec/windows/block_device.go
@@ -7,6 +7,8 @@ import (
 	"unsafe"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
+
 	"github.com/mackerelio/mackerel-agent/util/windows"
 )
 
@@ -14,16 +16,11 @@ import (
 type BlockDeviceGenerator struct {
 }
 
-// Key XXX
-func (g *BlockDeviceGenerator) Key() string {
-	return "block_device"
-}
-
 var blockDeviceLogger = logging.GetLogger("spec.block_device")
 
 // Generate XXX
 func (g *BlockDeviceGenerator) Generate() (interface{}, error) {
-	results := make(map[string]map[string]interface{})
+	results := make(mackerel.BlockDevice)
 
 	drivebuf := make([]byte, 256)
 	r, _, err := windows.GetLogicalDriveStrings.Call(

--- a/spec/windows/block_device_test.go
+++ b/spec/windows/block_device_test.go
@@ -5,6 +5,8 @@ package windows
 import (
 	"regexp"
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func hasValidBlockDeviceValueForKey(t *testing.T, deviceInfo map[string]interface{}, key string) {
@@ -23,9 +25,9 @@ func TestBlockDeviceGenerate(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	blockDevice, typeOk := value.(map[string]map[string]interface{})
+	blockDevice, typeOk := value.(mackerel.BlockDevice)
 	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
+		t.Errorf("value should be mackerel.BlockDevice. %+v", value)
 	}
 
 	sda, ok := blockDevice["sda"]

--- a/spec/windows/block_device_test.go
+++ b/spec/windows/block_device_test.go
@@ -7,14 +7,6 @@ import (
 	"testing"
 )
 
-func TestBlockDeviceGenerator(t *testing.T) {
-	g := &BlockDeviceGenerator{}
-
-	if g.Key() != "block_device" {
-		t.Error("key should be block_device")
-	}
-}
-
 func hasValidBlockDeviceValueForKey(t *testing.T, deviceInfo map[string]interface{}, key string) {
 	if value, ok := deviceInfo[key]; !ok {
 		t.Errorf("value of %s should be retrieved but none", key)

--- a/spec/windows/cpu.go
+++ b/spec/windows/cpu.go
@@ -7,23 +7,20 @@ import (
 	"unsafe"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
+
 	"github.com/mackerelio/mackerel-agent/util/windows"
 )
 
-// CPUGenerator XXX
+// CPUGenerator collects CPU specs
 type CPUGenerator struct {
-}
-
-// Key XXX
-func (g *CPUGenerator) Key() string {
-	return "cpu"
 }
 
 var cpuLogger = logging.GetLogger("spec.cpu")
 
-// Generate XXX
+// Generate collects CPU specs.
 func (g *CPUGenerator) Generate() (interface{}, error) {
-	var results []map[string]interface{}
+	var results mackerel.CPU
 
 	var systemInfo windows.SYSTEM_INFO
 	windows.GetSystemInfo.Call(uintptr(unsafe.Pointer(&systemInfo)))

--- a/spec/windows/cpu_test.go
+++ b/spec/windows/cpu_test.go
@@ -4,6 +4,8 @@ package windows
 
 import (
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestCPUGenerate(t *testing.T) {
@@ -13,9 +15,9 @@ func TestCPUGenerate(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	cpu, typeOk := value.([]map[string]interface{})
+	cpu, typeOk := value.(mackerel.CPU)
 	if !typeOk {
-		t.Errorf("value should be slice of map. %+v", value)
+		t.Errorf("value should be mackerel.CPU. %+v", value)
 	}
 
 	if len(cpu) == 0 {

--- a/spec/windows/cpu_test.go
+++ b/spec/windows/cpu_test.go
@@ -6,14 +6,6 @@ import (
 	"testing"
 )
 
-func TestCPUKey(t *testing.T) {
-	g := &CPUGenerator{}
-
-	if g.Key() != "cpu" {
-		t.Error("key should be cpu")
-	}
-}
-
 func TestCPUGenerate(t *testing.T) {
 	g := &CPUGenerator{}
 	value, err := g.Generate()

--- a/spec/windows/filesystem.go
+++ b/spec/windows/filesystem.go
@@ -4,24 +4,21 @@ package windows
 
 import (
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
+
 	"github.com/mackerelio/mackerel-agent/util/windows"
 )
 
-// FilesystemGenerator XXX
+// FilesystemGenerator generates filesystem spec.
 type FilesystemGenerator struct {
-}
-
-// Key XX
-func (g *FilesystemGenerator) Key() string {
-	return "filesystem"
 }
 
 var filesystemLogger = logging.GetLogger("spec.filesystem")
 
-// Generate XXX
+// Generate specs of filesystems.
 func (g *FilesystemGenerator) Generate() (interface{}, error) {
 
-	ret := make(map[string]map[string]interface{})
+	ret := make(mackerel.FileSystem)
 
 	fileSystems, err := windows.CollectFilesystemValues()
 	for drive, f := range fileSystems {

--- a/spec/windows/filesystem_test.go
+++ b/spec/windows/filesystem_test.go
@@ -4,14 +4,6 @@ package windows
 
 import "testing"
 
-func TestFilesystemGenerator(t *testing.T) {
-	g := &FilesystemGenerator{}
-
-	if g.Key() != "filesystem" {
-		t.Error("key should be 'filesystem'")
-	}
-}
-
 func TestFilesystemGenerate(t *testing.T) {
 	g := &FilesystemGenerator{}
 

--- a/spec/windows/filesystem_test.go
+++ b/spec/windows/filesystem_test.go
@@ -2,7 +2,11 @@
 
 package windows
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
 
 func TestFilesystemGenerate(t *testing.T) {
 	g := &FilesystemGenerator{}
@@ -12,8 +16,8 @@ func TestFilesystemGenerate(t *testing.T) {
 		t.Skipf("Generate() failed: %s", err)
 	}
 
-	_, resultTypeOk := result.(map[string]map[string]interface{})
+	_, resultTypeOk := result.(mackerel.FileSystem)
 	if !resultTypeOk {
-		t.Errorf("Return type of Generate() shuold be map[string]map[string]interface{}")
+		t.Errorf("Return type of Generate() shuold be mackerel.FileSystem")
 	}
 }

--- a/spec/windows/interface.go
+++ b/spec/windows/interface.go
@@ -14,11 +14,6 @@ import (
 type InterfaceGenerator struct {
 }
 
-// Key XXX
-func (g *InterfaceGenerator) Key() string {
-	return "interface"
-}
-
 var interfaceLogger = logging.GetLogger("spec.interface")
 
 // Generate XXX

--- a/spec/windows/interface_test.go
+++ b/spec/windows/interface_test.go
@@ -6,14 +6,6 @@ import (
 	"testing"
 )
 
-func TestInterfaceKey(t *testing.T) {
-	g := &InterfaceGenerator{}
-
-	if g.Key() != "interface" {
-		t.Error("key should be interface")
-	}
-}
-
 func TestInterfaceGenerate(t *testing.T) {
 	g := &InterfaceGenerator{}
 	interfaces, err := g.Generate()

--- a/spec/windows/kernel.go
+++ b/spec/windows/kernel.go
@@ -6,6 +6,8 @@ import (
 	"unsafe"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
+
 	"github.com/mackerelio/mackerel-agent/util/windows"
 )
 
@@ -13,16 +15,11 @@ import (
 type KernelGenerator struct {
 }
 
-// Key XXX
-func (g *KernelGenerator) Key() string {
-	return "kernel"
-}
-
 var kernelLogger = logging.GetLogger("spec.kernel")
 
 // Generate XXX
 func (g *KernelGenerator) Generate() (interface{}, error) {
-	results := make(map[string]string)
+	results := make(mackerel.Kernel)
 
 	name, _, err := windows.RegGetString(
 		windows.HKEY_LOCAL_MACHINE,

--- a/spec/windows/kernel_test.go
+++ b/spec/windows/kernel_test.go
@@ -4,6 +4,8 @@ package windows
 
 import (
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestKernelGenerate(t *testing.T) {
@@ -13,9 +15,9 @@ func TestKernelGenerate(t *testing.T) {
 		t.Errorf("should not raise error: %s", err)
 	}
 
-	kernel, typeOk := value.(map[string]string)
+	kernel, typeOk := value.(mackerel.Kernel)
 	if !typeOk {
-		t.Errorf("value should be map. %+v", value)
+		t.Errorf("value should be mackerel.Kernel. %+v", value)
 	}
 
 	if len(kernel["name"]) == 0 {

--- a/spec/windows/kernel_test.go
+++ b/spec/windows/kernel_test.go
@@ -6,14 +6,6 @@ import (
 	"testing"
 )
 
-func TestKernelKey(t *testing.T) {
-	g := &KernelGenerator{}
-
-	if g.Key() != "kernel" {
-		t.Error("key should be kernel")
-	}
-}
-
 func TestKernelGenerate(t *testing.T) {
 	g := &KernelGenerator{}
 	value, err := g.Generate()

--- a/spec/windows/memory.go
+++ b/spec/windows/memory.go
@@ -7,6 +7,8 @@ import (
 	"unsafe"
 
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
+
 	"github.com/mackerelio/mackerel-agent/util/windows"
 )
 
@@ -14,16 +16,11 @@ import (
 type MemoryGenerator struct {
 }
 
-// Key XXX
-func (g *MemoryGenerator) Key() string {
-	return "memory"
-}
-
 var memoryLogger = logging.GetLogger("spec.memory")
 
 // Generate XXX
 func (g *MemoryGenerator) Generate() (interface{}, error) {
-	result := make(map[string]interface{})
+	result := make(mackerel.Memory)
 
 	var memoryStatusEx windows.MEMORY_STATUS_EX
 	memoryStatusEx.Length = uint32(unsafe.Sizeof(memoryStatusEx))

--- a/spec/windows/memory_test.go
+++ b/spec/windows/memory_test.go
@@ -4,6 +4,8 @@ package windows
 
 import (
 	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestMemoryGenerator(t *testing.T) {
@@ -13,9 +15,9 @@ func TestMemoryGenerator(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	memory, typeOk := value.(map[string]interface{})
+	memory, typeOk := value.(mackerel.Memory)
 	if !typeOk {
-		t.Errorf("value should be map. %+v", value)
+		t.Errorf("value should be mackerel.Memory. %+v", value)
 	}
 
 	if _, ok := memory["total"]; !ok {

--- a/spec/windows/memory_test.go
+++ b/spec/windows/memory_test.go
@@ -6,14 +6,6 @@ import (
 	"testing"
 )
 
-func TestMemoryKey(t *testing.T) {
-	g := &MemoryGenerator{}
-
-	if g.Key() != "memory" {
-		t.Error("key should be memory")
-	}
-}
-
 func TestMemoryGenerator(t *testing.T) {
 	g := &MemoryGenerator{}
 	value, err := g.Generate()


### PR DESCRIPTION
This pull request refactors spec generators. I prefer using structs to `map[string]interface{}` and let JSON marshalization to the JSON tags. This is a part of refactoring, towards using the client-go library and remove the mackerel directory from this project.