### PR TITLE
Release version 0.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.65.0 (2019-12-05)
+
+* add -private-autoshutdown option #612 (lufia)
+* Fix Windows Edition name #614 (mattn)
+* Bump github.com/shirou/gopsutil from 2.19.10+incompatible to 2.19.11+incompatible #611 (dependabot-preview[bot])
+* update go-osstat and golang.org/x #610 (lufia)
+* refactor: improve interface and testing for spec/cloud #609 (astj)
+* refactor: Inject CloudMetaGenerators to Suggester in order to test them in safer way #608 (astj)
+
+
 ## 0.64.1 (2019-11-21)
 
 * Install development tools in module-aware mode #606 (lufia)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION := 0.64.1
+VERSION := 0.65.0
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 ARGS := "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS := "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.65.0-1.systemd) stable; urgency=low
+
+  * add -private-autoshutdown option (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/612>
+  * Fix Windows Edition name (by mattn)
+    <https://github.com/mackerelio/mackerel-agent/pull/614>
+  * Bump github.com/shirou/gopsutil from 2.19.10+incompatible to 2.19.11+incompatible (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/611>
+  * update go-osstat and golang.org/x (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/610>
+  * refactor: improve interface and testing for spec/cloud (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/609>
+  * refactor: Inject CloudMetaGenerators to Suggester in order to test them in safer way (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/608>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 05 Dec 2019 05:44:09 +0000
+
 mackerel-agent (0.64.1-1.systemd) stable; urgency=low
 
   * Install development tools in module-aware mode (by lufia)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.65.0-1) stable; urgency=low
+
+  * add -private-autoshutdown option (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/612>
+  * Fix Windows Edition name (by mattn)
+    <https://github.com/mackerelio/mackerel-agent/pull/614>
+  * Bump github.com/shirou/gopsutil from 2.19.10+incompatible to 2.19.11+incompatible (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/611>
+  * update go-osstat and golang.org/x (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/610>
+  * refactor: improve interface and testing for spec/cloud (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/609>
+  * refactor: Inject CloudMetaGenerators to Suggester in order to test them in safer way (by astj)
+    <https://github.com/mackerelio/mackerel-agent/pull/608>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 05 Dec 2019 05:44:09 +0000
+
 mackerel-agent (0.64.1-1) stable; urgency=low
 
   * Install development tools in module-aware mode (by lufia)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,14 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Thu Dec 05 2019 <mackerel-developers@hatena.ne.jp> - 0.65.0
+- add -private-autoshutdown option (by lufia)
+- Fix Windows Edition name (by mattn)
+- Bump github.com/shirou/gopsutil from 2.19.10+incompatible to 2.19.11+incompatible (by dependabot-preview[bot])
+- update go-osstat and golang.org/x (by lufia)
+- refactor: improve interface and testing for spec/cloud (by astj)
+- refactor: Inject CloudMetaGenerators to Suggester in order to test them in safer way (by astj)
+
 * Thu Nov 21 2019 <mackerel-developers@hatena.ne.jp> - 0.64.1
 - Install development tools in module-aware mode (by lufia)
 - Bump github.com/shirou/gopsutil from 2.18.12+incompatible to 2.19.10+incompatible (by dependabot-preview[bot])

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,14 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Thu Dec 05 2019 <mackerel-developers@hatena.ne.jp> - 0.65.0
+- add -private-autoshutdown option (by lufia)
+- Fix Windows Edition name (by mattn)
+- Bump github.com/shirou/gopsutil from 2.19.10+incompatible to 2.19.11+incompatible (by dependabot-preview[bot])
+- update go-osstat and golang.org/x (by lufia)
+- refactor: improve interface and testing for spec/cloud (by astj)
+- refactor: Inject CloudMetaGenerators to Suggester in order to test them in safer way (by astj)
+
 * Thu Nov 21 2019 <mackerel-developers@hatena.ne.jp> - 0.64.1
 - Install development tools in module-aware mode (by lufia)
 - Bump github.com/shirou/gopsutil from 2.18.12+incompatible to 2.19.10+incompatible (by dependabot-preview[bot])

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.64.1"
+const version = "0.65.0"
 
 var gitcommit string


### PR DESCRIPTION
- add -private-autoshutdown option #612
- Fix Windows Edition name #614
- Bump github.com/shirou/gopsutil from 2.19.10+incompatible to 2.19.11+incompatible #611
- update go-osstat and golang.org/x #610
- refactor: improve interface and testing for spec/cloud #609
- refactor: Inject CloudMetaGenerators to Suggester in order to test them in safer way #608