### PR TITLE
fix how to get self executable path for autoshutdown option

### DIFF
--- a/main.go
+++ b/main.go
@@ -188,11 +188,14 @@ func start(conf *config.Config, termCh chan struct{}) error {
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
-	go signalHandler(c, app, termCh)
-
 	if conf.AutoShutdown {
-		go notifyUpdateFile(c, os.Args[0], 10*time.Second)
+		prog, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("can't get executable file: %v", err)
+		}
+		go notifyUpdateFile(c, prog, 10*time.Second)
 	}
+	go signalHandler(c, app, termCh)
 
 	return command.Run(app, termCh)
 }


### PR DESCRIPTION
In current implementation, The `-private-autoshutdown` task uses `os.Args[0]` to get self filename. But when mackerel-agent is in $PATH and is launched with only name, the `-private-autoshutdown` task may not find the file named 'mackerel-agent' in current working directory.

This bug may be caused because `os.Args[0]` is used directly, so I fixed this to replace `os.Args[0]` with `os.Executable`.

ref #612