### PR TITLE
Reduce fetch ec2 metadata count

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -20,7 +20,7 @@ import (
 
 // This Generator collects metadata about cloud instances.
 // Currently EC2 and GCE are supported.
-// EC2: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
+// EC2: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 // GCE: https://developers.google.com/compute/docs/metadata
 // AzureVM: https://docs.microsoft.com/azure/virtual-machines/virtual-machines-instancemetadataservice-overview
 


### PR DESCRIPTION
There is an EC2 Instance Identity Document Endpoint in EC2 Metadata Endpoint to gets instance metadata.

Getting instance metadata from `169.254.169.254/latest/dynamic/instance-identity/document`, we can get many metadata at once. Also, although not implemented in this PR, metadata can be validated using signature, so that if implemented in the future, it can be validated. 