### PR TITLE
Check command name on pid check for pid confliction after OS restart

### DIFF
--- a/pidfile/pid.go
+++ b/pidfile/pid.go
@@ -4,3 +4,8 @@ package pidfile
 func ExistsPid(pid int) bool {
 	return existsPid(pid)
 }
+
+// GetCmdName gets the command name of pid
+func GetCmdName(pid int) string {
+	return getCmdName(pid)
+}

--- a/pidfile/pid_darwin.go
+++ b/pidfile/pid_darwin.go
@@ -3,26 +3,36 @@ package pidfile
 import (
 	"bytes"
 	"fmt"
-	"os"
+	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
-func existsPid(pid int) (b bool) {
+func existsPid(pid int) bool {
+	cmd := exec.Command("/usr/sbin/lsof", "-p", fmt.Sprint(pid))
+	cmd.Stdout = ioutil.Discard
+	cmd.Stderr = ioutil.Discard
+
+	err := cmd.Run()
+	return err == nil
+}
+
+func getCmdName(pid int) string {
 	cmd := exec.Command("/bin/ps", "-o", "command=", fmt.Sprint(pid))
 
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
+	cmd.Stderr = ioutil.Discard
 
 	err := cmd.Run()
 	if err != nil {
-		return false
+		return ""
 	}
 
 	out := stdout.String()
 	if i := strings.IndexRune(out, ' '); i > 0 {
 		out = out[:i]
 	}
-	return filepath.Base(out) == filepath.Base(os.Args[0])
+	return filepath.Base(out)
 }

--- a/pidfile/pid_darwin.go
+++ b/pidfile/pid_darwin.go
@@ -1,16 +1,28 @@
 package pidfile
 
 import (
+	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
-func existsPid(pid int) bool {
-	cmd := exec.Command("/usr/sbin/lsof", "-p", fmt.Sprint(pid))
-	cmd.Stdout = ioutil.Discard
-	cmd.Stderr = ioutil.Discard
+func existsPid(pid int) (b bool) {
+	cmd := exec.Command("/bin/ps", "-o", "command=", fmt.Sprint(pid))
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
 
 	err := cmd.Run()
-	return err == nil
+	if err != nil {
+		return false
+	}
+
+	out := stdout.String()
+	if i := strings.IndexRune(out, ' '); i > 0 {
+		out = out[:i]
+	}
+	return filepath.Base(out) == filepath.Base(os.Args[0])
 }

--- a/pidfile/pid_test.go
+++ b/pidfile/pid_test.go
@@ -19,7 +19,7 @@ func TestExistsPid(t *testing.T) {
 	}
 }
 
-func TestExistsPid_CheckProcessName(t *testing.T) {
+func TestGetCmdName(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "sleep", "10")
@@ -30,16 +30,8 @@ func TestExistsPid_CheckProcessName(t *testing.T) {
 	}
 	pid := cmd.Process.Pid
 
-	origArg0 := os.Args[0]
-	defer func() { os.Args[0] = origArg0 }()
-
-	os.Args[0] = "/bin/go-test"
-	if existsPid(pid) {
-		t.Errorf("existsPid should return false when os.Args[0] is %q and pid: %v", os.Args[0], pid)
-	}
-
-	os.Args[0] = "/bin/sleep" // note that only the base name is checked
-	if !existsPid(pid) {
-		t.Errorf("existsPid should return true when os.Args[0] is %q and pid: %v", os.Args[0], pid)
+	expected := "sleep"
+	if got := GetCmdName(pid); got != expected {
+		t.Errorf("GetCmdName should return %q bot got: %q", expected, got)
 	}
 }

--- a/pidfile/pid_test.go
+++ b/pidfile/pid_test.go
@@ -3,8 +3,10 @@
 package pidfile
 
 import (
+	"context"
 	"math"
 	"os"
+	"os/exec"
 	"testing"
 )
 
@@ -14,5 +16,30 @@ func TestExistsPid(t *testing.T) {
 	}
 	if ExistsPid(math.MaxInt32) {
 		t.Errorf("something went wrong")
+	}
+}
+
+func TestExistsPid_CheckProcessName(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sleep", "10")
+	cmd.Stdout = os.Stdout
+	err := cmd.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+
+	origArg0 := os.Args[0]
+	defer func() { os.Args[0] = origArg0 }()
+
+	os.Args[0] = "/bin/go-test"
+	if existsPid(pid) {
+		t.Errorf("existsPid should return false when os.Args[0] is %q and pid: %v", os.Args[0], pid)
+	}
+
+	os.Args[0] = "/bin/sleep" // note that only the base name is checked
+	if !existsPid(pid) {
+		t.Errorf("existsPid should return true when os.Args[0] is %q and pid: %v", os.Args[0], pid)
 	}
 }

--- a/pidfile/pid_unix.go
+++ b/pidfile/pid_unix.go
@@ -4,10 +4,21 @@ package pidfile
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 func existsPid(pid int) bool {
-	_, err := os.Stat(fmt.Sprintf("/proc/%d/", pid))
-	return err == nil
+	cnt, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return false
+	}
+
+	out := string(cnt)
+	if i := strings.IndexRune(out, '\x00'); i > 0 {
+		out = out[:i]
+	}
+	return filepath.Base(out) == filepath.Base(os.Args[0])
 }

--- a/pidfile/pid_unix.go
+++ b/pidfile/pid_unix.go
@@ -11,14 +11,19 @@ import (
 )
 
 func existsPid(pid int) bool {
+	_, err := os.Stat(fmt.Sprintf("/proc/%d/", pid))
+	return err == nil
+}
+
+func getCmdName(pid int) string {
 	cnt, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 	if err != nil {
-		return false
+		return ""
 	}
 
 	out := string(cnt)
 	if i := strings.IndexRune(out, '\x00'); i > 0 {
 		out = out[:i]
 	}
-	return filepath.Base(out) == filepath.Base(os.Args[0])
+	return filepath.Base(out)
 }

--- a/pidfile/pid_windows.go
+++ b/pidfile/pid_windows.go
@@ -1,6 +1,11 @@
 package pidfile
 
-func existsPid(_ int) bool {
+func existsPid(int) bool {
 	// XXX not implemented. should use `tasklist` command or so
 	return false
+}
+
+func getCmdName(int) string {
+	// XXX not implemented.
+	return ""
 }

--- a/pidfile/pidfile.go
+++ b/pidfile/pidfile.go
@@ -22,7 +22,7 @@ func Create(pidfile string) error {
 			if pid == os.Getpid() {
 				return nil
 			}
-			if ExistsPid(pid) {
+			if GetCmdName(pid) == filepath.Base(os.Args[0]) {
 				return fmt.Errorf("pidfile found, try stopping another running mackerel-agent or delete %s", pidfile)
 			}
 			// Note mackerel-agent in windows can't remove pidfile during stoping the service

--- a/pidfile/pidfile_test.go
+++ b/pidfile/pidfile_test.go
@@ -16,7 +16,7 @@ func TestCreate(t *testing.T) {
 		t.Errorf("err should be nil but: %v", err)
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := ioutil.TempDir("", "mackerel-agent-test-pidfile")
 	if err != nil {
 		t.Fatalf("failed to create tempdir")
 	}
@@ -43,7 +43,7 @@ func TestRemove(t *testing.T) {
 	if err != nil {
 		t.Errorf("err should be nil but: %v", err)
 	}
-	dir, err := ioutil.TempDir("", "")
+	dir, err := ioutil.TempDir("", "mackerel-agent-test-pidfile")
 	if err != nil {
 		t.Fatalf("failed to create tempdir")
 	}

--- a/pidfile/pidfile_test.go
+++ b/pidfile/pidfile_test.go
@@ -3,7 +3,6 @@
 package pidfile
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -36,20 +35,6 @@ func TestCreate(t *testing.T) {
 	err = Create(pidfile)
 	if err != nil {
 		t.Errorf("When the content of pidfile is the same as own pid, the error should be nil, but: %s", err.Error())
-	}
-}
-
-func TestCreate_mutex(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create tempdir")
-	}
-	defer os.RemoveAll(dir)
-	pidfile := filepath.Join(dir, "pidfile")
-	ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getppid())), 0644)
-	err = Create(pidfile)
-	if err == nil {
-		t.Errorf("if pidfile exists and its process is running, an error should be returned, but successfully overwriting the pidfile unintentionally")
 	}
 }
 

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -21,6 +21,14 @@ func init() {
 	}
 }
 
+func TestMain(m *testing.M) {
+	// overwrite os.Args[0] to make pid check pass
+	oldArg0 := os.Args[0]
+	os.Args[0] = stubAgent
+	defer func() { os.Args[0] = oldArg0 }()
+	os.Exit(m.Run())
+}
+
 func TestSupervise(t *testing.T) {
 	ch := make(chan os.Signal, 1)
 	done := make(chan error)

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -21,14 +21,6 @@ func init() {
 	}
 }
 
-func TestMain(m *testing.M) {
-	// overwrite os.Args[0] to make pid check pass
-	oldArg0 := os.Args[0]
-	os.Args[0] = stubAgent
-	defer func() { os.Args[0] = oldArg0 }()
-	os.Exit(m.Run())
-}
-
 func TestSupervise(t *testing.T) {
 	ch := make(chan os.Signal, 1)
 	done := make(chan error)


### PR DESCRIPTION
On unexpected OS restart, there happens that different process uses the same pid as mackerel-agent before restart. We should start the mackerel-agent, when it finds a process matching the old pid file but is not mackerel-agent.