### PR TITLE
add -private-autoshutdown option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -121,6 +121,7 @@ type Config struct {
 	MetricPlugins   map[string]*MetricPlugin
 	CheckPlugins    map[string]*CheckPlugin
 	MetadataPlugins map[string]*MetadataPlugin
+	Quit            bool
 }
 
 // PluginConfig represents a plugin configuration.

--- a/config/config.go
+++ b/config/config.go
@@ -121,7 +121,7 @@ type Config struct {
 	MetricPlugins   map[string]*MetricPlugin
 	CheckPlugins    map[string]*CheckPlugin
 	MetadataPlugins map[string]*MetadataPlugin
-	Quit            bool
+	AutoShutdown    bool
 }
 
 // PluginConfig represents a plugin configuration.

--- a/main.go
+++ b/main.go
@@ -241,13 +241,16 @@ func notifyUpdateFile(c chan<- os.Signal, file string, interval time.Duration) {
 		time.Sleep(interval)
 		stat, err := os.Stat(file)
 		if err != nil {
+			if os.IsNotExist(err) {
+				break
+			}
 			logger.Errorf("Can't stat %s: %v", file, err)
 			continue
 		}
 		if stat.ModTime().After(lastUpdated) {
-			logger.Infof("Detected %s was updated; quitting", file)
-			c <- os.Interrupt
-			return
+			break
 		}
 	}
+	logger.Infof("Detected %s was updated; quitting", file)
+	c <- os.Interrupt
 }

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func resolveConfig(fs *flag.FlagSet, argv []string) (*config.Config, error) {
 		root          = fs.String("root", config.DefaultConfig.Root, "Directory containing variable state information")
 		apikey        = fs.String("apikey", "", "(DEPRECATED) API key from mackerel.io web site")
 		diagnostic    = fs.Bool("diagnostic", false, "Enables diagnostic features")
+		quit          = fs.Bool("quit", false, "Quit if agent is updated")
 		child         = fs.Bool("child", false, "(internal use) child process of the supervise mode")
 		verbose       bool
 		roleFullnames roleFullnamesFlag
@@ -122,6 +123,8 @@ func resolveConfig(fs *flag.FlagSet, argv []string) (*config.Config, error) {
 			conf.Root = *root
 		case "diagnostic":
 			conf.Diagnostic = *diagnostic
+		case "quit":
+			conf.Quit = *quit
 		case "verbose", "v":
 			conf.Verbose = verbose
 		case "role":
@@ -187,6 +190,10 @@ func start(conf *config.Config, termCh chan struct{}) error {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	go signalHandler(c, app, termCh)
 
+	if conf.Quit {
+		go notifyUpdateFile(c, os.Args[0], 10*time.Second)
+	}
+
 	return command.Run(app, termCh)
 }
 
@@ -216,6 +223,31 @@ func signalHandler(c chan os.Signal, app *command.App, termCh chan struct{}) {
 				logger.Infof("Timed out. force shutdown.")
 				termCh <- struct{}{}
 			}()
+		}
+	}
+}
+
+func notifyUpdateFile(c chan<- os.Signal, file string, interval time.Duration) {
+	var lastUpdated time.Time
+
+	stat, err := os.Stat(file)
+	if err != nil {
+		logger.Errorf("Can't stat %s: %v; last modified time is set to now", file, err)
+		lastUpdated = time.Now()
+	} else {
+		lastUpdated = stat.ModTime()
+	}
+	for {
+		time.Sleep(interval)
+		stat, err := os.Stat(file)
+		if err != nil {
+			logger.Errorf("Can't stat %s: %v", file, err)
+			continue
+		}
+		if stat.ModTime().After(lastUpdated) {
+			logger.Infof("Detected %s was updated; quitting", file)
+			c <- os.Interrupt
+			return
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -196,6 +196,33 @@ func TestNotifyUpdateFile(t *testing.T) {
 	}
 }
 
+func TestNotifyUpdateFileDelete(t *testing.T) {
+	app := &command.App{}
+	termCh := make(chan struct{})
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
+	go signalHandler(c, app, termCh)
+
+	f, err := ioutil.TempFile("", "mackerel-agent.test.*")
+	if err != nil {
+		t.Fatalf("can't create a temporary file: %v", err)
+	}
+	file := f.Name()
+	f.Close()
+
+	interval := 100 * time.Millisecond
+	go notifyUpdateFile(c, file, interval)
+	time.Sleep(interval)
+	if err := os.Remove(file); err != nil {
+		t.Fatalf("can't remove %v: %v", file, err)
+	}
+	select {
+	case <-termCh:
+	case <-time.After(time.Second):
+		t.Errorf("Interrupt signal is not received in a second")
+	}
+}
+
 func TestConfigTestOK(t *testing.T) {
 	// prepare dummy config
 	confFile, err := ioutil.TempFile("", "mackerel-config-test")

--- a/testdata/fake-agent
+++ b/testdata/fake-agent
@@ -1,0 +1,1 @@
+This file's last modified time will be updated on TestNotifyUpdateFile


### PR DESCRIPTION
In macOS 10.15, all *exec(2)* syscall will fail after mackerel-agent is removed once. Thus this case, mackerel-agent is required to be restarted.

The `-private-autoshutdown` option watches my own executable file. If it is updated, then shutdown gracefully.

If mackerel-agent is running under supervise, then:

1. `-private-autoshutdown` option detects that mackerel-agent was updated.
2. mackerel-agent shutdown gracefully.
3. supervise detects child mackerel-agent process is stopped.
4. supervise try to respawn mackerel-agent
5. but, supervise cannot start it because it was removed once.
6. supervise will exit.
7. (maybe) launchd will restart fresh supervise and mackerel-agent.

Related p-r: mackerelio/go-osstat#16