### PR TITLE
Remove memory.active and inactive metrics

### DIFF
--- a/metrics/darwin/memory.go
+++ b/metrics/darwin/memory.go
@@ -13,7 +13,7 @@ MemoryGenerator collect memory usage
 
 `memory.{metric}`: using memory size retrieved from `vm_stat`
 
-metric = "total", "free", "used", "cached", "active", "inactive"
+metric = "total", "free", "used", "cached"
 
 graph: stacks `memory.{metric}`
 */
@@ -34,8 +34,6 @@ func (g *MemoryGenerator) Generate() (metrics.Values, error) {
 		"memory.used":       float64(memory.Used),
 		"memory.cached":     float64(memory.Cached),
 		"memory.free":       float64(memory.Free),
-		"memory.active":     float64(memory.Active),
-		"memory.inactive":   float64(memory.Inactive),
 		"memory.swap_total": float64(memory.SwapTotal),
 		"memory.swap_free":  float64(memory.SwapFree),
 	}

--- a/metrics/darwin/memory_test.go
+++ b/metrics/darwin/memory_test.go
@@ -16,8 +16,6 @@ func TestMemoryGenerator(t *testing.T) {
 		"total",
 		"free",
 		"cached",
-		"active",
-		"inactive",
 		"used",
 		"swap_total",
 		"swap_free",

--- a/metrics/freebsd/memory.go
+++ b/metrics/freebsd/memory.go
@@ -47,14 +47,6 @@ func (g *MemoryGenerator) Generate() (metrics.Values, error) {
 						k = k[0 : len(k)-1]
 					}
 					switch k {
-					case "Active":
-						ret["memory.active"] = v
-					case "Inact":
-						ret["memory.inactive"] = v
-					/*
-						case "Wired":
-							ret["memory.wired"] = v
-					*/
 					case "Cache":
 						ret["memory.cached"] = v
 					case "Buf":

--- a/metrics/freebsd/memory_test.go
+++ b/metrics/freebsd/memory_test.go
@@ -18,8 +18,6 @@ func TestMemoryGenerator(t *testing.T) {
 		"free",
 		"buffers",
 		"cached",
-		"active",
-		"inactive",
 		"swap_total",
 		"swap_free",
 	} {

--- a/metrics/linux/memory.go
+++ b/metrics/linux/memory.go
@@ -13,7 +13,7 @@ MemoryGenerator collect memory usage
 
 `memory.{metric}`: using memory size[KiB] retrieved from /proc/meminfo
 
-metric = "total", "free", "buffers", "cached", "active", "inactive", "swap_cached", "swap_total", "swap_free"
+metric = "total", "free", "buffers", "cached", "swap_cached", "swap_total", "swap_free"
 
 Metrics "used" is calculated by
   (total - available) when MemAvailable is available in /proc/meminfo and
@@ -37,8 +37,6 @@ func (g *MemoryGenerator) Generate() (metrics.Values, error) {
 	ret := map[string]float64{
 		"memory.total":       float64(mem.Total),
 		"memory.used":        float64(mem.Used),
-		"memory.active":      float64(mem.Active),
-		"memory.inactive":    float64(mem.Inactive),
 		"memory.swap_total":  float64(mem.SwapTotal),
 		"memory.swap_cached": float64(mem.SwapCached),
 		"memory.swap_free":   float64(mem.SwapFree),

--- a/metrics/linux/memory_test.go
+++ b/metrics/linux/memory_test.go
@@ -17,8 +17,6 @@ func TestMemoryGenerator(t *testing.T) {
 	metricNames := []string{
 		"total",
 		"mem_available",
-		"active",
-		"inactive",
 		"swap_cached",
 		"swap_total",
 		"swap_free",


### PR DESCRIPTION
These metrics is not used in Mackerel web console and users suffer a disadvantage in a viewpoint of metrics count.