### PR TITLE
CollectDfValues only from local file systems on linux

### DIFF
--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -54,7 +54,7 @@ func init() {
 	case "netbsd":
 		dfOpt = []string{"-Pkl"}
 	default:
-		dfOpt = []string{"-P"}
+		dfOpt = []string{"-Pl"}
 	}
 }
 


### PR DESCRIPTION
For example, when we are using NFS, the df command may hang and even
doesn't accept the "kill -kill" command, so I have targeted only the
local file system.