### PR TITLE
[check-plugin] Support custom_identifier 

### DIFF
--- a/checks/checker.go
+++ b/checks/checker.go
@@ -49,6 +49,7 @@ type Report struct {
 	OccurredAt           time.Time
 	NotificationInterval *int32
 	MaxCheckAttempts     *int32
+	CustomIdentfier      *string
 }
 
 func (c *Checker) String() string {
@@ -81,6 +82,7 @@ func (c *Checker) Check() *Report {
 		OccurredAt:           now,
 		NotificationInterval: c.Config.NotificationInterval,
 		MaxCheckAttempts:     c.Config.MaxCheckAttempts,
+		CustomIdentfier:      c.Config.CustomIdentifier,
 	}
 }
 

--- a/command/command.go
+++ b/command/command.go
@@ -531,27 +531,25 @@ func runCheckersLoop(app *App, termCheckerCh <-chan struct{}, quit <-chan struct
 			}
 			partialReports = append(partialReports, report)
 			if len(partialReports) >= checkReportMaxSize {
-				host := app.Host
-				if customIdentifier != "" {
-					if h, ok := app.CustomIdentifierHosts[customIdentifier]; ok {
-						host = h
-					}
-				}
-				reportCheckMonitors(app, host, partialReports)
+				reportCheckMonitorsForCustomIdentifier(app, customIdentifier, partialReports)
 				delete(reportsByCustomIdentifier, customIdentifier)
 				time.Sleep(time.Duration(reportCheckDelay) * time.Second)
 			}
 		}
 		for customIdentifier, partialReports := range reportsByCustomIdentifier {
-			host := app.Host
-			if customIdentifier != "" {
-				if h, ok := app.CustomIdentifierHosts[customIdentifier]; ok {
-					host = h
-				}
-			}
-			reportCheckMonitors(app, host, partialReports)
+			reportCheckMonitorsForCustomIdentifier(app, customIdentifier, partialReports)
 		}
 	}
