### PR TITLE
migrate to use mkr.Host instead of mackerel.Host

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -46,7 +46,7 @@ type AgentMeta struct {
 
 // prepareHost collects specs of the host and sends them to Mackerel server.
 // A unique host-id is returned by the server if one is not specified.
-func prepareHost(conf *config.Config, ameta *AgentMeta, api *mackerel.API) (*mackerel.Host, error) {
+func prepareHost(conf *config.Config, ameta *AgentMeta, api *mackerel.API) (*mkr.Host, error) {
 	doRetry := func(f func() error) {
 		retry.Retry(retryNum, retryInterval, f)
 	}
@@ -74,7 +74,7 @@ func prepareHost(conf *config.Config, ameta *AgentMeta, api *mackerel.API) (*mac
 		return nil, fmt.Errorf("error while collecting host specs: %s", lastErr.Error())
 	}
 
-	var result *mackerel.Host
+	var result *mkr.Host
 	if hostID, err := conf.LoadHostID(); err != nil { // create
 
 		if hostSpec.CustomIdentifier != "" {
@@ -147,8 +147,8 @@ func prepareHost(conf *config.Config, ameta *AgentMeta, api *mackerel.API) (*mac
 
 // prepareCustomIdentiferHosts collects the host information based on the
 // configuration of the custom_identifier fields.
-func prepareCustomIdentiferHosts(conf *config.Config, api *mackerel.API) map[string]*mackerel.Host {
-	customIdentifierHosts := make(map[string]*mackerel.Host)
+func prepareCustomIdentiferHosts(conf *config.Config, api *mackerel.API) map[string]*mkr.Host {
+	customIdentifierHosts := make(map[string]*mkr.Host)
 	for _, customIdentifier := range conf.ListCustomIdentifiers() {
 		host, err := api.FindHostByCustomIdentifier(customIdentifier)
 		if err != nil {
@@ -163,7 +163,7 @@ func prepareCustomIdentiferHosts(conf *config.Config, api *mackerel.API) map[str
 // Interval between each updating host specs.
 var specsUpdateInterval = 1 * time.Hour
 
-func delayByHost(host *mackerel.Host) int {
+func delayByHost(host *mkr.Host) int {
 	s := sha1.Sum([]byte(host.ID))
 	return int(s[len(s)-1]) % int(config.PostMetricsInterval.Seconds())
 }
@@ -172,9 +172,9 @@ func delayByHost(host *mackerel.Host) int {
 type App struct {
 	Agent                 *agent.Agent
 	Config                *config.Config
-	Host                  *mackerel.Host
+	Host                  *mkr.Host
 	API                   *mackerel.API
-	CustomIdentifierHosts map[string]*mackerel.Host
+	CustomIdentifierHosts map[string]*mkr.Host
 	AgentMeta             *AgentMeta
 }
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -17,17 +17,18 @@ import (
 	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/mackerel"
 	"github.com/mackerelio/mackerel-agent/metrics"
+	mkr "github.com/mackerelio/mackerel-client-go"
 )
 
 func TestDelayByHost(t *testing.T) {
-	delay1 := time.Duration(delayByHost(&mackerel.Host{
+	delay1 := time.Duration(delayByHost(&mkr.Host{
 		ID:     "246PUVUngPo",
 		Name:   "hogehoge2.host.h",
 		Type:   "unknown",
 		Status: "working",
 	})) * time.Second
 
-	delay2 := time.Duration(delayByHost(&mackerel.Host{
+	delay2 := time.Duration(delayByHost(&mkr.Host{
 		ID:     "21GZjCE5Etb",
 		Name:   "hogehoge2.host.h",
 		Type:   "unknown",
@@ -98,7 +99,7 @@ func TestPrepareWithCreate(t *testing.T) {
 
 	mockHandlers["GET /api/v0/hosts/xxx1234567890"] = func(req *http.Request) (int, jsonObject) {
 		return 200, jsonObject{
-			"host": mackerel.Host{
+			"host": mkr.Host{
 				ID:     "xxx1234567890",
 				Name:   "host.example.com",
 				Type:   "unknown",
@@ -162,7 +163,7 @@ func TestPrepareWithUpdate(t *testing.T) {
 
 	mockHandlers["GET /api/v0/hosts/xxx12345678901"] = func(req *http.Request) (int, jsonObject) {
 		return 200, jsonObject{
-			"host": mackerel.Host{
+			"host": mkr.Host{
 				ID:     "xxx12345678901",
 				Name:   "host.example.com",
 				Type:   "unknown",
@@ -323,7 +324,7 @@ func TestLoop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	host := &mackerel.Host{ID: "xyzabc12345"}
+	host := &mkr.Host{ID: "xyzabc12345"}
 
 	termCh := make(chan struct{})
 	exitCh := make(chan error)
@@ -403,7 +404,7 @@ func TestReportCheckMonitors(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		host := &mackerel.Host{ID: "xyzabc12345"}
+		host := &mkr.Host{ID: "xyzabc12345"}
 
 		app := &App{
 			Agent:     &agent.Agent{},

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mackerelio/golib/logging"
+	mkr "github.com/mackerelio/mackerel-client-go"
 )
 
 var logger = logging.GetLogger("api")
@@ -138,7 +139,7 @@ func closeResp(resp *http.Response) {
 }
 
 // FindHost find the host
-func (api *API) FindHost(id string) (*Host, error) {
+func (api *API) FindHost(id string) (*mkr.Host, error) {
 	resp, err := api.get(fmt.Sprintf("/api/v0/hosts/%s", id), "")
 	defer closeResp(resp)
 	if err != nil {
@@ -150,7 +151,7 @@ func (api *API) FindHost(id string) (*Host, error) {
 	}
 
 	var data struct {
-		Host *Host `json:"host"`
+		Host *mkr.Host `json:"host"`
 	}
 	err = json.NewDecoder(resp.Body).Decode(&data)
 	if err != nil {
@@ -160,7 +161,7 @@ func (api *API) FindHost(id string) (*Host, error) {
 }
 
 // FindHostByCustomIdentifier find the host by the custom identifier
-func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*Host, error) {
+func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*mkr.Host, error) {
 	v := url.Values{}
 	v.Set("customIdentifier", customIdentifier)
 	for _, status := range []string{"working", "standby", "maintenance", "poweroff"} {
@@ -177,7 +178,7 @@ func (api *API) FindHostByCustomIdentifier(customIdentifier string) (*Host, erro
 	}
 
 	var data struct {
-		Hosts []*Host `json:"hosts"`
+		Hosts []*mkr.Host `json:"hosts"`
 	}
 	err = json.NewDecoder(resp.Body).Decode(&data)
 	if err != nil {

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -378,10 +378,14 @@ func TestFindHost(t *testing.T) {
 	}
 
 	if reflect.DeepEqual(host, &mkr.Host{
-		ID:               "9rxGOHfVF8F",
-		Name:             "mydb001",
-		Type:             "",
-		Status:           "working",
+		ID:     "9rxGOHfVF8F",
+		Name:   "mydb001",
+		Type:   "",
+		Status: "working",
+		Memo:   "memo",
+		Roles: mkr.Roles{
+			"My-Service": []string{"db-master", "db-slave"},
+		},
 		CustomIdentifier: "",
 	}) != true {
 		t.Error("request sends json including memo but: ", host)
@@ -437,6 +441,10 @@ func TestFindHostByCustomIdentifier(t *testing.T) {
 				Type:             "",
 				Status:           "working",
 				CustomIdentifier: "foo-bar",
+				Memo:             "memo",
+				Roles: mkr.Roles{
+					"My-Service": []string{"db-master", "db-slave"},
+				},
 			},
 			returnInfoError: false,
 		},

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -377,7 +377,7 @@ func TestFindHost(t *testing.T) {
 		t.Error("err shoud be nil but: ", err)
 	}
 
-	if reflect.DeepEqual(host, &Host{
+	if reflect.DeepEqual(host, &mkr.Host{
 		ID:               "9rxGOHfVF8F",
 		Name:             "mydb001",
 		Type:             "",
@@ -426,12 +426,12 @@ func TestFindHostByCustomIdentifier(t *testing.T) {
 
 	var tests = []struct {
 		customIdentifier string
-		host             *Host
+		host             *mkr.Host
 		returnInfoError  bool
 	}{
 		{
 			customIdentifier: "foo-bar",
-			host: &Host{
+			host: &mkr.Host{
 				ID:               "9rxGOHfVF8F",
 				Name:             "mydb001",
 				Type:             "",

--- a/mackerel/host.go
+++ b/mackerel/host.go
@@ -2,15 +2,6 @@ package mackerel
 
 import mkr "github.com/mackerelio/mackerel-client-go"
 
-// Host XXX
-type Host struct {
-	ID               string `json:"id"`
-	Name             string `json:"name"`
-	Type             string `json:"type"` // TODO ENUM
-	Status           string `json:"status"`
-	CustomIdentifier string `json:"customIdentifier"`
-}
-
 // HostSpec is host specifications sent Mackerel server per hour
 type HostSpec struct {
 	Name             string            `json:"name"`

--- a/start_test.go
+++ b/start_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mackerelio/mackerel-agent/mackerel"
+	mkr "github.com/mackerelio/mackerel-client-go"
 )
 
 func respJSON(w http.ResponseWriter, data map[string]interface{}) {
@@ -28,7 +29,7 @@ func TestStart(t *testing.T) {
 		switch r.Method {
 		case "GET":
 			respJSON(w, map[string]interface{}{
-				"host": mackerel.Host{
+				"host": mkr.Host{
 					ID:     hostID,
 					Name:   "host.example.com",
 					Status: "standby",


### PR DESCRIPTION
This p-r is a part of an integration `mackerel.*` into `mackerel-client-go`.

Related p-r is #515