### PR TITLE
Fix detecting EC2 instance on Windows

### DIFF
--- a/spec/isec2.go
+++ b/spec/isec2.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!windows
 
 package spec
 

--- a/spec/isec2_linux.go
+++ b/spec/isec2_linux.go
@@ -85,7 +85,7 @@ func isEC2UUID(uuid string) bool {
 		return true
 	}
 
-	// Check as littele endian.
+	// Check as little endian.
 	// see. https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/UserGuide/identify_ec2_instances.html
 	fields := strings.Split(uuid, "-")
 	decoded, _ := hex.DecodeString(fields[0]) // fields[0]: UUID time_low(uint32)

--- a/spec/isec2_windows.go
+++ b/spec/isec2_windows.go
@@ -96,7 +96,7 @@ func isEC2UUID(uuid string) bool {
 		return true
 	}
 
-	// Check as littele endian.
+	// Check as little endian.
 	// see. https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/UserGuide/identify_ec2_instances.html
 	fields := strings.Split(uuid, "-")
 	decoded, _ := hex.DecodeString(fields[0]) // fields[0]: UUID time_low(uint32)

--- a/spec/isec2_windows.go
+++ b/spec/isec2_windows.go
@@ -14,8 +14,8 @@ import (
 	"github.com/StackExchange/wmi"
 )
 
