### PR TITLE
Fix wix/mackerel-agent.sample.conf

### DIFF
--- a/wix/mackerel-agent.sample.conf
+++ b/wix/mackerel-agent.sample.conf
@@ -1,15 +1,15 @@
-# pidfile = "C:\path\to\pidfile"
-# root = "C:\path\to\root"
+# pidfile = 'C:\path\to\pidfile'
+# root = 'C:\path\to\root'
 verbose = false
 apikey = "___YOUR_API_KEY___"
 
 # Include other config files
-# include = "C:\path\to\conf\*.conf"
+# include = 'C:\path\to\conf\*.conf'
 
 # Configuration for Custom Metrics Plugins
 # see also: https://mackerel.io/ja/docs/entry/advanced/custom-metrics
 #
 # [plugin.metrics.vmstat]
-# command = "ruby C:\path\to\plugins\metrics-vmstat.rb"
+# command = 'ruby C:\path\to\plugins\metrics-vmstat.rb'
 # [plugin.metrics.curl]
-# command = "ruby C:\path\to\plugins\metrics-curl.rb"
+# command = "ruby C:\\path\\to\\plugins\\metrics-curl.rb"


### PR DESCRIPTION
In windows, mackerel-agent can't start with sample format because the path-separator `\` is not escaped.
In double quoted path string, path separator mult be escaped with `\\`. 
Or need to quote with single quote.

```mackerel-agent.conf
apikey = "___MY_API_KEY___"

[plugin.metrics.sample]
command = "C:\Program Files (x86)\Mackerel\mackerel-agent\plugins\bin\mackerel-plugin-sample"
#command = 'C:\Program Files (x86)\Mackerel\mackerel-agent\plugins\bin\mackerel-plugin-sample'
#command = "C:\\Program Files (x86)\\Mackerel\\mackerel-agent\\plugins\\bin\\mackerel-plugin-sample"
```

using the above config, mackerel-agent can't start.
The Event log is below.

```event log
failed to load config: failed to load the config file: Near line 4 (last key parsed 'plugin.metrics.sample.command'): invalid escape character 'P'; only the following escape characters are allowed: \b, \t, \n, \f, \r, \", \\, \uXXXX, and \UXXXXXXXX
```

The comment outed line is valid and mackerel-agent can start.