### PR TITLE
migrate CreatingMetricsValue to mackerel.HostMetricValue

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -230,7 +230,7 @@ func (g *counterGenerator) Generate() (metrics.Values, error) {
 	return map[string]float64{"dummy.a": float64(g.counter)}, nil
 }
 
-type byTime []mackerel.CreatingMetricsValue
+type byTime []mkr.HostMetricValue
 
 func (b byTime) Len() int           { return len(b) }
 func (b byTime) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
@@ -277,11 +277,11 @@ func TestLoop(t *testing.T) {
 		totalPosts    = 7
 	)
 	failureCount := 0
-	receivedDataPoints := []mackerel.CreatingMetricsValue{}
+	receivedDataPoints := []mkr.HostMetricValue{}
 	done := make(chan struct{})
 
 	mockHandlers["POST /api/v0/tsdb"] = func(req *http.Request) (int, jsonObject) {
-		payload := []mackerel.CreatingMetricsValue{}
+		payload := []mkr.HostMetricValue{}
 		json.NewDecoder(req.Body).Decode(&payload)
 
 		for _, p := range payload {

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -15,14 +15,6 @@ import (
 
 var logger = logging.GetLogger("api")
 
-// CreatingMetricsValue parameters of metric values
-type CreatingMetricsValue struct {
-	HostID string      `json:"hostId"`
-	Name   string      `json:"name"`
-	Time   float64     `json:"time"`
-	Value  interface{} `json:"value"`
-}
-
 // API is the main interface of Mackerel API.
 type API struct {
 	BaseURL        *url.URL
@@ -237,8 +229,8 @@ func (api *API) UpdateHostStatus(hostID string, status string) error {
 	return nil
 }
 
-// PostMetricsValues post metrics
-func (api *API) PostMetricsValues(metricsValues [](*CreatingMetricsValue)) error {
+// PostMetricValues post metrics
+func (api *API) PostMetricValues(metricsValues [](*mkr.HostMetricValue)) error {
 	resp, err := api.postJSON("/api/v0/tsdb", metricsValues)
 	defer closeResp(resp)
 	if err != nil {

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -524,12 +524,14 @@ func TestPostHostMetricValues(t *testing.T) {
 	defer ts.Close()
 
 	api, _ := NewAPI(ts.URL, "dummy-key", false)
-	err := api.PostMetricsValues([]*CreatingMetricsValue{
+	err := api.PostMetricValues([]*mkr.HostMetricValue{
 		{
 			HostID: "9rxGOHfVF8F",
-			Name:   "custom.metric.mysql.connections",
-			Time:   123456789,
-			Value:  100,
+			MetricValue: &mkr.MetricValue{
+				Name:  "custom.metric.mysql.connections",
+				Time:  123456789,
+				Value: 100,
+			},
 		},
 	})
 

--- a/start_test.go
+++ b/start_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mackerelio/mackerel-agent/mackerel"
 	mkr "github.com/mackerelio/mackerel-client-go"
 )
 
@@ -46,7 +45,7 @@ func TestStart(t *testing.T) {
 	mux.HandleFunc("/api/v0/tsdb", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case "POST":
-			payload := []mackerel.CreatingMetricsValue{}
+			var payload []*mkr.HostMetricValue
 			err := json.NewDecoder(r.Body).Decode(&payload)
 			if err != nil {
 				t.Errorf("decode failed: %s", err)


### PR DESCRIPTION
I replaced CreatingMetricsValue with HostMetricValue of mackerel-client.

And also I dropped **"s"** from *PostMetric **"s"** Values* because type name don't contain **"s"**.