### PR TITLE
Release version 0.61.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.61.1 (2019-07-23)
+
+* Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 #581 (astj)
+
+
 ## 0.61.0 (2019-07-22)
 
 * Generate and include CREDITS file in the release artifacts #575 (itchyny)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION := 0.61.0
+VERSION := 0.61.1
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 ARGS := "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS := "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,10 @@
+mackerel-agent (0.61.1-1.systemd) stable; urgency=low
+
+  * Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/581>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 23 Jul 2019 16:24:08 +0900
+
 mackerel-agent (0.61.0-1.systemd) stable; urgency=low
 
   * Generate and include CREDITS file in the release artifacts (by itchyny)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,10 @@
+mackerel-agent (0.61.1-1) stable; urgency=low
+
+  * Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/581>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 23 Jul 2019 16:24:08 +0900
+
 mackerel-agent (0.61.0-1) stable; urgency=low
 
   * Generate and include CREDITS file in the release artifacts (by itchyny)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,9 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Tue Jul 23 2019 <mackerel-developers@hatena.ne.jp> - 0.61.1
+- Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 (by astj)
+
 * Mon Jul 22 2019 <mackerel-developers@hatena.ne.jp> - 0.61.0
 - Generate and include CREDITS file in the release artifacts (by itchyny)
 - Migrate docker repository (by hayajo)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,9 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Tue Jul 23 2019 <mackerel-developers@hatena.ne.jp> - 0.61.1
+- Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 (by astj)
+
 * Mon Jul 22 2019 <mackerel-developers@hatena.ne.jp> - 0.61.0
 - Generate and include CREDITS file in the release artifacts (by itchyny)
 - Migrate docker repository (by hayajo)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.61.0"
+const version = "0.61.1"
 
 var gitcommit string


### PR DESCRIPTION
- Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 #581