### PR TITLE
Release version 0.59.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.59.3 (2019-05-08)
+
+* Add rc script for FreeBSD #559 (owatan)
+* migrate to use mkr.Interface instead of mackerel.NetInterface #553 (lufia)
+* migrate to use mkr.Host instead of mackerel.Host #552 (lufia)
+
+
 ## 0.59.2 (2019-03-27)
 
 * trim trailing newlines from command string on windows #548 (Songmu)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION := 0.59.2
+VERSION := 0.59.3
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 ARGS := "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS := "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent (0.59.3-1.systemd) stable; urgency=low
+
+  * Add rc script for FreeBSD (by owatan)
+    <https://github.com/mackerelio/mackerel-agent/pull/559>
+  * migrate to use mkr.Interface instead of mackerel.NetInterface (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/553>
+  * migrate to use mkr.Host instead of mackerel.Host (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/552>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 08 May 2019 07:35:51 +0000
+
 mackerel-agent (0.59.2-1.systemd) stable; urgency=low
 
   * trim trailing newlines from command string on windows (by Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent (0.59.3-1) stable; urgency=low
+
+  * Add rc script for FreeBSD (by owatan)
+    <https://github.com/mackerelio/mackerel-agent/pull/559>
+  * migrate to use mkr.Interface instead of mackerel.NetInterface (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/553>
+  * migrate to use mkr.Host instead of mackerel.Host (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/552>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 08 May 2019 07:35:51 +0000
+
 mackerel-agent (0.59.2-1) stable; urgency=low
 
   * trim trailing newlines from command string on windows (by Songmu)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,11 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Wed May 08 2019 <mackerel-developers@hatena.ne.jp> - 0.59.3
+- Add rc script for FreeBSD (by owatan)
+- migrate to use mkr.Interface instead of mackerel.NetInterface (by lufia)
+- migrate to use mkr.Host instead of mackerel.Host (by lufia)
+
 * Wed Mar 27 2019 <mackerel-developers@hatena.ne.jp> - 0.59.2
 - trim trailing newlines from command string on windows (by Songmu)
 - Improve Makefile (by itchyny)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,11 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed May 08 2019 <mackerel-developers@hatena.ne.jp> - 0.59.3
+- Add rc script for FreeBSD (by owatan)
+- migrate to use mkr.Interface instead of mackerel.NetInterface (by lufia)
+- migrate to use mkr.Host instead of mackerel.Host (by lufia)
+
 * Wed Mar 27 2019 <mackerel-developers@hatena.ne.jp> - 0.59.2
 - trim trailing newlines from command string on windows (by Songmu)
 - Improve Makefile (by itchyny)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.59.2"
+const version = "0.59.3"
 
 var gitcommit string


### PR DESCRIPTION
- Add rc script for FreeBSD #559
- migrate to use mkr.Interface instead of mackerel.NetInterface #553
- migrate to use mkr.Host instead of mackerel.Host #552