### PR TITLE
[darwin] Fix iostat output parsing in CPU usage generator

### DIFF
--- a/metrics/darwin/cpuusage.go
+++ b/metrics/darwin/cpuusage.go
@@ -43,12 +43,20 @@ func (g *CPUUsageGenerator) Generate() (metrics.Values, error) {
 
 func parseIostatOutput(output string) (metrics.Values, error) {
 	lines := strings.Split(output, "\n")
-	if len(lines) != 5 {
-		return nil, fmt.Errorf("iostat result malformed: [%q]", output)
+
+	var fields []string
+	for i := len(lines) - 1; i >= 0; i-- {
+		if lines[i] == "" {
+			continue
+		}
+		xs := strings.Fields(lines[i])
+		if len(xs) >= len(iostatFieldToMetricName) {
+			fields = xs
+			break
+		}
 	}
 
-	fields := strings.Fields(lines[3])
-	if len(fields) < len(iostatFieldToMetricName) {
+	if len(fields) == 0 {
 		return nil, fmt.Errorf("iostat result malformed: [%q]", output)
 	}
 

--- a/metrics/darwin/cpuusage.go
+++ b/metrics/darwin/cpuusage.go
@@ -38,15 +38,18 @@ func (g *CPUUsageGenerator) Generate() (metrics.Values, error) {
 		return nil, err
 	}
 
-	iostat := string(iostatBytes)
-	lines := strings.Split(iostat, "\n")
+	return parseIostatOutput(string(iostatBytes))
+}
+
+func parseIostatOutput(output string) (metrics.Values, error) {
+	lines := strings.Split(output, "\n")
 	if len(lines) != 5 {
-		return nil, fmt.Errorf("iostat result malformed: [%q]", iostat)
+		return nil, fmt.Errorf("iostat result malformed: [%q]", output)
 	}
 
 	fields := strings.Fields(lines[3])
 	if len(fields) < len(iostatFieldToMetricName) {
-		return nil, fmt.Errorf("iostat result malformed: [%q]", iostat)
+		return nil, fmt.Errorf("iostat result malformed: [%q]", output)
 	}
 
 	cpuUsage := make(map[string]float64, len(iostatFieldToMetricName))

--- a/metrics/darwin/cpuusage_test.go
+++ b/metrics/darwin/cpuusage_test.go
@@ -2,7 +2,12 @@
 
 package darwin
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hatena/mackerel-container-agent/metric"
+)
 
 func TestCPUUsageGenerator_Generate(t *testing.T) {
 	g := &CPUUsageGenerator{}
@@ -20,4 +25,33 @@ func TestCPUUsageGenerator_Generate(t *testing.T) {
 	}
 
 	t.Logf("cpu metrics: %+v", values)
+}
+
+func TestCPUUsageGenerator_parseIostatOutput(t *testing.T) {
+	testCases := []struct {
+		output string
+		values metric.Values
+	}{
+		{
+			output: `      cpu    load average
+ us sy id   1m   5m   15m
+ 19  9 72  2.50 3.04 3.20
+ 16 12 72  2.50 3.04 3.20
+`,
+			values: metric.Values{
+				"cpu.user.percentage":   16.0,
+				"cpu.system.percentage": 12.0,
+				"cpu.idle.percentage":   72.0,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		got, err := parseIostatOutput(testCase.output)
+		if err != nil {
+			t.Errorf("error should be nil but got: %s", err)
+		}
+		if !reflect.DeepEqual(map[string]float64(got), map[string]float64(testCase.values)) {
+			t.Errorf("metric values should be %#v but got: %#v", testCase.values, got)
+		}
+	}
 }

--- a/metrics/darwin/cpuusage_test.go
+++ b/metrics/darwin/cpuusage_test.go
@@ -44,6 +44,20 @@ func TestCPUUsageGenerator_parseIostatOutput(t *testing.T) {
 				"cpu.idle.percentage":   72.0,
 			},
 		},
+		{
+			output: `      cpu    load average
+ us sy id   1m   5m   15m
+ 19  9 72  2.50 3.04 3.20
+      cpu    load average
+ us sy id   1m   5m   15m
+ 16 12 72  2.50 3.04 3.20
+`,
+			values: metric.Values{
+				"cpu.user.percentage":   16.0,
+				"cpu.system.percentage": 12.0,
+				"cpu.idle.percentage":   72.0,
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		got, err := parseIostatOutput(testCase.output)


### PR DESCRIPTION
The CPUUsageGenerator on darwin platform sometimes emits parsing errors. I'm not sure why and how often it happens but I think we should take care of the format.
```
2018/08/01 10:27:00 ERROR <agent> Failed to generate value in *darwin.CPUUsageGenerator (skip this metric): iostat result malformed: ["      cpu    load average\n us sy id   1m   5m   15m\n 16  8 76  6.70 3.77 3.17\n      cpu    load average\n us sy id   1m   5m   15m\n 44 38 17  6.70 3.77 3.17\n"]
```