### PR TITLE
Change deb package maintainer name to mackerel

### DIFF
--- a/packaging/deb-systemd/debian/control
+++ b/packaging/deb-systemd/debian/control
@@ -1,7 +1,7 @@
 Source: mackerel-agent
 Section: admin
 Priority: extra
-Maintainer: Hatena <mackerel-developers@hatena.ne.jp>
+Maintainer: mackerel <mackerel-developers@hatena.ne.jp>
 Build-Depends: debhelper (>= 9), dh-systemd
 Standards-Version: 3.9.6
 Vcs-Browser: https://github.com/mackerelio/mackerel-agent

--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -1,7 +1,7 @@
 Source: mackerel-agent
 Section: admin
 Priority: extra
-Maintainer: Hatena <mackerel-developers@hatena.ne.jp>
+Maintainer: mackerel <mackerel-developers@hatena.ne.jp>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.6
 Vcs-Browser: https://github.com/mackerelio/mackerel-agent


### PR DESCRIPTION
Now maintainer name is "Hatena" in debian control file, but in changelog author name is "mackerel".
https://github.com/mackerelio/mackerel-agent/blob/master/packaging/deb/debian/changelog#L16

Therefore currently [changelog-should-mention-nmu](https://lintian.debian.org/tags/changelog-should-mention-nmu.html) warning is claimed by lintian.
This p-r changes maintainer name to match those two.  (I believe changing maintainer name will not cause problem, but I need further investigation.)