### PR TITLE
Release version 0.64.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.64.1 (2019-11-21)
+
+* Install development tools in module-aware mode #606 (lufia)
+* Bump github.com/shirou/gopsutil from 2.18.12+incompatible to 2.19.10+incompatible #602 (dependabot-preview[bot])
+* Add armhf Debian package to release #599 (hnw)
+
+
 ## 0.64.0 (2019-10-24)
 
 * Build with Go 1.12.12

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION := 0.64.0
+VERSION := 0.64.1
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 ARGS := "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS := "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent (0.64.1-1.systemd) stable; urgency=low
+
+  * Install development tools in module-aware mode (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/606>
+  * Bump github.com/shirou/gopsutil from 2.18.12+incompatible to 2.19.10+incompatible (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/602>
+  * Add armhf Debian package to release (by hnw)
+    <https://github.com/mackerelio/mackerel-agent/pull/599>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 21 Nov 2019 10:32:53 +0000
+
 mackerel-agent (0.64.0-1.systemd) stable; urgency=low
 
   * Build with Go 1.12.12

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent (0.64.1-1) stable; urgency=low
+
+  * Install development tools in module-aware mode (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/606>
+  * Bump github.com/shirou/gopsutil from 2.18.12+incompatible to 2.19.10+incompatible (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/602>
+  * Add armhf Debian package to release (by hnw)
+    <https://github.com/mackerelio/mackerel-agent/pull/599>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 21 Nov 2019 10:32:53 +0000
+
 mackerel-agent (0.64.0-1) stable; urgency=low
 
   * Build with Go 1.12.12

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,11 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Thu Nov 21 2019 <mackerel-developers@hatena.ne.jp> - 0.64.1
+- Install development tools in module-aware mode (by lufia)
+- Bump github.com/shirou/gopsutil from 2.18.12+incompatible to 2.19.10+incompatible (by dependabot-preview[bot])
+- Add armhf Debian package to release (by hnw)
+
 * Thu Oct 24 2019 <mackerel-developers@hatena.ne.jp> - 0.64.0
 - Build with Go 1.12.12
 - stop building 32bit Darwin artifacts (by astj)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,11 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Thu Nov 21 2019 <mackerel-developers@hatena.ne.jp> - 0.64.1
+- Install development tools in module-aware mode (by lufia)
+- Bump github.com/shirou/gopsutil from 2.18.12+incompatible to 2.19.10+incompatible (by dependabot-preview[bot])
+- Add armhf Debian package to release (by hnw)
+
 * Thu Oct 24 2019 <mackerel-developers@hatena.ne.jp> - 0.64.0
 - Build with Go 1.12.12
 - stop building 32bit Darwin artifacts (by astj)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.64.0"
+const version = "0.64.1"
 
 var gitcommit string


### PR DESCRIPTION
- Install development tools in module-aware mode #606
- Bump github.com/shirou/gopsutil from 2.18.12+incompatible to 2.19.10+incompatible #602
- Add armhf Debian package to release #599