### PR TITLE
Fixed to create configuration directory directory when executing init command if not exist directory

### DIFF
--- a/do_init.go
+++ b/do_init.go
@@ -28,7 +28,7 @@ func doInitialize(fs *flag.FlagSet, argv []string) error {
 		if !os.IsNotExist(err) {
 			return err
 		}
-		err := os.MkdirAll(filepath.Dir(*conffile), 0744)
+		err := os.MkdirAll(root, 0744)
 		if err != nil {
 			return err
 		}

--- a/do_init.go
+++ b/do_init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/mackerelio/mackerel-agent/config"
 )
@@ -21,6 +22,13 @@ func doInitialize(fs *flag.FlagSet, argv []string) error {
 		return fmt.Errorf("-apikey option is required")
 	}
 	_, err := os.Stat(*conffile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		os.MkdirAll(filepath.Dir(*conffile), 0644)
+	}
+
 	confExists := err == nil
 	if confExists {
 		conf, err := config.LoadConfig(*conffile)

--- a/do_init.go
+++ b/do_init.go
@@ -28,7 +28,7 @@ func doInitialize(fs *flag.FlagSet, argv []string) error {
 		if !os.IsNotExist(err) {
 			return err
 		}
-		err := os.MkdirAll(root, 0744)
+		err := os.MkdirAll(root, 0755)
 		if err != nil {
 			return err
 		}

--- a/do_init.go
+++ b/do_init.go
@@ -21,14 +21,20 @@ func doInitialize(fs *flag.FlagSet, argv []string) error {
 		// Setting apikey via environment variable should be supported or not?
 		return fmt.Errorf("-apikey option is required")
 	}
-	_, err := os.Stat(*conffile)
-	if err != nil {
+
+	// make the config file directory if not exist
+	root := filepath.Dir(*conffile)
+	if _, err := os.Stat(root); err != nil {
 		if !os.IsNotExist(err) {
 			return err
 		}
-		os.MkdirAll(filepath.Dir(*conffile), 0644)
+		err := os.MkdirAll(filepath.Dir(*conffile), 0744)
+		if err != nil {
+			return err
+		}
 	}
 
+	_, err := os.Stat(*conffile)
 	confExists := err == nil
 	if confExists {
 		conf, err := config.LoadConfig(*conffile)

--- a/do_init_test.go
+++ b/do_init_test.go
@@ -21,10 +21,10 @@ func TestDoInitialize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not create temporary dir for test")
 	}
-	defer os.RemoveAll(root)
+	// defer os.RemoveAll(root)
 
 	{
-		// confファイルがのディレクトリが存在しないとき
+		// not exist config file directory
 		confdir := filepath.Join(root, "confdir-test")
 		conffile := filepath.Join(confdir, "mackerel-agent.conf")
 		argv := []string{"-conf", conffile, "-apikey", "hoge"}

--- a/do_init_test.go
+++ b/do_init_test.go
@@ -24,6 +24,17 @@ func TestDoInitialize(t *testing.T) {
 	defer os.RemoveAll(root)
 
 	{
+		// confファイルがのディレクトリが存在しないとき
+		confdir := filepath.Join(root, "confdir-test")
+		conffile := filepath.Join(confdir, "mackerel-agent.conf")
+		argv := []string{"-conf", conffile, "-apikey", "hoge"}
+		err := doInit(&flag.FlagSet{}, argv)
+		if err != nil {
+			t.Errorf("err should be nil but: %s", err)
+		}
+	}
+
+	{
 		conffile := filepath.Join(root, "mackerel-agent.conf")
 		argv := []string{"-conf", conffile, "-apikey", "hoge"}
 		err := doInit(&flag.FlagSet{}, argv)

--- a/do_init_test.go
+++ b/do_init_test.go
@@ -21,7 +21,7 @@ func TestDoInitialize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not create temporary dir for test")
 	}
-	// defer os.RemoveAll(root)
+	defer os.RemoveAll(root)
 
 	{
 		// not exist config file directory


### PR DESCRIPTION
If the configuration file directory does not exist, 
executing ```mackerel-agent init -apikey "api key "``` will return an error with no such file or directory.
So, modified to create a directory if it doesn't exist when executing the above command,
And, add test code for not existing configuration directory.