### PR TITLE
Release version 0.63.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.63.0 (2019-09-11)
+
+* avoid to use unnamed NICs for registering hosts on Windows #580 (lufia)
+* Fixed to create configuration directory directory when executing init command if not exist directory #592 (homedm)
+
+
 ## 0.62.1 (2019-08-29)
 
 * Update dependencies #590 (astj)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION := 0.62.1
+VERSION := 0.63.0
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 ARGS := "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS := "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.63.0-1.systemd) stable; urgency=low
+
+  * avoid to use unnamed NICs for registering hosts on Windows (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/580>
+  * Fixed to create configuration directory directory when executing init command if not exist directory (by homedm)
+    <https://github.com/mackerelio/mackerel-agent/pull/592>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 11 Sep 2019 14:41:31 +0000
+
 mackerel-agent (0.62.1-1.systemd) stable; urgency=low
 
   * Update dependencies (by astj)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent (0.63.0-1) stable; urgency=low
+
+  * avoid to use unnamed NICs for registering hosts on Windows (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/580>
+  * Fixed to create configuration directory directory when executing init command if not exist directory (by homedm)
+    <https://github.com/mackerelio/mackerel-agent/pull/592>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 11 Sep 2019 14:41:31 +0000
+
 mackerel-agent (0.62.1-1) stable; urgency=low
 
   * Update dependencies (by astj)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,10 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Wed Sep 11 2019 <mackerel-developers@hatena.ne.jp> - 0.63.0
+- avoid to use unnamed NICs for registering hosts on Windows (by lufia)
+- Fixed to create configuration directory directory when executing init command if not exist directory (by homedm)
+
 * Thu Aug 29 2019 <mackerel-developers@hatena.ne.jp> - 0.62.1
 - Update dependencies (by astj)
 

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,10 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Sep 11 2019 <mackerel-developers@hatena.ne.jp> - 0.63.0
+- avoid to use unnamed NICs for registering hosts on Windows (by lufia)
+- Fixed to create configuration directory directory when executing init command if not exist directory (by homedm)
+
 * Thu Aug 29 2019 <mackerel-developers@hatena.ne.jp> - 0.62.1
 - Update dependencies (by astj)
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.62.1"
+const version = "0.63.0"
 
 var gitcommit string


### PR DESCRIPTION
- avoid to use unnamed NICs for registering hosts on Windows #580
- Fixed to create configuration directory directory when executing init command if not exist directory #592