### PR TITLE
Add mips and arm64 architecture debian packaging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,10 @@ packaging/deb/debian/mackerel-agent.bin
 packaging/*.tar.gz
 packaging/deb-build
 packaging/rpm-build
+packaging/*.deb
+packaging/*.changes
+packaging/*.dsc
+packaging/*.build*
+packaging/*.debian.tar.xz
 
 /mackerel-agent.conf

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,10 @@ deb-arm64: crossbuild-package-arm64
 	BUILD_DIRECTORY=build-linux-arm64 BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us -aarm64
 
+.PHONY: deb-on-docker
+deb-on-docker:
+	docker run --rm -v "$(PWD)":/workspace:rw -w=/workspace/ tnishinaga/mackerel-deb-builder make deb
+
 .PHONY: rpm-kcps
 rpm-kcps: rpm-kcps-v1 rpm-kcps-v2
 

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,13 @@ crossbuild-package-mips:
 	GOOS=linux GOARCH=mips make build
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-mips/
 
+.PHONY: crossbuild-package-arm64
+crossbuild-package-arm64:
+	mkdir -p ./build-linux-arm64
+	GOOS=linux GOARCH=arm64 make build
+	mv build/$(MACKEREL_AGENT_NAME) build-linux-arm64/
+
+
 .PHONY: crossbuild-package-kcps
 crossbuild-package-kcps:
 	make crossbuild-package MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16
@@ -114,7 +121,7 @@ rpm-v2: crossbuild-package
 	-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
 
 .PHONY: deb
-deb: deb-v1 deb-v2 deb-mips
+deb: deb-v1 deb-v2 deb-mips deb-arm64
 
 .PHONY: deb-v1
 deb-v1: crossbuild-package
@@ -130,6 +137,11 @@ deb-v2: crossbuild-package
 deb-mips: crossbuild-package-mips
 	BUILD_DIRECTORY=build-linux-mips BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us -amips
+
+.PHONY: deb-arm64
+deb-arm64: crossbuild-package-arm64
+	BUILD_DIRECTORY=build-linux-arm64 BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
+	cd packaging/deb-build && debuild --no-tgz-check -uc -us -aarm64
 
 .PHONY: rpm-kcps
 rpm-kcps: rpm-kcps-v1 rpm-kcps-v2

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,12 @@ crossbuild-package:
 	GOOS=linux GOARCH=amd64 make build
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-amd64/
 
+.PHONY: crossbuild-package-mips
+crossbuild-package-mips:
+	mkdir -p ./build-linux-mips
+	GOOS=linux GOARCH=mips make build
+	mv build/$(MACKEREL_AGENT_NAME) build-linux-mips/
+
 .PHONY: crossbuild-package-kcps
 crossbuild-package-kcps:
 	make crossbuild-package MACKEREL_AGENT_NAME=mackerel-agent-kcps MACKEREL_API_BASE=http://198.18.0.16
@@ -108,7 +114,7 @@ rpm-v2: crossbuild-package
 	-bb packaging/rpm-build/$(MACKEREL_AGENT_NAME).spec
 
 .PHONY: deb
-deb: deb-v1 deb-v2
+deb: deb-v1 deb-v2 deb-mips
 
 .PHONY: deb-v1
 deb-v1: crossbuild-package
@@ -119,6 +125,11 @@ deb-v1: crossbuild-package
 deb-v2: crossbuild-package
 	BUILD_DIRECTORY=build-linux-amd64 BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
 	cd packaging/deb-build && debuild --no-tgz-check -uc -us
+
+.PHONY: deb-mips
+deb-mips: crossbuild-package-mips
+	BUILD_DIRECTORY=build-linux-mips BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
+	cd packaging/deb-build && debuild --no-tgz-check -uc -us -amips
 
 .PHONY: rpm-kcps
 rpm-kcps: rpm-kcps-v1 rpm-kcps-v2

--- a/packaging/deb-systemd/debian/control
+++ b/packaging/deb-systemd/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/mackerelio/mackerel-agent.git
 Homepage: https://mackerel.io
 
 Package: mackerel-agent
-Architecture: amd64
+Architecture: any
 Depends: ${misc:Depends}, systemd
 Description: mackerel.io agent
  Server monitoring agent for https://mackerel.io (Monitoring SaaS)


### PR DESCRIPTION
Hello,

I add mips and arm64 architecture support to mackerel debian packaging.

I tested on EdgeRouterLite(mips) and SynQuacer(arm64), it works fine 😄 .
