### PR TITLE
refactor: Inject CloudMetaGenerators to Suggester in order to test them in safer way

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -578,7 +578,7 @@ func collectHostParam(conf *config.Config, ameta *AgentMeta) (*mkr.CreateHostPar
 	}
 
 	specGens := specGenerators()
-	cGen := spec.SuggestCloudGenerator(conf)
+	cGen := spec.CloudGeneratorSuggestor.Suggest(conf)
 	if cGen != nil {
 		specGens = append(specGens, cGen)
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -578,7 +578,7 @@ func collectHostParam(conf *config.Config, ameta *AgentMeta) (*mkr.CreateHostPar
 	}
 
 	specGens := specGenerators()
-	cGen := spec.CloudGeneratorSuggestor.Suggest(conf)
+	cGen := spec.CloudGeneratorSuggester.Suggest(conf)
 	if cGen != nil {
 		specGens = append(specGens, cGen)
 	}

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -54,14 +54,14 @@ var cloudLogger = logging.GetLogger("spec.cloud")
 
 var ec2BaseURL, gceMetaURL, azureVMBaseURL *url.URL
 
-type cloudGeneratorSuggestor struct {
+type cloudGeneratorSuggester struct {
 	ec2Generator     ec2Generator
 	gceGenerator     gceGenerator
 	azureVMGenerator azureVMGenerator
 }
 
 // Suggest returns suitable CloudGenerator
-func (s *cloudGeneratorSuggestor) Suggest(conf *config.Config) *CloudGenerator {
+func (s *cloudGeneratorSuggester) Suggest(conf *config.Config) *CloudGenerator {
 	// if CloudPlatform is specified, return corresponding one
 	switch conf.CloudPlatform {
 	case config.CloudPlatformNone:
@@ -112,15 +112,15 @@ func (s *cloudGeneratorSuggestor) Suggest(conf *config.Config) *CloudGenerator {
 	return <-gCh
 }
 
-// CloudGeneratorSuggestor suggests suitable CloudGenerator
-var CloudGeneratorSuggestor *cloudGeneratorSuggestor
+// CloudGeneratorSuggester suggests suitable CloudGenerator
+var CloudGeneratorSuggester *cloudGeneratorSuggester
 
 func init() {
 	ec2BaseURL, _ = url.Parse("http://169.254.169.254/latest/meta-data")
 	gceMetaURL, _ = url.Parse("http://metadata.google.internal./computeMetadata/v1/?recursive=true")
 	azureVMBaseURL, _ = url.Parse("http://169.254.169.254/metadata/instance")
 
-	CloudGeneratorSuggestor = &cloudGeneratorSuggestor{
+	CloudGeneratorSuggester = &cloudGeneratorSuggester{
 		ec2Generator:     &EC2Generator{ec2BaseURL},
 		gceGenerator:     &GCEGenerator{gceMetaURL},
 		azureVMGenerator: &AzureVMGenerator{azureVMBaseURL},

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -112,6 +112,7 @@ func (s *cloudGeneratorSuggestor) Suggest(conf *config.Config) *CloudGenerator {
 	return <-gCh
 }
 
+// CloudGeneratorSuggestor suggests suitable CloudGenerator
 var CloudGeneratorSuggestor *cloudGeneratorSuggestor
 
 func init() {

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -54,25 +54,27 @@ var cloudLogger = logging.GetLogger("spec.cloud")
 
 var ec2BaseURL, gceMetaURL, azureVMBaseURL *url.URL
 
-func init() {
-	ec2BaseURL, _ = url.Parse("http://169.254.169.254/latest/meta-data")
-	gceMetaURL, _ = url.Parse("http://metadata.google.internal./computeMetadata/v1/?recursive=true")
-	azureVMBaseURL, _ = url.Parse("http://169.254.169.254/metadata/instance")
-}
-
-var timeout = 3 * time.Second
-
 type cloudGeneratorSuggestor struct {
 	ec2Generator     ec2Generator
 	gceGenerator     gceGenerator
 	azureVMGenerator azureVMGenerator
 }
 
-var CloudGeneratorSuggestor = &cloudGeneratorSuggestor{
-	ec2Generator:     &EC2Generator{ec2BaseURL},
-	gceGenerator:     &GCEGenerator{gceMetaURL},
-	azureVMGenerator: &AzureVMGenerator{azureVMBaseURL},
+var CloudGeneratorSuggestor *cloudGeneratorSuggestor
+
+func init() {
+	ec2BaseURL, _ = url.Parse("http://169.254.169.254/latest/meta-data")
+	gceMetaURL, _ = url.Parse("http://metadata.google.internal./computeMetadata/v1/?recursive=true")
+	azureVMBaseURL, _ = url.Parse("http://169.254.169.254/metadata/instance")
+
+	CloudGeneratorSuggestor = &cloudGeneratorSuggestor{
+		ec2Generator:     &EC2Generator{ec2BaseURL},
+		gceGenerator:     &GCEGenerator{gceMetaURL},
+		azureVMGenerator: &AzureVMGenerator{azureVMBaseURL},
+	}
 }
+
+var timeout = 3 * time.Second
 
 // Suggest returns suitable CloudGenerator
 func (s *cloudGeneratorSuggestor) Suggest(conf *config.Config) *CloudGenerator {

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -143,6 +143,7 @@ type EC2Generator struct {
 
 // IsEC2 checks current environment is EC2 or not
 func (g *EC2Generator) IsEC2(ctx context.Context) bool {
+	// implementation varies between OSs. see ec2_XXX.go
 	return isEC2(ctx)
 }
 

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -60,22 +60,6 @@ type cloudGeneratorSuggestor struct {
 	azureVMGenerator azureVMGenerator
 }
 
-var CloudGeneratorSuggestor *cloudGeneratorSuggestor
-
-func init() {
-	ec2BaseURL, _ = url.Parse("http://169.254.169.254/latest/meta-data")
-	gceMetaURL, _ = url.Parse("http://metadata.google.internal./computeMetadata/v1/?recursive=true")
-	azureVMBaseURL, _ = url.Parse("http://169.254.169.254/metadata/instance")
-
-	CloudGeneratorSuggestor = &cloudGeneratorSuggestor{
-		ec2Generator:     &EC2Generator{ec2BaseURL},
-		gceGenerator:     &GCEGenerator{gceMetaURL},
-		azureVMGenerator: &AzureVMGenerator{azureVMBaseURL},
-	}
-}
-
-var timeout = 3 * time.Second
-
 // Suggest returns suitable CloudGenerator
 func (s *cloudGeneratorSuggestor) Suggest(conf *config.Config) *CloudGenerator {
 	// if CloudPlatform is specified, return corresponding one
@@ -127,6 +111,22 @@ func (s *cloudGeneratorSuggestor) Suggest(conf *config.Config) *CloudGenerator {
 
 	return <-gCh
 }
+
+var CloudGeneratorSuggestor *cloudGeneratorSuggestor
+
+func init() {
+	ec2BaseURL, _ = url.Parse("http://169.254.169.254/latest/meta-data")
+	gceMetaURL, _ = url.Parse("http://metadata.google.internal./computeMetadata/v1/?recursive=true")
+	azureVMBaseURL, _ = url.Parse("http://169.254.169.254/metadata/instance")
+
+	CloudGeneratorSuggestor = &cloudGeneratorSuggestor{
+		ec2Generator:     &EC2Generator{ec2BaseURL},
+		gceGenerator:     &GCEGenerator{gceMetaURL},
+		azureVMGenerator: &AzureVMGenerator{azureVMBaseURL},
+	}
+}
+
+var timeout = 3 * time.Second
 
 func httpCli() *http.Client {
 	return &http.Client{

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -19,7 +19,7 @@ import (
 )
 
 // This Generator collects metadata about cloud instances.
-// Currently EC2 and GCE are supported.
+// Currently EC2, AzureVM and GCE are supported.
 // EC2: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
 // GCE: https://developers.google.com/compute/docs/metadata
 // AzureVM: https://docs.microsoft.com/azure/virtual-machines/virtual-machines-instancemetadataservice-overview

--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -146,7 +146,7 @@ type EC2Generator struct {
 
 // IsEC2 checks current environment is EC2 or not
 func (g *EC2Generator) IsEC2(ctx context.Context) bool {
-	// implementation varies between OSs. see ec2_XXX.go
+	// implementation varies between OSs. see isec2_XXX.go
 	return isEC2(ctx)
 }
 

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -306,7 +306,7 @@ func TestSuggestCloudGenerator(t *testing.T) {
 		}
 	}()
 
-	func() { // multiple generators are available, but suggest the first responded one (in this case EC2)
+	func() { // multiple generators are available, but suggest the first responded one (in this case Azure)
 		// azure. ok immediately
 		tsA := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 			fmt.Fprint(res, "ok")

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -282,16 +282,16 @@ func (g *slowCloudMetaGenerator) IsGCE(ctx context.Context) bool {
 	return true
 }
 
-func TestCloudGeneratorSuggestor(t *testing.T) {
+func TestCloudGeneratorSuggester(t *testing.T) {
 	conf := config.Config{}
 	// none
 	{
-		suggestor := &cloudGeneratorSuggestor{
+		suggester := &cloudGeneratorSuggester{
 			ec2Generator:     &mockEC2CloudMetaGenerator{isEC2: false},
 			gceGenerator:     &mockGCECloudMetaGenerator{isGCE: false},
 			azureVMGenerator: &mockAzureCloudMetaGenerator{isAzureVM: false},
 		}
-		cGen := suggestor.Suggest(&conf)
+		cGen := suggester.Suggest(&conf)
 		if cGen != nil {
 			t.Errorf("cGen should be nil but, %s", cGen)
 		}
@@ -299,12 +299,12 @@ func TestCloudGeneratorSuggestor(t *testing.T) {
 
 	// EC2
 	{
-		suggestor := &cloudGeneratorSuggestor{
+		suggester := &cloudGeneratorSuggester{
 			ec2Generator:     &mockEC2CloudMetaGenerator{isEC2: true},
 			gceGenerator:     &mockGCECloudMetaGenerator{isGCE: false},
 			azureVMGenerator: &mockAzureCloudMetaGenerator{isAzureVM: false},
 		}
-		cGen := suggestor.Suggest(&conf)
+		cGen := suggester.Suggest(&conf)
 		if cGen == nil {
 			t.Errorf("cGen should not be nil.")
 		}
@@ -317,12 +317,12 @@ func TestCloudGeneratorSuggestor(t *testing.T) {
 
 	// GCE
 	{
-		suggestor := &cloudGeneratorSuggestor{
+		suggester := &cloudGeneratorSuggester{
 			ec2Generator:     &mockEC2CloudMetaGenerator{isEC2: false},
 			gceGenerator:     &mockGCECloudMetaGenerator{isGCE: true},
 			azureVMGenerator: &mockAzureCloudMetaGenerator{isAzureVM: false},
 		}
-		cGen := suggestor.Suggest(&conf)
+		cGen := suggester.Suggest(&conf)
 		if cGen == nil {
 			t.Errorf("cGen should not be nil.")
 		}
@@ -335,12 +335,12 @@ func TestCloudGeneratorSuggestor(t *testing.T) {
 
 	// AzureVM
 	{
-		suggestor := &cloudGeneratorSuggestor{
+		suggester := &cloudGeneratorSuggester{
 			ec2Generator:     &mockEC2CloudMetaGenerator{isEC2: false},
 			gceGenerator:     &mockGCECloudMetaGenerator{isGCE: false},
 			azureVMGenerator: &mockAzureCloudMetaGenerator{isAzureVM: true},
 		}
-		cGen := suggestor.Suggest(&conf)
+		cGen := suggester.Suggest(&conf)
 		if cGen == nil {
 			t.Errorf("cGen should not be nil.")
 		}
@@ -353,12 +353,12 @@ func TestCloudGeneratorSuggestor(t *testing.T) {
 
 	// multiple generators are available, but suggest the first responded one (in this case Azure)
 	{
-		suggestor := &cloudGeneratorSuggestor{
+		suggester := &cloudGeneratorSuggester{
 			ec2Generator:     &slowCloudMetaGenerator{},
 			gceGenerator:     &slowCloudMetaGenerator{},
 			azureVMGenerator: &mockAzureCloudMetaGenerator{isAzureVM: true},
 		}
-		cGen := suggestor.Suggest(&conf)
+		cGen := suggester.Suggest(&conf)
 		if cGen == nil {
 			t.Errorf("cGen should not be nil.")
 		}
@@ -370,8 +370,8 @@ func TestCloudGeneratorSuggestor(t *testing.T) {
 	}
 }
 
-func TestCloudGeneratorSuggestor_CloudPlatformSpecified(t *testing.T) {
-	suggestor := &cloudGeneratorSuggestor{
+func TestCloudGeneratorSuggester_CloudPlatformSpecified(t *testing.T) {
+	suggester := &cloudGeneratorSuggester{
 		ec2Generator:     &mockEC2CloudMetaGenerator{isEC2: false},
 		gceGenerator:     &mockGCECloudMetaGenerator{isGCE: false},
 		azureVMGenerator: &mockAzureCloudMetaGenerator{isAzureVM: false},
@@ -381,7 +381,7 @@ func TestCloudGeneratorSuggestor_CloudPlatformSpecified(t *testing.T) {
 			CloudPlatform: config.CloudPlatformNone,
 		}
 
-		cGen := suggestor.Suggest(&conf)
+		cGen := suggester.Suggest(&conf)
 		if cGen != nil {
 			t.Errorf("cGen should be nil.")
 		}
@@ -392,7 +392,7 @@ func TestCloudGeneratorSuggestor_CloudPlatformSpecified(t *testing.T) {
 			CloudPlatform: config.CloudPlatformEC2,
 		}
 
-		cGen := suggestor.Suggest(&conf)
+		cGen := suggester.Suggest(&conf)
 		if cGen == nil {
 			t.Errorf("cGen should not be nil.")
 		}
@@ -408,7 +408,7 @@ func TestCloudGeneratorSuggestor_CloudPlatformSpecified(t *testing.T) {
 			CloudPlatform: config.CloudPlatformGCE,
 		}
 
-		cGen := suggestor.Suggest(&conf)
+		cGen := suggester.Suggest(&conf)
 		if cGen == nil {
 			t.Errorf("cGen should not be nil.")
 		}
@@ -424,7 +424,7 @@ func TestCloudGeneratorSuggestor_CloudPlatformSpecified(t *testing.T) {
 			CloudPlatform: config.CloudPlatformAzureVM,
 		}
 
-		cGen := suggestor.Suggest(&conf)
+		cGen := suggester.Suggest(&conf)
 		if cGen == nil {
 			t.Errorf("cGen should not be nil.")
 		}
@@ -436,9 +436,9 @@ func TestCloudGeneratorSuggestor_CloudPlatformSpecified(t *testing.T) {
 	}
 }
 
-func TestCloudGeneratorSuggestor_Public(t *testing.T) {
+func TestCloudGeneratorSuggester_Public(t *testing.T) {
 	{
-		gen, ok := CloudGeneratorSuggestor.ec2Generator.(*EC2Generator)
+		gen, ok := CloudGeneratorSuggester.ec2Generator.(*EC2Generator)
 		if !ok {
 			t.Error("EC2Generator should be injected as ec2Generator")
 		}
@@ -447,7 +447,7 @@ func TestCloudGeneratorSuggestor_Public(t *testing.T) {
 		}
 	}
 	{
-		gen, ok := CloudGeneratorSuggestor.gceGenerator.(*GCEGenerator)
+		gen, ok := CloudGeneratorSuggester.gceGenerator.(*GCEGenerator)
 		if !ok {
 			t.Error("GCEGenerator should be injected as gceGenerator")
 		}
@@ -456,7 +456,7 @@ func TestCloudGeneratorSuggestor_Public(t *testing.T) {
 		}
 	}
 	{
-		gen, ok := CloudGeneratorSuggestor.azureVMGenerator.(*AzureVMGenerator)
+		gen, ok := CloudGeneratorSuggester.azureVMGenerator.(*AzureVMGenerator)
 		if !ok {
 			t.Error("AzureVMGenerator should be injected as azureVMGenerator")
 		}

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -435,3 +435,33 @@ func TestCloudGeneratorSuggestor_CloudPlatformSpecified(t *testing.T) {
 		}
 	}
 }
+
+func TestCloudGeneratorSuggestor_Public(t *testing.T) {
+	{
+		gen, ok := CloudGeneratorSuggestor.ec2Generator.(*EC2Generator)
+		if !ok {
+			t.Error("EC2Generator should be injected as ec2Generator")
+		}
+		if gen.baseURL.String() != ec2BaseURL.String() {
+			t.Error("real baseURL should be embedded to ec2Generator")
+		}
+	}
+	{
+		gen, ok := CloudGeneratorSuggestor.gceGenerator.(*GCEGenerator)
+		if !ok {
+			t.Error("GCEGenerator should be injected as gceGenerator")
+		}
+		if gen.metaURL.String() != gceMetaURL.String() {
+			t.Error("real metaURL should be embedded to gceGenerator")
+		}
+	}
+	{
+		gen, ok := CloudGeneratorSuggestor.azureVMGenerator.(*AzureVMGenerator)
+		if !ok {
+			t.Error("AzureVMGenerator should be injected as azureVMGenerator")
+		}
+		if gen.baseURL.String() != azureVMBaseURL.String() {
+			t.Error("real baseURL should be embedded to azureVMGenerator ")
+		}
+	}
+}


### PR DESCRIPTION
Currently spec/cloud_test.go directly overwrites cloud meta URLs. This may race, therefore sometimes CI reports build failure due to the race.

In this p-r, I'd like to introduce `spec/cloud#cloudGeneratorSuggester`, so that spec/cloud_test.go can inject mock CloudMetaGenerators (and their determination logic) to test the suggestion logic without race.  To achieve this, now Suggester does not call `isEC2()` (and their brothers) directly but calls them via injected CloudMetaGenerators.

I think we need to refine/add test cases in spec/cloud_test.go, but this p-r does not.  (Maybe in another p-r).