### PR TITLE
avoid to use unnamed NICs for registering hosts on Windows

### DIFF
--- a/metrics/windows/interface.go
+++ b/metrics/windows/interface.go
@@ -62,7 +62,7 @@ func NewInterfaceGenerator(interval time.Duration) (*InterfaceGenerator, error) 
 	names := []string{}
 	for ai = first; ai != nil; ai = ai.Next {
 		name, err := windows.AnsiBytePtrToString(&ai.Description[0])
-		if err == nil {
+		if err == nil && name != "" {
 			names = append(names, name)
 		}
 	}

--- a/spec/windows/interface.go
+++ b/spec/windows/interface.go
@@ -35,14 +35,15 @@ func (g *InterfaceGenerator) Generate() ([]mkr.Interface, error) {
 			continue
 		}
 
+		// XXX occur mojibake when containing multi-byte strings
 		name := ifi.Name
 		for ; ai != nil; ai = ai.Next {
 			if ifi.Index == int(ai.Index) {
-				s, err := windows.AnsiBytePtrToString(&ai.Description[0])
-				if err == nil && s != "" {
-					name = s
-				}
+				name = windows.BytePtrToString(&ai.Description[0])
 			}
+		}
+		if name == "" {
+			continue
 		}
 
 		addrs, err := ifi.Addrs()

--- a/spec/windows/interface.go
+++ b/spec/windows/interface.go
@@ -35,11 +35,13 @@ func (g *InterfaceGenerator) Generate() ([]mkr.Interface, error) {
 			continue
 		}
 
-		// XXX occur mojibake when containing multi-byte strings
 		name := ifi.Name
 		for ; ai != nil; ai = ai.Next {
 			if ifi.Index == int(ai.Index) {
-				name = windows.BytePtrToString(&ai.Description[0])
+				s, err := windows.AnsiBytePtrToString(&ai.Description[0])
+				if err == nil && s != "" {
+					name = s
+				}
 			}
 		}
 


### PR DESCRIPTION
*Registering host information* API will reject registering a host that have an unnamed interface because *name* parameter is not optional.

https://mackerel.io/api-docs/entry/hosts

Thus I changed to skip unnamed NICs.

I'm not sure why *ai.Description* or *ifi.Name* is set as empty string by Windows.