### PR TITLE
[nit] Update help URL in mackerel-agent.sample.conf

### DIFF
--- a/mackerel-agent.sample.conf
+++ b/mackerel-agent.sample.conf
@@ -11,7 +11,7 @@
 # ignore = "/dev/ram.*"
 
 # Configuration for Custom Metrics Plugins
-# see also: http://help-ja.mackerel.io/entry/advanced/custom-metrics
+# see also: http://mackerel.io/ja/docs/entry/advanced/custom-metrics
 
 # followings are mackerel-agent-plugins https://github.com/mackerelio/mackerel-agent-plugins
 

--- a/mackerel-agent.sample.conf
+++ b/mackerel-agent.sample.conf
@@ -11,7 +11,7 @@
 # ignore = "/dev/ram.*"
 
 # Configuration for Custom Metrics Plugins
-# see also: http://mackerel.io/ja/docs/entry/advanced/custom-metrics
+# see also: https://mackerel.io/ja/docs/entry/advanced/custom-metrics
 
 # followings are mackerel-agent-plugins https://github.com/mackerelio/mackerel-agent-plugins
 


### PR DESCRIPTION
Although we can still access to old url with redirect, but we should use preferred url.