### PR TITLE
Release version 0.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.60.0 (2019-06-11)
+
+* migrate CreatingMetricsValue to mackerel.HostMetricValue #565 (lufia)
+* migrate to use mkr.GraphDefsParam instead of CreateGraphDefsPayload #564 (lufia)
+* migrate to use mkr.CheckReports instead of monitoringChecksPayload #563 (lufia)
+* update appveyor.yml to build 64bit binaries #561 (lufia)
+* migrate to use mkr.XxxHostParam instead of mackerel.HostSpec #554 (lufia)
+* support Go Modules #549 (lufia)
+
+
 ## 0.59.3 (2019-05-08)
 
 * Add rc script for FreeBSD #559 (owatan)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION := 0.59.3
+VERSION := 0.60.0
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 ARGS := "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS := "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.60.0-1.systemd) stable; urgency=low
+
+  * migrate CreatingMetricsValue to mackerel.HostMetricValue (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/565>
+  * migrate to use mkr.GraphDefsParam instead of CreateGraphDefsPayload (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/564>
+  * migrate to use mkr.CheckReports instead of monitoringChecksPayload (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/563>
+  * update appveyor.yml to build 64bit binaries (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/561>
+  * migrate to use mkr.XxxHostParam instead of mackerel.HostSpec (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/554>
+  * support Go Modules (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/549>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 11 Jun 2019 03:11:20 +0000
+
 mackerel-agent (0.59.3-1.systemd) stable; urgency=low
 
   * Add rc script for FreeBSD (by owatan)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.60.0-1) stable; urgency=low
+
+  * migrate CreatingMetricsValue to mackerel.HostMetricValue (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/565>
+  * migrate to use mkr.GraphDefsParam instead of CreateGraphDefsPayload (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/564>
+  * migrate to use mkr.CheckReports instead of monitoringChecksPayload (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/563>
+  * update appveyor.yml to build 64bit binaries (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/561>
+  * migrate to use mkr.XxxHostParam instead of mackerel.HostSpec (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/554>
+  * support Go Modules (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/549>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 11 Jun 2019 03:11:20 +0000
+
 mackerel-agent (0.59.3-1) stable; urgency=low
 
   * Add rc script for FreeBSD (by owatan)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,14 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Tue Jun 11 2019 <mackerel-developers@hatena.ne.jp> - 0.60.0
+- migrate CreatingMetricsValue to mackerel.HostMetricValue (by lufia)
+- migrate to use mkr.GraphDefsParam instead of CreateGraphDefsPayload (by lufia)
+- migrate to use mkr.CheckReports instead of monitoringChecksPayload (by lufia)
+- update appveyor.yml to build 64bit binaries (by lufia)
+- migrate to use mkr.XxxHostParam instead of mackerel.HostSpec (by lufia)
+- support Go Modules (by lufia)
+
 * Wed May 08 2019 <mackerel-developers@hatena.ne.jp> - 0.59.3
 - Add rc script for FreeBSD (by owatan)
 - migrate to use mkr.Interface instead of mackerel.NetInterface (by lufia)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,14 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Tue Jun 11 2019 <mackerel-developers@hatena.ne.jp> - 0.60.0
+- migrate CreatingMetricsValue to mackerel.HostMetricValue (by lufia)
+- migrate to use mkr.GraphDefsParam instead of CreateGraphDefsPayload (by lufia)
+- migrate to use mkr.CheckReports instead of monitoringChecksPayload (by lufia)
+- update appveyor.yml to build 64bit binaries (by lufia)
+- migrate to use mkr.XxxHostParam instead of mackerel.HostSpec (by lufia)
+- support Go Modules (by lufia)
+
 * Wed May 08 2019 <mackerel-developers@hatena.ne.jp> - 0.59.3
 - Add rc script for FreeBSD (by owatan)
 - migrate to use mkr.Interface instead of mackerel.NetInterface (by lufia)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.59.3"
+const version = "0.60.0"
 
 var gitcommit string


### PR DESCRIPTION
- migrate CreatingMetricsValue to mackerel.HostMetricValue #565
- migrate to use mkr.GraphDefsParam instead of CreateGraphDefsPayload #564
- migrate to use mkr.CheckReports instead of monitoringChecksPayload #563
- update appveyor.yml to build 64bit binaries #561
- migrate to use mkr.XxxHostParam instead of mackerel.HostSpec #554
- support Go Modules #549