### PR TITLE
add loadavg1 and loadavg15

### DIFF
--- a/command/command_darwin.go
+++ b/command/command_darwin.go
@@ -23,7 +23,7 @@ func interfaceGenerator() spec.InterfaceGenerator {
 
 func metricsGenerators(conf *config.Config) []metrics.Generator {
 	generators := []metrics.Generator{
-		&metrics.Loadavg5Generator{},
+		&metrics.LoadavgGenerator{},
 		&metricsDarwin.CPUUsageGenerator{},
 		&metricsDarwin.MemoryGenerator{},
 		&metrics.FilesystemGenerator{IgnoreRegexp: conf.Filesystems.Ignore.Regexp, UseMountpoint: conf.Filesystems.UseMountpoint},

--- a/command/command_freebsd.go
+++ b/command/command_freebsd.go
@@ -23,7 +23,7 @@ func interfaceGenerator() spec.InterfaceGenerator {
 
 func metricsGenerators(conf *config.Config) []metrics.Generator {
 	generators := []metrics.Generator{
-		&metrics.Loadavg5Generator{},
+		&metrics.LoadavgGenerator{},
 		&metricsFreebsd.CPUUsageGenerator{},
 		&metrics.FilesystemGenerator{IgnoreRegexp: conf.Filesystems.Ignore.Regexp, UseMountpoint: conf.Filesystems.UseMountpoint},
 		&metricsFreebsd.MemoryGenerator{},

--- a/command/command_linux.go
+++ b/command/command_linux.go
@@ -24,7 +24,7 @@ func interfaceGenerator() spec.InterfaceGenerator {
 
 func metricsGenerators(conf *config.Config) []metrics.Generator {
 	generators := []metrics.Generator{
-		&metrics.Loadavg5Generator{},
+		&metrics.LoadavgGenerator{},
 		&metricsLinux.CPUUsageGenerator{Interval: metricsInterval},
 		&metricsLinux.MemoryGenerator{},
 		&metrics.InterfaceGenerator{Interval: metricsInterval},

--- a/command/command_netbsd.go
+++ b/command/command_netbsd.go
@@ -23,7 +23,7 @@ func interfaceGenerator() spec.InterfaceGenerator {
 
 func metricsGenerators(conf *config.Config) []metrics.Generator {
 	generators := []metrics.Generator{
-		&metrics.Loadavg5Generator{},
+		&metrics.LoadavgGenerator{},
 		&metricsNetbsd.CPUUsageGenerator{},
 		&metrics.FilesystemGenerator{IgnoreRegexp: conf.Filesystems.Ignore.Regexp, UseMountpoint: conf.Filesystems.UseMountpoint},
 		&metricsNetbsd.MemoryGenerator{},

--- a/metrics/loadavg.go
+++ b/metrics/loadavg.go
@@ -7,20 +7,22 @@ import (
 	"github.com/mackerelio/golib/logging"
 )
 
-// loadavg5
+// loadavg
+//   - loadavg1: load average per 1 minutes
 //   - loadavg5: load average per 5 minutes
+//   - loadavg15: load average per 15 minutes
 
-// Loadavg5Generator generates load average values
-type Loadavg5Generator struct {
+// LoadavgGenerator generates load average values
+type LoadavgGenerator struct {
 }
 
-var loadavg5Logger = logging.GetLogger("metrics.loadavg5")
+var loadavgLogger = logging.GetLogger("metrics.loadavg")
 
 // Generate load averages
-func (g *Loadavg5Generator) Generate() (Values, error) {
+func (g *LoadavgGenerator) Generate() (Values, error) {
 	loadavgs, err := loadavg.Get()
 	if err != nil {
-		loadavg5Logger.Errorf("%s", err)
+		loadavgLogger.Errorf("%s", err)
 		return nil, err
 	}
 	return Values{

--- a/metrics/loadavg5.go
+++ b/metrics/loadavg5.go
@@ -23,5 +23,9 @@ func (g *Loadavg5Generator) Generate() (Values, error) {
 		loadavg5Logger.Errorf("%s", err)
 		return nil, err
 	}
-	return Values{"loadavg5": loadavgs.Loadavg5}, nil
+	return Values{
+		"loadavg1":  loadavgs.Loadavg1,
+		"loadavg5":  loadavgs.Loadavg5,
+		"loadavg15": loadavgs.Loadavg15,
+	}, nil
 }

--- a/metrics/loadavg_test.go
+++ b/metrics/loadavg_test.go
@@ -6,20 +6,20 @@ import (
 	"testing"
 )
 
-func TestLoadAvg5Generate(t *testing.T) {
-	g := &Loadavg5Generator{}
+func TestLoadAvgGenerate(t *testing.T) {
+	g := &LoadavgGenerator{}
 	values, err := g.Generate()
 
 	if err != nil {
 		t.Errorf("error should be nil but got: %s", err)
 	}
 
-	metricName := []string{"loadavg5"}
+	metricName := []string{"loadavg1", "loadavg5", "loadavg15"}
 	for _, n := range metricName {
 		if _, ok := values[n]; !ok {
-			t.Errorf("loadavg5 metrics should have '%s': %v", n, values)
+			t.Errorf("loadavg metrics should have '%s': %v", n, values)
 		}
 	}
 
-	t.Logf("loadavg5 metrics: %+v", values)
+	t.Logf("loadavg metrics: %+v", values)
 }


### PR DESCRIPTION
This pull request adds loadavg1 and loadavg15 metrics to the loadavg graph, on all platforms except for Windows. The loadavg graph is more useful when comparing the loadavg5 vs 15 to see the CPU load is increasing or decreasing. We already updated the application to accept these system metrics.

<img src=https://user-images.githubusercontent.com/375258/44830555-26f00400-ac5d-11e8-8e1e-9d94381e70a0.png>
