### PR TITLE
Do HTTP retry on determining cloud platform and suggesting customIdentifier

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -71,30 +71,31 @@ func SuggestCloudGenerator(conf *config.Config) *CloudGenerator {
 	go func() {
 		if isEC2(ctx) {
 			gCh <- &CloudGenerator{&EC2Generator{ec2BaseURL}}
+			cancel()
 		}
 		wg.Done()
 	}()
 	go func() {
 		if isGCE(ctx) {
 			gCh <- &CloudGenerator{&GCEGenerator{gceMetaURL}}
+			cancel()
 		}
 		wg.Done()
 	}()
 	go func() {
 		if isAzure(ctx) {
 			gCh <- &CloudGenerator{&AzureVMGenerator{azureVMBaseURL}}
+			cancel()
 		}
 		wg.Done()
 	}()
 
-	var cg *CloudGenerator
 	go func() {
-		cg = <-gCh
-		cancel()
+		wg.Wait()
+		close(gCh)
 	}()
-	wg.Wait()
 
-	return cg
+	return <-gCh
 }
 
 func httpCli() *http.Client {

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -124,6 +124,25 @@ func requestGCEMeta() ([]byte, error) {
 	return ioutil.ReadAll(resp.Body)
 }
 
+const maxRetry = 3
+
+func suggestWithRetry(f func() (string, error)) (string, error) {
+	var (
+		retry      int
+		identifier string
+		err        error
+	)
+
+	for retry < maxRetry {
+		identifier, err = f()
+		if err == nil {
+			break
+		}
+		retry++
+	}
+	return identifier, err
+}
+
 // EC2Generator meta generator for EC2
 type EC2Generator struct {
 	baseURL *url.URL
@@ -174,25 +193,27 @@ func (g *EC2Generator) Generate() (interface{}, error) {
 
 // SuggestCustomIdentifier suggests the identifier of the EC2 instance
 func (g *EC2Generator) SuggestCustomIdentifier() (string, error) {
-	cl := httpCli()
-	key := "instance-id"
-	resp, err := cl.Get(g.baseURL.String() + "/" + key)
-	if err != nil {
-		return "", fmt.Errorf("error while retrieving instance-id")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("failed to request instance-id. response code: %d", resp.StatusCode)
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("results of requesting instance-id cannot be read: '%s'", err)
-	}
-	instanceID := string(body)
-	if instanceID == "" {
-		return "", fmt.Errorf("invalid instance id")
-	}
-	return instanceID + ".ec2.amazonaws.com", nil
+	return suggestWithRetry(func() (string, error) {
+		cl := httpCli()
+		key := "instance-id"
+		resp, err := cl.Get(g.baseURL.String() + "/" + key)
+		if err != nil {
+			return "", fmt.Errorf("error while retrieving instance-id")
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			return "", fmt.Errorf("failed to request instance-id. response code: %d", resp.StatusCode)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("results of requesting instance-id cannot be read: '%s'", err)
+		}
+		instanceID := string(body)
+		if instanceID == "" {
+			return "", fmt.Errorf("invalid instance id")
+		}
+		return instanceID + ".ec2.amazonaws.com", nil
+	})
 }
 
 // GCEGenerator generate for GCE
@@ -324,29 +345,31 @@ func retrieveAzureVMMetadata(metadataMap map[string]string, baseURL string, urlS
 
 // SuggestCustomIdentifier suggests the identifier of the Azure VM instance
 func (g *AzureVMGenerator) SuggestCustomIdentifier() (string, error) {
-	cl := httpCli()
-	req, err := http.NewRequest("GET", azureVMBaseURL.String()+"/compute/vmId?api-version=2017-04-02&format=text", nil)
-	if err != nil {
-		return "", fmt.Errorf("error while retrieving vmId")
-	}
-	req.Header.Set("Metadata", "true")
+	return suggestWithRetry(func() (string, error) {
+		cl := httpCli()
+		req, err := http.NewRequest("GET", azureVMBaseURL.String()+"/compute/vmId?api-version=2017-04-02&format=text", nil)
+		if err != nil {
+			return "", fmt.Errorf("error while retrieving vmId")
+		}
+		req.Header.Set("Metadata", "true")
 
-	resp, err := cl.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("error while retrieving vmId")
-	}
-	defer resp.Body.Close()
+		resp, err := cl.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("error while retrieving vmId")
+		}
+		defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("failed to request vmId. response code: %d", resp.StatusCode)
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("results of requesting vmId cannot be read: '%s'", err)
-	}
-	instanceID := string(body)
-	if instanceID == "" {
-		return "", fmt.Errorf("invalid instance id")
-	}
-	return instanceID + ".virtual_machine.azure.microsoft.com", nil
+		if resp.StatusCode != 200 {
+			return "", fmt.Errorf("failed to request vmId. response code: %d", resp.StatusCode)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("results of requesting vmId cannot be read: '%s'", err)
+		}
+		instanceID := string(body)
+		if instanceID == "" {
+			return "", fmt.Errorf("invalid instance id")
+		}
+		return instanceID + ".virtual_machine.azure.microsoft.com", nil
+	})
 }

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -92,6 +92,7 @@ func SuggestCloudGenerator(conf *config.Config) *CloudGenerator {
 
 	go func() {
 		wg.Wait()
+		// close so that `<-gCh` will receive nul
 		close(gCh)
 	}()
 

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/Songmu/retry"
 	"github.com/mackerelio/golib/logging"
+	"github.com/mackerelio/mackerel-client-go"
 
 	"github.com/mackerelio/mackerel-agent/config"
-	"github.com/mackerelio/mackerel-client-go"
 )
 
 // This Generator collects metadata about cloud instances.

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -110,7 +110,7 @@ func httpCli() *http.Client {
 }
 
 func isGCE(ctx context.Context) bool {
-	err := retry.Retry(2, 2*time.Second, func() error {
+	err := retry.WithContext(ctx, 2, 2*time.Second, func() error {
 		_, err := requestGCEMeta(ctx)
 		return err
 	})
@@ -120,7 +120,7 @@ func isGCE(ctx context.Context) bool {
 // Note: May want to check without using the API.
 func isAzure(ctx context.Context) bool {
 	isAzure := false
-	err := retry.Retry(2, 2*time.Second, func() error {
+	err := retry.WithContext(ctx, 2, 2*time.Second, func() error {
 		cl := httpCli()
 		// '/vmId` is probably Azure VM specific URL
 		req, err := http.NewRequest("GET", azureVMBaseURL.String()+"/compute/vmId?api-version=2017-04-02&format=text", nil)

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -307,21 +307,21 @@ func TestSuggestCloudGenerator(t *testing.T) {
 	}()
 
 	func() { // multiple generators are available, but suggest the first responded one (in this case EC2)
-		// ec2. ok immediately
-		tsEc2 := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		// azure. ok immediately
+		tsA := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 			fmt.Fprint(res, "ok")
 		}))
-		defer tsEc2.Close()
-		uEc2, _ := url.Parse(tsEc2.URL)
-		ec2BaseURL = uEc2
-		// azure / gce. ok after 1 second
+		defer tsA.Close()
+		uA, _ := url.Parse(tsA.URL)
+		azureVMBaseURL = uA
+		// ec2 / gce. ok after 1 second
 		ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 			time.Sleep(2 * time.Second)
 			fmt.Fprint(res, "ok")
 		}))
 		defer ts.Close()
 		u, _ := url.Parse(ts.URL)
-		azureVMBaseURL = u
+		ec2BaseURL = u
 		gceMetaURL = u
 		defer func() {
 			ec2BaseURL = unreachableURL
@@ -334,9 +334,9 @@ func TestSuggestCloudGenerator(t *testing.T) {
 			t.Errorf("cGen should not be nil.")
 		}
 
-		_, ok := cGen.CloudMetaGenerator.(*EC2Generator)
+		_, ok := cGen.CloudMetaGenerator.(*AzureVMGenerator)
 		if !ok {
-			t.Errorf("cGen should be *EC2Generator")
+			t.Errorf("cGen should be *AzureVMGenerator")
 		}
 	}()
 }

--- a/spec/isec2.go
+++ b/spec/isec2.go
@@ -13,7 +13,7 @@ import (
 // For instances other than Linux, retry only 1 times to shorten whole process
 func isEC2(ctx context.Context) bool {
 	isEC2 := false
-	err := retry.Retry(2, 2*time.Second, func() error {
+	err := retry.WithContext(ctx, 2, 2*time.Second, func() error {
 		cl := httpCli()
 		// '/ami-id` is probably an AWS specific URL
 		req, err := http.NewRequest("GET", ec2BaseURL.String()+"/ami-id", nil)

--- a/spec/isec2.go
+++ b/spec/isec2.go
@@ -2,11 +2,20 @@
 
 package spec
 
+import (
+	"context"
+	"net/http"
+)
+
 // For instances other than Linux, call Metadata API only once.
-func isEC2() bool {
+func isEC2(ctx context.Context) bool {
 	cl := httpCli()
 	// '/ami-id` is probably an AWS specific URL
-	resp, err := cl.Get(ec2BaseURL.String() + "/ami-id")
+	req, err := http.NewRequest("GET", ec2BaseURL.String()+"/ami-id", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := cl.Do(req.WithContext(ctx))
 	if err != nil {
 		return false
 	}

--- a/spec/isec2_linux.go
+++ b/spec/isec2_linux.go
@@ -14,14 +14,18 @@ import (
 	"github.com/Songmu/retry"
 )
 
-var uuidFiles = [2]string{
-	"/sys/hypervisor/uuid",
-	"/sys/devices/virtual/dmi/id/product_uuid",
-}
-
 // If the OS is Linux, check /sys/hypervisor/uuid and /sys/devices/virtual/dmi/id/product_uuid files first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
 // ref. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
 func isEC2(ctx context.Context) bool {
+	var uuidFiles = []string{
+		"/sys/hypervisor/uuid",
+		"/sys/devices/virtual/dmi/id/product_uuid",
+	}
+
+	return isEC2WithSpecifiedUUIDFiles(ctx, uuidFiles)
+}
+
+func isEC2WithSpecifiedUUIDFiles(ctx context.Context, uuidFiles []string) bool {
 	looksLikeEC2 := false
 	for _, u := range uuidFiles {
 		data, err := ioutil.ReadFile(u)

--- a/spec/isec2_linux.go
+++ b/spec/isec2_linux.go
@@ -36,6 +36,11 @@ func isEC2(ctx context.Context) bool {
 		return false
 	}
 
+	// give up if ctx already closed
+	if ctx.Err() != nil {
+		return false
+	}
+
 	res := false
 	cl := httpCli()
 	err := retry.Retry(3, 2*time.Second, func() error {

--- a/spec/isec2_linux.go
+++ b/spec/isec2_linux.go
@@ -42,8 +42,10 @@ func isEC2WithSpecifiedUUIDFiles(ctx context.Context, uuidFiles []string) bool {
 	}
 
 	// give up if ctx already closed
-	if ctx.Err() != nil {
+	select {
+	case <-ctx.Done():
 		return false
+	default:
 	}
 
 	res := false

--- a/spec/isec2_linux.go
+++ b/spec/isec2_linux.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"strings"
 	"time"
 

--- a/spec/isec2_linux.go
+++ b/spec/isec2_linux.go
@@ -48,7 +48,7 @@ func isEC2WithSpecifiedUUIDFiles(ctx context.Context, uuidFiles []string) bool {
 
 	res := false
 	cl := httpCli()
-	err := retry.Retry(3, 2*time.Second, func() error {
+	err := retry.WithContext(ctx, 3, 2*time.Second, func() error {
 		// '/ami-id` is probably an AWS specific URL
 		req, err := http.NewRequest("GET", ec2BaseURL.String()+"/ami-id", nil)
 		if err != nil {

--- a/spec/isec2_linux_test.go
+++ b/spec/isec2_linux_test.go
@@ -18,14 +18,6 @@ func setEc2BaseURL(url *url.URL) func() {
 	}
 }
 
-func setUUIDFiles(files [2]string) func() {
-	oldUUIDFiles := uuidFiles
-	uuidFiles = files
-	return func() {
-		uuidFiles = oldUUIDFiles // restore value
-	}
-}
-
 func TestIsEC2UUID(t *testing.T) {
 	tests := []struct {
 		uuid   string
@@ -108,15 +100,15 @@ func TestIsEC2(t *testing.T) {
 			u, _ := url.Parse(ts.URL)
 			defer setEc2BaseURL(u)()
 
-			var uuidFiles [2]string
-			for i, exist := range tc.existsUUIDFiles {
+			uuidFiles := make([]string, 0, 2)
+			for _, exist := range tc.existsUUIDFiles {
 				tf, err := ioutil.TempFile("", "")
 				if err != nil {
 					t.Errorf("should not raise error: %s", err)
 				}
 
 				tn := tf.Name()
-				uuidFiles[i] = tn
+				uuidFiles = append(uuidFiles, tn)
 
 				if exist {
 					defer os.Remove(tn)
@@ -128,9 +120,8 @@ func TestIsEC2(t *testing.T) {
 				tf.Write([]byte("ec2e1916-9099-7caf-fd21-012345abcdef")) // valid EC2 UUID
 				tf.Close()
 			}
-			defer setUUIDFiles(uuidFiles)()
 
-			if isEC2(context.Background()) != tc.expect {
+			if isEC2WithSpecifiedUUIDFiles(context.Background(), uuidFiles) != tc.expect {
 				t.Errorf("isEC2() should be %t: %#v\n", tc.expect, tc)
 			}
 		}()

--- a/spec/isec2_linux_test.go
+++ b/spec/isec2_linux_test.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -129,7 +130,7 @@ func TestIsEC2(t *testing.T) {
 			}
 			defer setUUIDFiles(uuidFiles)()
 
-			if isEC2() != tc.expect {
+			if isEC2(context.Background()) != tc.expect {
 				t.Errorf("isEC2() should be %t: %#v\n", tc.expect, tc)
 			}
 		}()


### PR DESCRIPTION
In some unlucky situations, HTTP requests to internal metadata endpoint might fail accidentally.
This p-r introduces:
- Retry on SuggestCustomIdentifier itself
    - 1 time => up to 3 times with 2 seconds interval
- Concurrent requests to determine cloud platform
    - (isEC2 => isGCE => isAzure) => (isEC2, isGCE, isAzure)
- Retry on determining cloud platform by HTTP requests
    - 1 time => up to 2 times with 2 seconds interval (exception: EC2 on Linux already retries)

Concurrent requesting `isXXX` is introduced to reduce impact on retry in `isXXX`, which may take up to (3+2+3) seconds for each `isXXX`.

And also, I modified `isEC2` in Linux to avoid data race in tests (happend in  
https://travis-ci.org/mackerelio/mackerel-agent/builds/418496127 ).