### PR TITLE
[nit] add snapshot directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !.travis.yml
 /build
 /build-linux-*/
+/snapshot
 /id
 /pid
 /wix/mackerel-agent.wxs


### PR DESCRIPTION
The directory is generated by make crossbuild and this should be ignored.