### PR TITLE
[nit] Introduce context.Context

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"time"
 
 	"github.com/mackerelio/mackerel-agent/checks"
@@ -36,7 +37,7 @@ func (agent *Agent) CollectMetrics(collectedTime time.Time) *MetricsResult {
 }
 
 // Watch XXX
-func (agent *Agent) Watch(quit chan struct{}) chan *MetricsResult {
+func (agent *Agent) Watch(ctx context.Context) chan *MetricsResult {
 
 	metricsResult := make(chan *MetricsResult)
 	ticker := make(chan time.Time)
@@ -50,7 +51,7 @@ func (agent *Agent) Watch(quit chan struct{}) chan *MetricsResult {
 
 		for {
 			select {
-			case <-quit:
+			case <-ctx.Done():
 				close(ticker)
 				t.Stop()
 				return

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -58,8 +59,8 @@ func TestAgent_Watch(t *testing.T) {
 	// we cannot set interval less than 1 second
 	config.PostMetricsInterval = 1 * time.Second
 
-	quit := make(chan struct{})
-	metricsResult := ag.Watch(quit)
+	ctx := context.Background()
+	metricsResult := ag.Watch(ctx)
 
 	cnt := 0
 	end := time.After(5 * time.Second)


### PR DESCRIPTION
This is a part of refactoring, introducing context.Context. Actually mackerel-agent was written before context package came out. I believe this is useful for canceling, especially for testing, as proved in mackerel-container-agent.