### PR TITLE
Install development tools in module-aware mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,19 +44,19 @@ credits: $(GOBIN)/gocredits
 	gocredits -w .
 
 $(GOBIN)/golint:
-	GO111MODULE=off go get golang.org/x/lint/golint
+	cd && go get golang.org/x/lint/golint
 
 $(GOBIN)/gotestcover:
-	GO111MODULE=off go get github.com/pierrre/gotestcover
+	cd && go get github.com/pierrre/gotestcover
 
 $(GOBIN)/gocredits:
-	GO111MODULE=off go get github.com/Songmu/gocredits/cmd/gocredits
+	cd && go get github.com/Songmu/gocredits/cmd/gocredits
 
 $(GOBIN)/goxz:
-	GO111MODULE=off go get github.com/Songmu/goxz/cmd/goxz
+	cd && go get github.com/Songmu/goxz/cmd/goxz
 
 $(GOBIN)/goveralls:
-	GO111MODULE=off go get github.com/mattn/goveralls
+	cd && go get github.com/mattn/goveralls
 
 .PHONY: lint
 lint: deps


### PR DESCRIPTION
The import path `<repository>/<branch>` is accepted only module-aware mode.

Currently `github.com/mholt/archiver/v3` uses above notation, so go-build can't find archiver/v3 package on GOPATH mode.

ref mackerelio/mkr#246