+}
+
+func reportCheckMonitorsForCustomIdentifier(app *App, customIdentifier string, reports []*checks.Report) {
+	host := app.Host
+	if customIdentifier != "" {
+		if h, ok := app.CustomIdentifierHosts[customIdentifier]; ok {
+			host = h
+		}
+	}
+	reportCheckMonitors(app, host, reports)
 }
 
 func reportCheckMonitors(app *App, host *mkr.Host, reports []*checks.Report) {

--- a/command/command.go
+++ b/command/command.go
@@ -607,6 +607,10 @@ func collectHostParam(conf *config.Config, ameta *AgentMeta) (*mkr.CreateHostPar
 
 	checks := make([]mkr.CheckConfig, 0, len(conf.CheckPlugins))
 	for name, checkPlugin := range conf.CheckPlugins {
+		// Exclude checks with customIdentifiers, which is not for the host itself.
+		if checkPlugin.CustomIdentifier != nil {
+			continue
+		}
 		checks = append(checks,
 			mkr.CheckConfig{
 				Name: name,

--- a/command/command.go
+++ b/command/command.go
@@ -525,13 +525,12 @@ func runCheckersLoop(app *App, termCheckerCh <-chan struct{}, quit <-chan struct
 			if report.CustomIdentfier != nil {
 				customIdentifier = *report.CustomIdentfier
 			}
-			partialReports, exists := reportsByCustomIdentifier[customIdentifier]
-			if !exists {
-				partialReports = make([]*checks.Report, 0, checkReportMaxSize)
+			if _, exists := reportsByCustomIdentifier[customIdentifier]; !exists {
+				reportsByCustomIdentifier[customIdentifier] = make([]*checks.Report, 0, checkReportMaxSize)
 			}
-			partialReports = append(partialReports, report)
-			if len(partialReports) >= checkReportMaxSize {
-				reportCheckMonitorsForCustomIdentifier(app, customIdentifier, partialReports)
+			reportsByCustomIdentifier[customIdentifier] = append(reportsByCustomIdentifier[customIdentifier], report)
+			if len(reportsByCustomIdentifier[customIdentifier]) >= checkReportMaxSize {
+				reportCheckMonitorsForCustomIdentifier(app, customIdentifier, reportsByCustomIdentifier[customIdentifier])
 				delete(reportsByCustomIdentifier, customIdentifier)
 				time.Sleep(time.Duration(reportCheckDelay) * time.Second)
 			}

--- a/command/command.go
+++ b/command/command.go
@@ -542,14 +542,16 @@ func runCheckersLoop(app *App, termCheckerCh <-chan struct{}, quit <-chan struct
 }
 
 func reportCheckMonitors(app *App, customIdentifier string, reports []*checks.Report) {
-	host := app.Host
+	hostID := app.Host.ID
 	if customIdentifier != "" {
-		if h, ok := app.CustomIdentifierHosts[customIdentifier]; ok {
-			host = h
+		if host, ok := app.CustomIdentifierHosts[customIdentifier]; ok {
+			hostID = host.ID
+		} else {
+			return
 		}
 	}
 	for {
-		err := app.API.ReportCheckMonitors(host.ID, reports)
+		err := app.API.ReportCheckMonitors(hostID, reports)
 		if err == nil {
 			break
 		}

--- a/command/command.go
+++ b/command/command.go
@@ -530,28 +530,24 @@ func runCheckersLoop(app *App, termCheckerCh <-chan struct{}, quit <-chan struct
 			}
 			reportsByCustomIdentifier[customIdentifier] = append(reportsByCustomIdentifier[customIdentifier], report)
 			if len(reportsByCustomIdentifier[customIdentifier]) >= checkReportMaxSize {
-				reportCheckMonitorsForCustomIdentifier(app, customIdentifier, reportsByCustomIdentifier[customIdentifier])
+				reportCheckMonitors(app, customIdentifier, reportsByCustomIdentifier[customIdentifier])
 				delete(reportsByCustomIdentifier, customIdentifier)
 				time.Sleep(time.Duration(reportCheckDelay) * time.Second)
 			}
 		}
 		for customIdentifier, partialReports := range reportsByCustomIdentifier {
-			reportCheckMonitorsForCustomIdentifier(app, customIdentifier, partialReports)
+			reportCheckMonitors(app, customIdentifier, partialReports)
 		}
 	}
 }
 
-func reportCheckMonitorsForCustomIdentifier(app *App, customIdentifier string, reports []*checks.Report) {
+func reportCheckMonitors(app *App, customIdentifier string, reports []*checks.Report) {
 	host := app.Host
 	if customIdentifier != "" {
 		if h, ok := app.CustomIdentifierHosts[customIdentifier]; ok {
 			host = h
 		}
 	}
-	reportCheckMonitors(app, host, reports)
-}
-
-func reportCheckMonitors(app *App, host *mkr.Host, reports []*checks.Report) {
 	for {
 		err := app.API.ReportCheckMonitors(host.ID, reports)
 		if err == nil {

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -189,7 +189,7 @@ func TestPrepareWithUpdate(t *testing.T) {
 	}
 }
 
-func TestCollectHostSpecs(t *testing.T) {
+func TestCollectHostParam(t *testing.T) {
 	conf := config.Config{}
 	hostParam, err := collectHostParam(&conf, &AgentMeta{})
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -218,6 +218,32 @@ func TestCollectHostParam(t *testing.T) {
 	}
 }
 
+func TestCollectHostParamWithChecks(t *testing.T) {
+	customIdentifier := "app.example.com"
+	conf := config.Config{
+		CheckPlugins: map[string]*config.CheckPlugin{
+			"chk1": &config.CheckPlugin{
+				CustomIdentifier: nil,
+			},
+			"chk2": &config.CheckPlugin{
+				CustomIdentifier: &customIdentifier,
+			},
+		},
+	}
+	hostParam, err := collectHostParam(&conf, &AgentMeta{})
+
+	if err != nil {
+		t.Errorf("collectHostParam should not fail: %s", err)
+	}
+
+	if len(hostParam.Checks) != 1 {
+		t.Error("only checks without customIdentifier should be included in param")
+	}
+	if hostParam.Checks[0].Name != "chk1" {
+		t.Error("only checks without customIdentifier should be included in param")
+	}
+}
+
 type counterGenerator struct {
 	counter int
 	sync.Mutex

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -415,7 +415,7 @@ func TestReportCheckMonitors(t *testing.T) {
 		}
 
 		go func() {
-			reportCheckMonitors(app, []*checks.Report{})
+			reportCheckMonitors(app, app.Host, []*checks.Report{})
 		}()
 
 		time.Sleep(time.Duration(reportCheckRetryDelaySeconds) * 3 * time.Second)

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -441,7 +441,7 @@ func TestReportCheckMonitors(t *testing.T) {
 		}
 
 		go func() {
-			reportCheckMonitors(app, app.Host, []*checks.Report{})
+			reportCheckMonitors(app, "", []*checks.Report{})
 		}()
 
 		time.Sleep(time.Duration(reportCheckRetryDelaySeconds) * 3 * time.Second)

--- a/config/config.go
+++ b/config/config.go
@@ -394,6 +394,11 @@ func (conf *Config) ListCustomIdentifiers() []string {
 			customIdentifiers = append(customIdentifiers, *pconf.CustomIdentifier)
 		}
 	}
+	for _, cconf := range conf.CheckPlugins {
+		if cconf.CustomIdentifier != nil && index(customIdentifiers, *cconf.CustomIdentifier) == -1 {
+			customIdentifiers = append(customIdentifiers, *cconf.CustomIdentifier)
+		}
+	}
 	return customIdentifiers
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -248,6 +248,7 @@ func (pconf *PluginConfig) buildMetricPlugin() (*MetricPlugin, error) {
 // The User option is ignored on Windows
 type CheckPlugin struct {
 	Command               Command
+	CustomIdentifier      *string
 	NotificationInterval  *int32
 	CheckInterval         *int32
 	MaxCheckAttempts      *int32
@@ -286,6 +287,7 @@ func (pconf *PluginConfig) buildCheckPlugin(name string) (*CheckPlugin, error) {
 
 	plugin := CheckPlugin{
 		Command:               *cmd,
+		CustomIdentifier:      pconf.CustomIdentifier,
 		NotificationInterval:  pconf.NotificationInterval,
 		CheckInterval:         pconf.CheckInterval,
 		MaxCheckAttempts:      pconf.MaxCheckAttempts,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -51,6 +51,10 @@ action = { command = "cardiac_massage", user = "doctor", env = { "NAME_1" = "VAL
 [plugin.checks.heartbeat3]
 command = "heartbeat.sh"
 
+[plugin.checks.heartbeat4]
+command = "heartbeat.sh"
+custom_identifier = "app2.example.com"
+
 [plugin.metadata.hostinfo]
 command = "hostinfo.sh"
 user = "zzz"
@@ -398,11 +402,15 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Error("plugin timeout_seconds should be 60s")
 	}
 	customIdentifiers := config.ListCustomIdentifiers()
-	if len(customIdentifiers) != 1 {
-		t.Errorf("config should have 1 custom_identifier")
+	if len(customIdentifiers) != 2 {
+		t.Errorf("config should have 2 custom_identifier")
 	}
-	if customIdentifiers[0] != "app1.example.com" {
-		t.Errorf("first custom_identifier should be 'app1.example.com'")
+	// In fact they should be [app1, app2], but we don't mind their order here
+	if customIdentifiers[0] != "app1.example.com" && customIdentifiers[1] != "app1.example.com"{
+		t.Errorf("custom_identifier should include 'app1.example.com'")
+	}
+	if customIdentifiers[0] != "app2.example.com" && customIdentifiers[1] != "app2.example.com"{
+		t.Errorf("custom_identifier should include 'app2.example.com'")
 	}
 	if pluginConf.IncludePattern != nil {
 		t.Errorf("plugin include_pattern should be nil but got %v", pluginConf.IncludePattern)
@@ -488,6 +496,14 @@ func TestLoadConfigFile(t *testing.T) {
 	checks3 := config.CheckPlugins["heartbeat3"]
 	if checks3.Action != nil {
 		t.Error("config should not have action of check plugin")
+	}
+	if checks3.CustomIdentifier != nil {
+		t.Error("config should not have customIdentifier")
+	}
+
+	checks4 := config.CheckPlugins["heartbeat4"]
+	if checks4.CustomIdentifier == nil || *checks4.CustomIdentifier != "app2.example.com" {
+		t.Error("config should have customIdentifier 'app2.example.com'")
 	}
 
 	if config.MetadataPlugins == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -406,10 +406,10 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Errorf("config should have 2 custom_identifier")
 	}
 	// In fact they should be [app1, app2], but we don't mind their order here
-	if customIdentifiers[0] != "app1.example.com" && customIdentifiers[1] != "app1.example.com"{
+	if customIdentifiers[0] != "app1.example.com" && customIdentifiers[1] != "app1.example.com" {
 		t.Errorf("custom_identifier should include 'app1.example.com'")
 	}
-	if customIdentifiers[0] != "app2.example.com" && customIdentifiers[1] != "app2.example.com"{
+	if customIdentifiers[0] != "app2.example.com" && customIdentifiers[1] != "app2.example.com" {
 		t.Errorf("custom_identifier should include 'app2.example.com'")
 	}
 	if pluginConf.IncludePattern != nil {


### PR DESCRIPTION
configuration syntax is same as metrics plugin:
```toml
[plugin.checks.foobar]
custom_identifier = "myapp.example.com"
command = "check-uptime"
```
