### PR TITLE
mackerel-agent.conf default permissions are too open

### DIFF
--- a/do_init.go
+++ b/do_init.go
@@ -39,7 +39,7 @@ func doInitialize(fs *flag.FlagSet, argv []string) error {
 		}
 		contents = append(contents, cBytes...)
 	}
-	return ioutil.WriteFile(*conffile, contents, 0644)
+	return ioutil.WriteFile(*conffile, contents, 0600)
 }
 
 type apikeyAlreadySetError string

--- a/packaging/deb-systemd/debian/mackerel-agent.postinst
+++ b/packaging/deb-systemd/debian/mackerel-agent.postinst
@@ -5,6 +5,7 @@ case "$1" in
 configure)
   if [ ! -e /etc/mackerel-agent/mackerel-agent.conf ]; then
     cp /etc/mackerel-agent/mackerel-agent.conf.example /etc/mackerel-agent/mackerel-agent.conf
+    chmod 600 /etc/mackerel-agent/mackerel-agent.conf
   fi
 ;;
 abort-upgrade|abort-remove|abort-deconfigure)

--- a/packaging/deb/debian/mackerel-agent.postinst
+++ b/packaging/deb/debian/mackerel-agent.postinst
@@ -5,6 +5,7 @@ case "$1" in
 configure)
   if [ ! -e /etc/mackerel-agent/mackerel-agent.conf ]; then
     cp /etc/mackerel-agent/mackerel-agent.conf.example /etc/mackerel-agent/mackerel-agent.conf
+    chmod 600 /etc/mackerel-agent/mackerel-agent.conf
   fi
 ;;
 abort-upgrade|abort-remove|abort-deconfigure)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -31,7 +31,7 @@ mackerel.io agent
 %{__rm} -rf %{buildroot}
 %{__install} -Dp -m0755 %{_builddir}/%{name}             %{buildroot}%{_bindir}/%{name}
 %{__install} -Dp -m0644 %{_sourcedir}/%{name}.sysconfig  %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
-%{__install} -Dp -m0644 %{_sourcedir}/%{name}.conf       %{buildroot}/%{_sysconfdir}/%{name}/%{name}.conf
+%{__install} -Dp -m0600 %{_sourcedir}/%{name}.conf       %{buildroot}/%{_sysconfdir}/%{name}/%{name}.conf
 %{__install} -Dp -m0644 %{_sourcedir}/%{name}.service    %{buildroot}%{_unitdir}/%{name}.service
 
 %clean

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -35,7 +35,7 @@ mackerel.io agent
 %{__install} -Dp -m0755 %{_sourcedir}/%{name}.initd      %{buildroot}/%{_initrddir}/%{name}
 %{__install} -Dp -m0644 %{_sourcedir}/%{name}.sysconfig  %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
 %{__install} -Dp -m0644 %{_sourcedir}/%{name}.logrotate  %{buildroot}/%{_sysconfdir}/logrotate.d/%{name}
-%{__install} -Dp -m0644 %{_sourcedir}/%{name}.conf       %{buildroot}/%{_sysconfdir}/%{name}/%{name}.conf
+%{__install} -Dp -m0600 %{_sourcedir}/%{name}.conf       %{buildroot}/%{_sysconfdir}/%{name}/%{name}.conf
 %{__install} -Dp -m0755 %{_sourcedir}/%{name}.deprecated %{buildroot}/usr/local/bin/%{name}
 
 %clean


### PR DESCRIPTION
_Please note that I am not as familiar with packaging systems as you are, so the changes I have made are only suggestions and I have only tested them running on my own server (seem to work fine for me)._

The issue is that /etc/mackerel-agent/mackerel-agent.conf by default is too permissive, as the default permissions of 644 make it world-readable.

For example, here is the apache user on my machine, reading my Mackerel API key and my MySQL credentials:

```
[apache@node1 ~]# egrep "^[^#;](.*)(key|pass)" /etc/mackerel-agent/mackerel-agent.conf 
apikey = "censored"
command = "mackerel-plugin-mysql -username=root -password=censored"
```

The mackerel-agent service run under systemd is run as root, and the ownership of the file is also root. As such, I suggest that mackerel-agent should update the configuration file permissions to 600, and new installations should also have the permissions set to 600, to prevent credential leakage (especially in the case of a compromised box, in order to prevent privilege escalation.)