-// Win32_ComputerSystemProduct is struct for WMI. SKUNumber is nil-able.
-type Win32_ComputerSystemProduct struct {
+// Win32ComputerSystemProduct is struct for WMI. SKUNumber is nil-able.
+type Win32ComputerSystemProduct struct {
 	Caption           string
 	Description       string
 	IdentifyingNumber string
@@ -29,7 +29,7 @@ type Win32_ComputerSystemProduct struct {
 // If the OS is Windows, check UUID in WMI class Win32_ComputerSystemProduct first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
 // ref. https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/WindowsGuide/identify_ec2_instances.html
 func isEC2(ctx context.Context) bool {
-	var records []Win32_ComputerSystemProduct
+	var records []Win32ComputerSystemProduct
 	err := wmi.Query("SELECT * FROM Win32_ComputerSystemProduct", &records)
 	if err != nil {
 		return false
@@ -40,7 +40,7 @@ func isEC2(ctx context.Context) bool {
 	return isEC2WithSpecifiedWmiRecords(ctx, records)
 }
 
-func isEC2WithSpecifiedWmiRecords(ctx context.Context, records []Win32_ComputerSystemProduct) bool {
+func isEC2WithSpecifiedWmiRecords(ctx context.Context, records []Win32ComputerSystemProduct) bool {
 	looksLikeEC2 := false
 	for _, r := range records {
 		if isEC2UUID(r.UUID) {

--- a/spec/isec2_windows.go
+++ b/spec/isec2_windows.go
@@ -14,13 +14,13 @@ import (
 	"github.com/StackExchange/wmi"
 )
 
-// Win32_ComputerSystemProduct is struct for WMI
+// Win32_ComputerSystemProduct is struct for WMI. SKUNumber is nil-able.
 type Win32_ComputerSystemProduct struct {
 	Caption           string
 	Description       string
 	IdentifyingNumber string
 	Name              string
-	SKUNumber         string
+	SKUNumber         *string
 	UUID              string
 	Vendor            string
 	Version           string

--- a/spec/isec2_windows.go
+++ b/spec/isec2_windows.go
@@ -1,0 +1,108 @@
+package spec
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Songmu/retry"
+	"github.com/StackExchange/wmi"
+)
+
+// Win32_ComputerSystemProduct is struct for WMI
+type Win32_ComputerSystemProduct struct {
+	Caption           string
+	Description       string
+	IdentifyingNumber string
+	Name              string
+	SKUNumber         string
+	UUID              string
+	Vendor            string
+	Version           string
+}
+
+// If the OS is Windows, check UUID in WMIC class Win32_ComputerSystemProduct first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
+// ref. https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/WindowsGuide/identify_ec2_instances.html
+func isEC2(ctx context.Context) bool {
+	var records []Win32_ComputerSystemProduct
+	err := wmi.Query("SELECT * FROM Win32_ComputerSystemProduct", &records)
+	if err != nil {
+		return false
+	}
+	if len(records) == 0 {
+		return false
+	}
+	return isEC2WithSpecifiedWmicRecords(ctx, records)
+}
+
+func isEC2WithSpecifiedWmicRecords(ctx context.Context, records []Win32_ComputerSystemProduct) bool {
+	looksLikeEC2 := false
+	for _, r := range records {
+		if isEC2UUID(r.UUID) {
+			looksLikeEC2 = true
+			break
+		}
+	}
+	if !looksLikeEC2 {
+		return false
+	}
+
+	// give up if ctx already closed
+	select {
+	case <-ctx.Done():
+		return false
+	default:
+	}
+
+	res := false
+	cl := httpCli()
+	err := retry.WithContext(ctx, 3, 2*time.Second, func() error {
+		// '/ami-id` is probably an AWS specific URL
+		req, err := http.NewRequest("GET", ec2BaseURL.String()+"/ami-id", nil)
+		if err != nil {
+			return nil // something wrong. give up
+		}
+		resp, err := cl.Do(req.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		res = resp.StatusCode == 200
+		return nil
+	})
+
+	if err == nil {
+		return res
+	}
+
+	return false
+}
+
+func isEC2UUID(uuid string) bool {
+	conds := func(uuid string) bool {
+		if strings.HasPrefix(uuid, "ec2") || strings.HasPrefix(uuid, "EC2") {
+			return true
+		}
+		return false
+	}
+
+	if conds(uuid) {
+		return true
+	}
+
+	// Check as littele endian.
+	// see. https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/UserGuide/identify_ec2_instances.html
+	fields := strings.Split(uuid, "-")
+	decoded, _ := hex.DecodeString(fields[0]) // fields[0]: UUID time_low(uint32)
+	r := bytes.NewReader(decoded)
+	var data uint32
+	binary.Read(r, binary.LittleEndian, &data)
+
+	return conds(fmt.Sprintf("%x", data))
+}

--- a/spec/isec2_windows.go
+++ b/spec/isec2_windows.go
@@ -26,7 +26,7 @@ type Win32_ComputerSystemProduct struct {
 	Version           string
 }
 
-// If the OS is Windows, check UUID in WMIC class Win32_ComputerSystemProduct first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
+// If the OS is Windows, check UUID in WMI class Win32_ComputerSystemProduct first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
 // ref. https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/WindowsGuide/identify_ec2_instances.html
 func isEC2(ctx context.Context) bool {
 	var records []Win32_ComputerSystemProduct
@@ -37,10 +37,10 @@ func isEC2(ctx context.Context) bool {
 	if len(records) == 0 {
 		return false
 	}
-	return isEC2WithSpecifiedWmicRecords(ctx, records)
+	return isEC2WithSpecifiedWmiRecords(ctx, records)
 }
 
-func isEC2WithSpecifiedWmicRecords(ctx context.Context, records []Win32_ComputerSystemProduct) bool {
+func isEC2WithSpecifiedWmiRecords(ctx context.Context, records []Win32_ComputerSystemProduct) bool {
 	looksLikeEC2 := false
 	for _, r := range records {
 		if isEC2UUID(r.UUID) {

--- a/spec/isec2_windows.go
+++ b/spec/isec2_windows.go
@@ -15,22 +15,23 @@ import (
 )
 
 // Win32ComputerSystemProduct is struct for WMI. SKUNumber is nil-able.
+// The fields except UUID are ommited to not be checked.
 type Win32ComputerSystemProduct struct {
-	Caption           string
-	Description       string
-	IdentifyingNumber string
-	Name              string
-	SKUNumber         *string
-	UUID              string
-	Vendor            string
-	Version           string
+	// Caption           string
+	// Description       string
+	// IdentifyingNumber string
+	// Name              string
+	// SKUNumber         *string
+	UUID string
+	// Vendor            string
+	// Version           string
 }
 
 // If the OS is Windows, check UUID in WMI class Win32_ComputerSystemProduct first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
 // ref. https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/WindowsGuide/identify_ec2_instances.html
 func isEC2(ctx context.Context) bool {
 	var records []Win32ComputerSystemProduct
-	err := wmi.Query("SELECT * FROM Win32_ComputerSystemProduct", &records)
+	err := wmi.Query("SELECT UUID FROM Win32_ComputerSystemProduct", &records)
 	if err != nil {
 		return false
 	}

--- a/spec/isec2_windows_test.go
+++ b/spec/isec2_windows_test.go
@@ -98,16 +98,16 @@ func TestIsEC2(t *testing.T) {
 			u, _ := url.Parse(ts.URL)
 			defer setEc2BaseURL(u)()
 
-			wmicRecords := make([]Win32_ComputerSystemProduct, 2)
+			wmiRecords := make([]Win32_ComputerSystemProduct, 2)
 			for i, exist := range tc.existsWmicRecords {
 				if exist {
-					wmicRecords[i].UUID = "ec2e1916-9099-7caf-fd21-012345abcdef" // valid EC2 UUID
+					wmiRecords[i].UUID = "ec2e1916-9099-7caf-fd21-012345abcdef" // valid EC2 UUID
 				} else {
-					wmicRecords[i].UUID = "ec1e1916-9099-7caf-fd21-012345abcdef" // valid EC2 UUID
+					wmiRecords[i].UUID = "ec1e1916-9099-7caf-fd21-012345abcdef" // valid EC2 UUID
 				}
 			}
 
-			if isEC2WithSpecifiedWmicRecords(context.Background(), wmicRecords) != tc.expect {
+			if isEC2WithSpecifiedWmiRecords(context.Background(), wmiRecords) != tc.expect {
 				t.Errorf("isEC2() should be %t: %#v\n", tc.expect, tc)
 			}
 		}()

--- a/spec/isec2_windows_test.go
+++ b/spec/isec2_windows_test.go
@@ -98,7 +98,7 @@ func TestIsEC2(t *testing.T) {
 			u, _ := url.Parse(ts.URL)
 			defer setEc2BaseURL(u)()
 
-			wmiRecords := make([]Win32_ComputerSystemProduct, 2)
+			wmiRecords := make([]Win32ComputerSystemProduct, 2)
 			for i, exist := range tc.existsWmicRecords {
 				if exist {
 					wmiRecords[i].UUID = "ec2e1916-9099-7caf-fd21-012345abcdef" // valid EC2 UUID

--- a/spec/isec2_windows_test.go
+++ b/spec/isec2_windows_test.go
@@ -1,0 +1,115 @@
+package spec
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func setEc2BaseURL(url *url.URL) func() {
+	oldEC2BaseURL := ec2BaseURL
+	ec2BaseURL = url
+	return func() {
+		ec2BaseURL = oldEC2BaseURL // restore value
+	}
+}
+
+func TestIsEC2UUID(t *testing.T) {
+	tests := []struct {
+		uuid   string
+		expect bool
+	}{
+		{"ec2e1916-9099-7caf-fd21-01234abcdef", true},
+		{"EC2E1916-9099-7CAF-FD21-01234ABCDEF", true},
+		{"45e12aec-dcd1-b213-94ed-01234abcdef", true}, // litte endian
+		{"45E12AEC-DCD1-B213-94ED-01234ABCDEF", true}, // litte endian
+		{"abcd1916-9099-7caf-fd21-01234abcdef", false},
+		{"ABCD1916-9099-7CAF-FD21-01234ABCDEF", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		if isEC2UUID(tc.uuid) != tc.expect {
+			t.Errorf("isEC2() should be %t: %q\n", tc.expect, tc.uuid)
+		}
+	}
+}
+
+func TestIsEC2(t *testing.T) {
+	tests := []struct {
+		existsWmicRecords [2]bool
+		existsAMIId       bool
+		expect            bool
+	}{
+		{
+			existsWmicRecords: [2]bool{
+				true,
+				true,
+			},
+			existsAMIId: true,
+			expect:      true,
+		},
+		{
+			existsWmicRecords: [2]bool{
+				false,
+				true,
+			},
+			existsAMIId: true,
+			expect:      true,
+		},
+		{
+			existsWmicRecords: [2]bool{
+				true,
+				false,
+			},
+			existsAMIId: true,
+			expect:      true,
+		},
+		{
+			existsWmicRecords: [2]bool{
+				false,
+				false,
+			},
+			existsAMIId: true,
+			expect:      false,
+		},
+		{
+			existsWmicRecords: [2]bool{
+				true,
+				true,
+			},
+			existsAMIId: false,
+			expect:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		func() {
+			handler := func(res http.ResponseWriter, req *http.Request) {
+				if !tc.existsAMIId {
+					res.WriteHeader(http.StatusNotFound)
+				}
+			}
+			ts := httptest.NewServer(http.HandlerFunc(handler))
+			defer func() { ts.Close() }()
+
+			u, _ := url.Parse(ts.URL)
+			defer setEc2BaseURL(u)()
+
+			wmicRecords := make([]Win32_ComputerSystemProduct, 2)
+			for i, exist := range tc.existsWmicRecords {
+				if exist {
+					wmicRecords[i].UUID = "ec2e1916-9099-7caf-fd21-012345abcdef" // valid EC2 UUID
+				} else {
+					wmicRecords[i].UUID = "ec1e1916-9099-7caf-fd21-012345abcdef" // valid EC2 UUID
+				}
+			}
+
+			if isEC2WithSpecifiedWmicRecords(context.Background(), wmicRecords) != tc.expect {
+				t.Errorf("isEC2() should be %t: %#v\n", tc.expect, tc)
+			}
+		}()
+	}
+}

--- a/spec/isec2_windows_test.go
+++ b/spec/isec2_windows_test.go
@@ -103,7 +103,7 @@ func TestIsEC2(t *testing.T) {
 				if exist {
 					wmiRecords[i].UUID = "ec2e1916-9099-7caf-fd21-012345abcdef" // valid EC2 UUID
 				} else {
-					wmiRecords[i].UUID = "ec1e1916-9099-7caf-fd21-012345abcdef" // valid EC2 UUID
+					wmiRecords[i].UUID = "ec1e1916-9099-7caf-fd21-012345abcdef" // invalid EC2 UUID
 				}
 			}
 


### PR DESCRIPTION
Current implementation of Windows is trying to request ami-id endpoint even though the environment is not an EC2. It can do pre-checking before them as same as implementation of Linux.

https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/WindowsGuide/identify_ec2_instances.html