### PR TITLE
Release version 0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Check command name on pid check for pid confliction after OS restart #583 (itchyny)
 * change the owner of files created in docker #587 (hayajo)
 * Fix to fit #557 into our workflow. #577 (hayajo)
+* Add mips and arm64 architecture debian packaging support #557 (tnishinaga)
 
 
 ## 0.61.1 (2019-07-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.62.0 (2019-07-30)
+
+* Allow working directory configuration in env of metadata plugins #585 (itchyny)
+* Remove tempdir in tests #588 (astj)
+* Remove memory.active and inactive metrics #584 (itchyny)
+* Check command name on pid check for pid confliction after OS restart #583 (itchyny)
+* change the owner of files created in docker #587 (hayajo)
+* Fix to fit #557 into our workflow. #577 (hayajo)
+
+
 ## 0.61.1 (2019-07-23)
 
 * Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 #581 (astj)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION := 0.61.1
+VERSION := 0.62.0
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 ARGS := "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS := "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.62.0-1.systemd) stable; urgency=low
+
+  * Allow working directory configuration in env of metadata plugins (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/585>
+  * Remove tempdir in tests (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/588>
+  * Remove memory.active and inactive metrics (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/584>
+  * Check command name on pid check for pid confliction after OS restart (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/583>
+  * change the owner of files created in docker (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/587>
+  * Fix to fit #557 into our workflow. (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/577>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 30 Jul 2019 08:31:10 +0000
+
 mackerel-agent (0.61.1-1.systemd) stable; urgency=low
 
   * Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 (by astj)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.62.0-1) stable; urgency=low
+
+  * Allow working directory configuration in env of metadata plugins (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/585>
+  * Remove tempdir in tests (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/588>
+  * Remove memory.active and inactive metrics (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/584>
+  * Check command name on pid check for pid confliction after OS restart (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/583>
+  * change the owner of files created in docker (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/587>
+  * Fix to fit #557 into our workflow. (by hayajo)
+    <https://github.com/mackerelio/mackerel-agent/pull/577>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 30 Jul 2019 08:31:10 +0000
+
 mackerel-agent (0.61.1-1) stable; urgency=low
 
   * Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 (by astj)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,14 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Tue Jul 30 2019 <mackerel-developers@hatena.ne.jp> - 0.62.0
+- Allow working directory configuration in env of metadata plugins (by itchyny)
+- Remove tempdir in tests (by astj)
+- Remove memory.active and inactive metrics (by itchyny)
+- Check command name on pid check for pid confliction after OS restart (by itchyny)
+- change the owner of files created in docker (by hayajo)
+- Fix to fit #557 into our workflow. (by hayajo)
+
 * Tue Jul 23 2019 <mackerel-developers@hatena.ne.jp> - 0.61.1
 - Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 (by astj)
 

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,14 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Tue Jul 30 2019 <mackerel-developers@hatena.ne.jp> - 0.62.0
+- Allow working directory configuration in env of metadata plugins (by itchyny)
+- Remove tempdir in tests (by astj)
+- Remove memory.active and inactive metrics (by itchyny)
+- Check command name on pid check for pid confliction after OS restart (by itchyny)
+- change the owner of files created in docker (by hayajo)
+- Fix to fit #557 into our workflow. (by hayajo)
+
 * Tue Jul 23 2019 <mackerel-developers@hatena.ne.jp> - 0.61.1
 - Set rpm dist to ".el7.centos", not ".el7" in rpm-v2 (by astj)
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.61.1"
+const version = "0.62.0"
 
 var gitcommit string


### PR DESCRIPTION
- Allow working directory configuration in env of metadata plugins #585
- Remove tempdir in tests #588
- Remove memory.active and inactive metrics #584
- Check command name on pid check for pid confliction after OS restart #583
- change the owner of files created in docker #587
- Fix to fit #557 into our workflow. #577
- Add mips and arm64 architecture debian packaging support #557