### PR TITLE
Pass the check monitoring result message to "action" by env

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -429,7 +429,7 @@ func runChecker(ctx context.Context, checker *checks.Checker, checkReportCh chan
 			nextTime = now.Add(nextInterval)
 
 			if checker.Config.Action != nil {
-				env := []string{fmt.Sprintf("MACKEREL_STATUS=%s", report.Status), fmt.Sprintf("MACKEREL_PREVIOUS_STATUS=%s", lastStatus)}
+				env := []string{fmt.Sprintf("MACKEREL_STATUS=%s", report.Status), fmt.Sprintf("MACKEREL_PREVIOUS_STATUS=%s", lastStatus), fmt.Sprintf("MACKEREL_CHECK_MESSAGE=%s", report.Message)}
 				go func() {
 					logger.Debugf("Checker %q action: %q env: %+v", checker.Name, checker.Config.Action.CommandString(), env)
 					stdout, stderr, exitCode, _ := checker.Config.Action.RunWithEnv(env)


### PR DESCRIPTION
Currently, there is an "action" for check monitoring, but there is almost no way to pass the result of check monitoring to action.

This request is intended to pass a small amount of information to the action by setting the message that the check monitoring result "report" has to the environment variable "MACKEREL_CHECK_MESSAGE".