### PR TITLE
refactor: improve interface and testing for spec/cloud

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -29,9 +29,14 @@ type CloudGenerator struct {
 	CloudMetaGenerator
 }
 
+// Generate generates metadata
+func (c *CloudGenerator) Generate() (interface{}, error) {
+	return c.CloudMetaGenerator.Generate()
+}
+
 // CloudMetaGenerator interface of metadata generator for each cloud platform
 type CloudMetaGenerator interface {
-	Generate() (interface{}, error)
+	Generate() (*mackerel.Cloud, error)
 	SuggestCustomIdentifier() (string, error)
 }
 
@@ -151,7 +156,7 @@ func (g *EC2Generator) IsEC2(ctx context.Context) bool {
 }
 
 // Generate collects metadata from cloud platform.
-func (g *EC2Generator) Generate() (interface{}, error) {
+func (g *EC2Generator) Generate() (*mackerel.Cloud, error) {
 	cl := httpCli()
 
 	metadataKeys := []string{
@@ -256,7 +261,7 @@ func (g *GCEGenerator) IsGCE(ctx context.Context) bool {
 }
 
 // Generate collects metadata from cloud platform.
-func (g *GCEGenerator) Generate() (interface{}, error) {
+func (g *GCEGenerator) Generate() (*mackerel.Cloud, error) {
 	bytes, err := requestGCEMeta(context.Background())
 	if err != nil {
 		return nil, err
@@ -343,7 +348,7 @@ func (g *AzureVMGenerator) IsAzureVM(ctx context.Context) bool {
 }
 
 // Generate collects metadata from cloud platform.
-func (g *AzureVMGenerator) Generate() (interface{}, error) {
+func (g *AzureVMGenerator) Generate() (*mackerel.Cloud, error) {
 	metadataComputeKeys := map[string]string{
 		"location":  "location",
 		"offer":     "imageReferenceOffer",

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -114,7 +114,7 @@ func TestEC2Generate(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not raise error: %s", err)
 	}
-	g := &CloudGenerator{&EC2Generator{u}}
+	g := &EC2Generator{u}
 
 	value, err := g.Generate()
 	if err != nil {
@@ -165,7 +165,7 @@ func TestEC2SuggestCustomIdentifier(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not raise error: %s", err)
 	}
-	g := &CloudGenerator{&EC2Generator{u}}
+	g := &EC2Generator{u}
 
 	// 404, 404, 404 => give up
 	{

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -16,18 +16,21 @@ import (
 	"github.com/mackerelio/mackerel-agent/config"
 )
 
-type emptyCloudMetaGenerator struct{}
-
-func (g *emptyCloudMetaGenerator) Generate() (interface{}, error) {
-	return nil, nil
+type mockCloudMetaGenerator struct {
+	metadata         interface{}
+	customIdentifier string
 }
 
-func (g *emptyCloudMetaGenerator) SuggestCustomIdentifier() (string, error) {
-	return "", nil
+func (g *mockCloudMetaGenerator) Generate() (interface{}, error) {
+	return g.metadata, nil
+}
+
+func (g *mockCloudMetaGenerator) SuggestCustomIdentifier() (string, error) {
+	return g.customIdentifier, nil
 }
 
 type mockAzureCloudMetaGenerator struct {
-	emptyCloudMetaGenerator
+	mockCloudMetaGenerator
 	isAzureVM bool
 }
 
@@ -36,7 +39,7 @@ func (g *mockAzureCloudMetaGenerator) IsAzureVM(ctx context.Context) bool {
 }
 
 type mockEC2CloudMetaGenerator struct {
-	emptyCloudMetaGenerator
+	mockCloudMetaGenerator
 	isEC2 bool
 }
 
@@ -45,7 +48,7 @@ func (g *mockEC2CloudMetaGenerator) IsEC2(ctx context.Context) bool {
 }
 
 type mockGCECloudMetaGenerator struct {
-	emptyCloudMetaGenerator
+	mockCloudMetaGenerator
 	isGCE bool
 }
 
@@ -269,7 +272,7 @@ func TestGCEGenerate(t *testing.T) {
 }
 
 type slowCloudMetaGenerator struct {
-	emptyCloudMetaGenerator
+	mockCloudMetaGenerator
 }
 
 func (g *slowCloudMetaGenerator) IsEC2(ctx context.Context) bool {

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -57,6 +57,51 @@ func (g *mockGCECloudMetaGenerator) IsGCE(ctx context.Context) bool {
 }
 
 func TestCloudGenerate(t *testing.T) {
+	generator := &mockCloudMetaGenerator{
+		metadata: &mackerel.Cloud{
+			Provider: "mock",
+			MetaData: map[string]string{
+				"mockKey": "mockValue",
+			},
+		},
+		customIdentifier: "mock-generated-identifier.example.com",
+	}
+	g := &CloudGenerator{generator}
+
+	value, err := g.Generate()
+	if err != nil {
+		t.Errorf("should not raise error: %s", err)
+	}
+
+	cloud, typeOk := value.(*mackerel.Cloud)
+	if !typeOk {
+		t.Errorf("value should be *mackerel.Cloud. %+v", value)
+	}
+
+	if cloud.Provider != "mock" {
+		t.Errorf("Unexpected Provider: %s", cloud.Provider)
+	}
+
+	metadata, typeOk := cloud.MetaData.(map[string]string)
+	if !typeOk {
+		t.Errorf("MetaData should be map. %+v", cloud.MetaData)
+	}
+
+	if metadata["mockKey"] != "mockValue" {
+		t.Errorf("Unexpected metadata: %s", metadata["mockKey"])
+	}
+
+	customIdentifier, err := g.SuggestCustomIdentifier()
+	if err != nil {
+		t.Errorf("should not raise error: %s", err)
+	}
+
+	if customIdentifier != "mock-generated-identifier.example.com" {
+		t.Errorf("Unexpected customIdentifier: %s", customIdentifier)
+	}
+}
+
+func TestEC2Generate(t *testing.T) {
 	handler := func(res http.ResponseWriter, req *http.Request) {
 		fmt.Fprint(res, "i-4f90d537")
 	}

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -103,7 +103,8 @@ func TestCloudGenerate(t *testing.T) {
 
 func TestEC2Generator(t *testing.T) {
 	handler := func(res http.ResponseWriter, req *http.Request) {
-		// XXX: should be refined by removing path from ec2BaseURL
+		// The REAL path is /latest/meta-data/instance-id.
+		// This odd Path is due to current implementation.
 		if req.URL.Path == "/instance-id" {
 			fmt.Fprint(res, "i-4f90d537")
 		} else {

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -103,7 +103,12 @@ func TestCloudGenerate(t *testing.T) {
 
 func TestEC2Generate(t *testing.T) {
 	handler := func(res http.ResponseWriter, req *http.Request) {
-		fmt.Fprint(res, "i-4f90d537")
+		// XXX: should be refined by removing path from ec2BaseURL
+		if req.URL.Path == "/instance-id" {
+			fmt.Fprint(res, "i-4f90d537")
+		} else {
+			http.Error(res, "not found", 404)
+		}
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		handler(res, req)
@@ -131,8 +136,8 @@ func TestEC2Generate(t *testing.T) {
 		t.Errorf("MetaData should be map. %+v", cloud.MetaData)
 	}
 
-	if len(metadata["instance-id"]) == 0 {
-		t.Error("instance-id should be filled")
+	if metadata["instance-id"] != "i-4f90d537" {
+		t.Errorf("Unexpected metadata: %s", metadata["instance-id"])
 	}
 
 	customIdentifier, err := g.SuggestCustomIdentifier()
@@ -140,8 +145,8 @@ func TestEC2Generate(t *testing.T) {
 		t.Errorf("should not raise error: %s", err)
 	}
 
-	if len(customIdentifier) == 0 {
-		t.Error("customIdentifier should be retrieved")
+	if customIdentifier != "i-4f90d537.ec2.amazonaws.com" {
+		t.Errorf("Unexpected customIdentifier: %s", customIdentifier)
 	}
 }
 

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -101,7 +101,7 @@ func TestCloudGenerate(t *testing.T) {
 	}
 }
 
-func TestEC2Generate(t *testing.T) {
+func TestEC2Generator(t *testing.T) {
 	handler := func(res http.ResponseWriter, req *http.Request) {
 		// XXX: should be refined by removing path from ec2BaseURL
 		if req.URL.Path == "/instance-id" {
@@ -150,7 +150,7 @@ func TestEC2Generate(t *testing.T) {
 	}
 }
 
-func TestEC2SuggestCustomIdentifier(t *testing.T) {
+func TestEC2SuggestCustomIdentifier_ChangingHttpStatus(t *testing.T) {
 	i := 0
 	threshold := 100
 	handler := func(res http.ResponseWriter, req *http.Request) {

--- a/spec/cloud_test.go
+++ b/spec/cloud_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 type mockCloudMetaGenerator struct {
-	metadata         interface{}
+	metadata         *mackerel.Cloud
 	customIdentifier string
 }
 
-func (g *mockCloudMetaGenerator) Generate() (interface{}, error) {
+func (g *mockCloudMetaGenerator) Generate() (*mackerel.Cloud, error) {
 	return g.metadata, nil
 }
 
@@ -121,14 +121,9 @@ func TestEC2Generator(t *testing.T) {
 	}
 	g := &EC2Generator{u}
 
-	value, err := g.Generate()
+	cloud, err := g.Generate()
 	if err != nil {
 		t.Errorf("should not raise error: %s", err)
-	}
-
-	cloud, typeOk := value.(*mackerel.Cloud)
-	if !typeOk {
-		t.Errorf("value should be *mackerel.Cloud. %+v", value)
 	}
 
 	metadata, typeOk := cloud.MetaData.(map[string]string)


### PR DESCRIPTION
- Ensure `spec.CloudMetaGenerator#Generate()` generates `*mackerel.Cloud`
  - Currently (fortunately) it does
  - The return value will be wrapped in `spec.CloudGenerator#Generate()` as `interface{}`, in order to satisfy `spec.Generator#Generate`
- Test`spec.CloudGenerator#Generate()` and `spec.EC2Generator#Generate()` separetely
  - Now the former uses `mockCloudMetaGenerator`