### PR TITLE
[darwin] fix filesystem metrics for APFS vm partition volume

### DIFF
--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -101,8 +101,20 @@ func parseDfLines(out string) []*DfStat {
 			continue
 		}
 
-		if runtime.GOOS == "darwin" && strings.HasPrefix(dfstat.Mounted, "/Volumes/") {
-			continue
+		if runtime.GOOS == "darwin" {
+			if strings.HasPrefix(dfstat.Mounted, "/Volumes/") {
+				continue
+			}
+			// Skip APFS vm partition, add its usage to the root filesystem.
+			if dfstat.Mounted == "/private/var/vm" {
+				for _, fs := range filesystems {
+					if fs.Mounted == "/" {
+						fs.Used += dfstat.Used
+						break
+					}
+				}
+				continue
+			}
 		}
 
 		filesystems = append(filesystems, dfstat)


### PR DESCRIPTION
APFS creates a VM partition at /private/var/vm and the agent collects the filesystem metrics but this is totally useless. The partition size is annoying so I think we should skip the metric. The consumed capacity takes from the root disk size so I added to the used metric of the root filesystem.