### PR TITLE
Fix Windows Edition name

### DIFF
--- a/spec/windows/kernel.go
+++ b/spec/windows/kernel.go
@@ -3,6 +3,7 @@
 package windows
 
 import (
+	"strings"
 	"unsafe"
 
 	"github.com/mackerelio/golib/logging"
@@ -21,10 +22,17 @@ var kernelLogger = logging.GetLogger("spec.kernel")
 func (g *KernelGenerator) Generate() (interface{}, error) {
 	results := make(mackerel.Kernel)
 
-	name, _, err := windows.RegGetString(
+	osname, _, err := windows.RegGetString(
 		windows.HKEY_LOCAL_MACHINE,
 		`Software\Microsoft\Windows NT\CurrentVersion`,
 		`ProductName`)
+	if err != nil {
+		return nil, err
+	}
+	edition, _, err := windows.RegGetString(
+		windows.HKEY_LOCAL_MACHINE,
+		`Software\Microsoft\Windows NT\CurrentVersion`,
+		`EditionID`)
 	if err != nil {
 		return nil, err
 	}
@@ -43,8 +51,12 @@ func (g *KernelGenerator) Generate() (interface{}, error) {
 		return nil, err
 	}
 
+	if edition != "" && strings.Index(osname, edition) == -1 {
+		osname += " (" + edition + ")"
+	}
+
 	results["name"] = "Microsoft Windows"
-	results["os"] = name
+	results["os"] = osname
 	results["version"] = version
 	results["release"] = release
 

--- a/spec/windows/kernel.go
+++ b/spec/windows/kernel.go
@@ -12,6 +12,8 @@ import (
 	"github.com/mackerelio/mackerel-agent/util/windows"
 )
 
+const registryKey = `Software\Microsoft\Windows NT\CurrentVersion`
+
 // KernelGenerator XXX
 type KernelGenerator struct {
 }
@@ -23,30 +25,22 @@ func (g *KernelGenerator) Generate() (interface{}, error) {
 	results := make(mackerel.Kernel)
 
 	osname, _, err := windows.RegGetString(
-		windows.HKEY_LOCAL_MACHINE,
-		`Software\Microsoft\Windows NT\CurrentVersion`,
-		`ProductName`)
+		windows.HKEY_LOCAL_MACHINE, registryKey, `ProductName`)
 	if err != nil {
 		return nil, err
 	}
 	edition, _, err := windows.RegGetString(
-		windows.HKEY_LOCAL_MACHINE,
-		`Software\Microsoft\Windows NT\CurrentVersion`,
-		`EditionID`)
+		windows.HKEY_LOCAL_MACHINE, registryKey, `EditionID`)
 	if err != nil {
 		return nil, err
 	}
 	version, _, err := windows.RegGetString(
-		windows.HKEY_LOCAL_MACHINE,
-		`Software\Microsoft\Windows NT\CurrentVersion`,
-		`CurrentVersion`)
+		windows.HKEY_LOCAL_MACHINE, registryKey, `CurrentVersion`)
 	if err != nil {
 		return nil, err
 	}
 	release, errno, err := windows.RegGetString(
-		windows.HKEY_LOCAL_MACHINE,
-		`Software\Microsoft\Windows NT\CurrentVersion`,
-		`CSDVersion`)
+		windows.HKEY_LOCAL_MACHINE, registryKey, `CSDVersion`)
 	if err != nil && errno != windows.ERROR_FILE_NOT_FOUND { // CSDVersion is nullable
 		return nil, err
 	}


### PR DESCRIPTION
Windows Edition must be displayed. This change display edition name like below

```
Windows 10 Enterprise (Professional)
```
If edition name is "Enterprise", "(Enterprise)" is omitted.

Before

![image](https://user-images.githubusercontent.com/10111/70108435-a48a9700-168c-11ea-88dd-3186b9d8ea1f.png)

After (modified HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\EditionID)

![image](https://user-images.githubusercontent.com/10111/70108424-9e94b600-168c-11ea-9f47-6fd6e45fc14a.png)
