### PR TITLE
Add armhf Debian package to release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ cover: deps
 # We should be installed tools of native architecture.
 .PHONY: crossbuild-package
 crossbuild-package: deps
-	mkdir -p ./build-linux-386 ./build-linux-amd64 ./build-linux-arm64 ./build-linux-mips
+	mkdir -p ./build-linux-386 ./build-linux-amd64 ./build-linux-arm64 ./build-linux-mips ./build-linux-armhf
 	GOOS=linux GOARCH=386 make build
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-386/
 	GOOS=linux GOARCH=amd64 make build
@@ -103,6 +103,8 @@ crossbuild-package: deps
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-arm64/
 	GOOS=linux GOARCH=mips make build
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-mips/
+	GOOS=linux GOARCH=arm GOARM=6 make build
+	mv build/$(MACKEREL_AGENT_NAME) build-linux-armhf/
 
 .PHONY: crossbuild-package-kcps
 crossbuild-package-kcps:
@@ -147,20 +149,23 @@ deb: deb-v1 deb-v2
 .PHONY: deb-v1
 deb-v1: crossbuild-package
 	BUILD_DIRECTORY=build-linux-386 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 .PHONY: deb-v2
 deb-v2: crossbuild-package
 	BUILD_DIRECTORY=build-linux-amd64 BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 	BUILD_DIRECTORY=build-linux-arm64 BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us -aarm64; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 	BUILD_DIRECTORY=build-linux-mips BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us -amips; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
+	BUILD_DIRECTORY=build-linux-armhf BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
+		-c "debuild --no-tgz-check -uc -us -aarmhf; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 .PHONY: rpm-kcps
 rpm-kcps: rpm-kcps-v1 rpm-kcps-v2
@@ -192,13 +197,13 @@ deb-kcps: deb-kcps-v1 deb-kcps-v2
 .PHONY: deb-kcps-v1
 deb-kcps-v1: crossbuild-package-kcps
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps BUILD_DIRECTORY=build-linux-386 _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 .PHONY: deb-kcps-v2
 deb-kcps-v2: crossbuild-package-kcps
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps BUILD_SYSTEMD=1 BUILD_DIRECTORY=build-linux-amd64 _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 .PHONY: rpm-stage
@@ -226,13 +231,13 @@ deb-stage: deb-stage-v1 deb-stage-v2
 .PHONY: deb-stage-v1
 deb-stage-v1: crossbuild-package-stage
 	MACKEREL_AGENT_NAME=mackerel-agent-stage BUILD_DIRECTORY=build-linux-386 _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 .PHONY: deb-stage-v2
 deb-stage-v2: crossbuild-package-stage
 	MACKEREL_AGENT_NAME=mackerel-agent-stage BUILD_SYSTEMD=1 BUILD_DIRECTORY=build-linux-amd64 _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 tgz_dir = "build/tgz/$(MACKEREL_AGENT_NAME)"
@@ -263,7 +268,7 @@ release: check-release-deps
 
 .PHONY: clean
 clean:
-	rm -f build/$(MACKEREL_AGENT_NAME) build-linux-amd64/$(MACKEREL_AGENT_NAME) build-linux-386/$(MACKEREL_AGENT_NAME) CREDITS
+	rm -f build/$(MACKEREL_AGENT_NAME) build-linux-{386,amd64,arm64,mips,armhf}/$(MACKEREL_AGENT_NAME) CREDITS
 	go clean
 
 .PHONY: update

--- a/Makefile
+++ b/Makefile
@@ -149,22 +149,22 @@ deb: deb-v1 deb-v2
 .PHONY: deb-v1
 deb-v1: crossbuild-package
 	BUILD_DIRECTORY=build-linux-386 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 .PHONY: deb-v2
 deb-v2: crossbuild-package
 	BUILD_DIRECTORY=build-linux-amd64 BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 	BUILD_DIRECTORY=build-linux-arm64 BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us -aarm64; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 	BUILD_DIRECTORY=build-linux-mips BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us -amips; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 	BUILD_DIRECTORY=build-linux-armhf BUILD_SYSTEMD=1 MACKEREL_AGENT_NAME=$(MACKEREL_AGENT_NAME) _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us -aarmhf; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 .PHONY: rpm-kcps
@@ -197,13 +197,13 @@ deb-kcps: deb-kcps-v1 deb-kcps-v2
 .PHONY: deb-kcps-v1
 deb-kcps-v1: crossbuild-package-kcps
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps BUILD_DIRECTORY=build-linux-386 _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 .PHONY: deb-kcps-v2
 deb-kcps-v2: crossbuild-package-kcps
 	MACKEREL_AGENT_NAME=mackerel-agent-kcps BUILD_SYSTEMD=1 BUILD_DIRECTORY=build-linux-amd64 _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 .PHONY: rpm-stage
@@ -231,13 +231,13 @@ deb-stage: deb-stage-v1 deb-stage-v2
 .PHONY: deb-stage-v1
 deb-stage-v1: crossbuild-package-stage
 	MACKEREL_AGENT_NAME=mackerel-agent-stage BUILD_DIRECTORY=build-linux-386 _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 .PHONY: deb-stage-v2
 deb-stage-v2: crossbuild-package-stage
 	MACKEREL_AGENT_NAME=mackerel-agent-stage BUILD_SYSTEMD=1 BUILD_DIRECTORY=build-linux-amd64 _tools/packaging/prepare-deb-build.sh
-	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh yhnw/docker-mackerel-deb-builder \
+	docker run --rm -v "$(PWD)":/workspace -w /workspace/packaging/deb-build --entrypoint /bin/sh mackerel/docker-mackerel-deb-builder \
 		-c "debuild --no-tgz-check -uc -us; chown $(shell id -u):$(shell id -g) -R /workspace/packaging/deb-build"
 
 tgz_dir = "build/tgz/$(MACKEREL_AGENT_NAME)"

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ crossbuild-package: deps
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-arm64/
 	GOOS=linux GOARCH=mips make build
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-mips/
-	GOOS=linux GOARCH=arm GOARM=6 make build
+	GOOS=linux GOARCH=arm GOARM=6 make build # specify ARMv6 for supporting Raspberry Pi 1 / Zero
 	mv build/$(MACKEREL_AGENT_NAME) build-linux-armhf/
 
 .PHONY: crossbuild-package-kcps


### PR DESCRIPTION
Add armhf(32bit ARM with hardfloat) Debian package support.

The package has already been tested in two weeks on my own Raspberry Pi 2, and it works fine.

However, this pull request has one problem. This change requires Docker image `yhnw/docker-mackerel-deb-builder`. We should use Docker image which is managed by Mackerel dev team.

If the dev team approve mackerelio/docker-mackerel-deb-builder#1, then I'll fix the problem.