### PR TITLE
Allow working directory configuration in env of metadata plugins

### DIFF
--- a/command/metadata.go
+++ b/command/metadata.go
@@ -17,14 +17,10 @@ func metadataGenerators(conf *config.Config) []*metadata.Generator {
 
 	workdir := filepath.Join(pluginutil.PluginWorkDir(), "mackerel-metadata")
 	for name, pluginConfig := range conf.MetadataPlugins {
-		workdir := workdir
-		if dir := lookupPluginWorkDir(pluginConfig.Command.Env); dir != "" {
-			workdir = dir
-		}
 		generator := &metadata.Generator{
 			Name:      name,
 			Config:    pluginConfig,
-			Cachefile: filepath.Join(workdir, name),
+			Cachefile: getCacheFileName(name, workdir, pluginConfig),
 		}
 		logger.Debugf("Metadata plugin generator created: %#v %#v", generator, generator.Config)
 		generators = append(generators, generator)
@@ -44,6 +40,13 @@ func lookupPluginWorkDir(env []string) string {
 		}
 	}
 	return ""
+}
+
+func getCacheFileName(name, defaultWorkDir string, plugin *config.MetadataPlugin) string {
+	if dir := lookupPluginWorkDir(plugin.Command.Env); dir != "" {
+		return filepath.Join(dir, "mackerel-plugin-metadata-"+name)
+	}
+	return filepath.Join(defaultWorkDir, name)
 }
 
 type metadataResult struct {


### PR DESCRIPTION
The `MACKEREL_PLUGIN_WORKDIR` environment variable is handled by the plugin process for metrics and check plugins. So this value is often set in the `env` config within mackerel-agent.conf.
However, this environment variable is handled by the mackerel-agent process for metadata plugin. This is not intuitive when user want to configure the working directory for each metadata plugins.