### PR TITLE
Release version 0.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.64.0 (2019-10-24)
+
+* stop building 32bit Darwin artifacts #600 (astj)
+* Fix wix/mackerel-agent.sample.conf #597 (ryosms)
+* Pass the check monitoring result message to "action" by env #598 (a-know)
+* Bump github.com/mackerelio/mackerel-client-go from 0.6.0 to 0.8.0 #595 (dependabot-preview[bot])
+* add .dependabot/config.yml #594 (lufia)
+
+
 ## 0.63.0 (2019-09-11)
 
 * avoid to use unnamed NICs for registering hosts on Windows #580 (lufia)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION := 0.63.0
+VERSION := 0.64.0
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 ARGS := "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS := "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent (0.64.0-1.systemd) stable; urgency=low
+
+  * stop building 32bit Darwin artifacts (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/600>
+  * Fix wix/mackerel-agent.sample.conf (by ryosms)
+    <https://github.com/mackerelio/mackerel-agent/pull/597>
+  * Pass the check monitoring result message to "action" by env (by a-know)
+    <https://github.com/mackerelio/mackerel-agent/pull/598>
+  * Bump github.com/mackerelio/mackerel-client-go from 0.6.0 to 0.8.0 (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/595>
+  * add .dependabot/config.yml (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/594>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 24 Oct 2019 07:30:11 +0000
+
 mackerel-agent (0.63.0-1.systemd) stable; urgency=low
 
   * avoid to use unnamed NICs for registering hosts on Windows (by lufia)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent (0.64.0-1) stable; urgency=low
+
+  * stop building 32bit Darwin artifacts (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/600>
+  * Fix wix/mackerel-agent.sample.conf (by ryosms)
+    <https://github.com/mackerelio/mackerel-agent/pull/597>
+  * Pass the check monitoring result message to "action" by env (by a-know)
+    <https://github.com/mackerelio/mackerel-agent/pull/598>
+  * Bump github.com/mackerelio/mackerel-client-go from 0.6.0 to 0.8.0 (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/595>
+  * add .dependabot/config.yml (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/594>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 24 Oct 2019 07:30:11 +0000
+
 mackerel-agent (0.63.0-1) stable; urgency=low
 
   * avoid to use unnamed NICs for registering hosts on Windows (by lufia)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,13 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Thu Oct 24 2019 <mackerel-developers@hatena.ne.jp> - 0.64.0
+- stop building 32bit Darwin artifacts (by astj)
+- Fix wix/mackerel-agent.sample.conf (by ryosms)
+- Pass the check monitoring result message to "action" by env (by a-know)
+- Bump github.com/mackerelio/mackerel-client-go from 0.6.0 to 0.8.0 (by dependabot-preview[bot])
+- add .dependabot/config.yml (by lufia)
+
 * Wed Sep 11 2019 <mackerel-developers@hatena.ne.jp> - 0.63.0
 - avoid to use unnamed NICs for registering hosts on Windows (by lufia)
 - Fixed to create configuration directory directory when executing init command if not exist directory (by homedm)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,13 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Thu Oct 24 2019 <mackerel-developers@hatena.ne.jp> - 0.64.0
+- stop building 32bit Darwin artifacts (by astj)
+- Fix wix/mackerel-agent.sample.conf (by ryosms)
+- Pass the check monitoring result message to "action" by env (by a-know)
+- Bump github.com/mackerelio/mackerel-client-go from 0.6.0 to 0.8.0 (by dependabot-preview[bot])
+- add .dependabot/config.yml (by lufia)
+
 * Wed Sep 11 2019 <mackerel-developers@hatena.ne.jp> - 0.63.0
 - avoid to use unnamed NICs for registering hosts on Windows (by lufia)
 - Fixed to create configuration directory directory when executing init command if not exist directory (by homedm)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.63.0"
+const version = "0.64.0"
 
 var gitcommit string


### PR DESCRIPTION
- stop building 32bit Darwin artifacts #600
- Fix wix/mackerel-agent.sample.conf #597
- Pass the check monitoring result message to "action" by env #598
- Bump github.com/mackerelio/mackerel-client-go from 0.6.0 to 0.8.0 #595
- add .dependabot/config.yml #594