### PR TITLE
Release version 0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.57.0 (2018-09-13)
+
+* Build with Go 1.11 #522 (astj)
+* [darwin] Fix iostat output parsing in CPU usage generator #520 (itchyny)
+* [darwin] fix filesystem metrics for APFS vm partition volume #517 (itchyny)
+* add loadavg1 and loadavg15 #519 (itchyny)
+
+
 ## 0.56.1 (2018-08-30)
 
 * Do HTTP retry on determining cloud platform and suggesting customIdentifier #516 (astj)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION = 0.56.1
+VERSION = 0.57.0
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,16 @@
+mackerel-agent (0.57.0-1.systemd) stable; urgency=low
+
+  * Build with Go 1.11 (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/522>
+  * [darwin] Fix iostat output parsing in CPU usage generator (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/520>
+  * [darwin] fix filesystem metrics for APFS vm partition volume (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/517>
+  * add loadavg1 and loadavg15 (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/519>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 13 Sep 2018 14:15:12 +0900
+
 mackerel-agent (0.56.1-1.systemd) stable; urgency=low
 
   * Do HTTP retry on determining cloud platform and suggesting customIdentifier (by astj)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,16 @@
+mackerel-agent (0.57.0-1) stable; urgency=low
+
+  * Build with Go 1.11 (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/522>
+  * [darwin] Fix iostat output parsing in CPU usage generator (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/520>
+  * [darwin] fix filesystem metrics for APFS vm partition volume (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/517>
+  * add loadavg1 and loadavg15 (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/519>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 13 Sep 2018 14:15:12 +0900
+
 mackerel-agent (0.56.1-1) stable; urgency=low
 
   * Do HTTP retry on determining cloud platform and suggesting customIdentifier (by astj)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,12 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Thu Sep 13 2018 <mackerel-developers@hatena.ne.jp> - 0.57.0
+- Build with Go 1.11 (by astj)
+- [darwin] Fix iostat output parsing in CPU usage generator (by itchyny)
+- [darwin] fix filesystem metrics for APFS vm partition volume (by itchyny)
+- add loadavg1 and loadavg15 (by itchyny)
+
 * Thu Aug 30 2018 <mackerel-developers@hatena.ne.jp> - 0.56.1
 - Do HTTP retry on determining cloud platform and suggesting customIdentifier (by astj)
 - [windows] Add timeout to WMI query for disk metrics (by astj)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,12 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Thu Sep 13 2018 <mackerel-developers@hatena.ne.jp> - 0.57.0
+- Build with Go 1.11 (by astj)
+- [darwin] Fix iostat output parsing in CPU usage generator (by itchyny)
+- [darwin] fix filesystem metrics for APFS vm partition volume (by itchyny)
+- add loadavg1 and loadavg15 (by itchyny)
+
 * Thu Aug 30 2018 <mackerel-developers@hatena.ne.jp> - 0.56.1
 - Do HTTP retry on determining cloud platform and suggesting customIdentifier (by astj)
 - [windows] Add timeout to WMI query for disk metrics (by astj)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.56.1"
+const version = "0.57.0"
 
 var gitcommit string


### PR DESCRIPTION
- Build with Go 1.11 #522
- [darwin] Fix iostat output parsing in CPU usage generator #520
- [darwin] fix filesystem metrics for APFS vm partition volume #517
- add loadavg1 and loadavg15 #519