### PR TITLE
Allow formatted duration in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -127,9 +127,9 @@ type Config struct {
 // PluginConfig represents a plugin configuration.
 type PluginConfig struct {
 	CommandConfig
-	NotificationInterval  *int32        `toml:"notification_interval"`
-	CheckInterval         *int32        `toml:"check_interval"`
-	ExecutionInterval     *int32        `toml:"execution_interval"`
+	NotificationInterval  *duration     `toml:"notification_interval"`
+	CheckInterval         *duration     `toml:"check_interval"`
+	ExecutionInterval     *duration     `toml:"execution_interval"`
 	MaxCheckAttempts      *int32        `toml:"max_check_attempts"`
 	CustomIdentifier      *string       `toml:"custom_identifier"`
 	PreventAlertAutoClose bool          `toml:"prevent_alert_auto_close"`
@@ -289,8 +289,8 @@ func (pconf *PluginConfig) buildCheckPlugin(name string) (*CheckPlugin, error) {
 	plugin := CheckPlugin{
 		Command:               *cmd,
 		CustomIdentifier:      pconf.CustomIdentifier,
-		NotificationInterval:  pconf.NotificationInterval,
-		CheckInterval:         pconf.CheckInterval,
+		NotificationInterval:  pconf.NotificationInterval.Minutes(),
+		CheckInterval:         pconf.CheckInterval.Minutes(),
 		MaxCheckAttempts:      pconf.MaxCheckAttempts,
 		PreventAlertAutoClose: pconf.PreventAlertAutoClose,
 		Action:                action,
@@ -321,7 +321,7 @@ func (pconf *PluginConfig) buildMetadataPlugin() (*MetadataPlugin, error) {
 
 	return &MetadataPlugin{
 		Command:           *cmd,
-		ExecutionInterval: pconf.ExecutionInterval,
+		ExecutionInterval: pconf.ExecutionInterval.Minutes(),
 	}, nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,12 +39,15 @@ env = { "MYSQL_USERNAME" = "USERNAME", "MYSQL_PASSWORD" = "PASSWORD" }
 command = "heartbeat.sh"
 user = "xyz"
 notification_interval = 60
+check_interval = 30
 max_check_attempts = 3
 timeout_seconds = 60
 action = { command = "cardiac_massage", user = "doctor" }
 
 [plugin.checks.heartbeat2]
 command = "heartbeat.sh"
+notification_interval = "1h30m"
+check_interval = "1h"
 env = { "ES_HOSTS" = "10.45.3.2:9220,10.45.3.1:9230" }
 action = { command = "cardiac_massage", user = "doctor", env = { "NAME_1" = "VALUE_1", "NAME_2" = "VALUE_2", "NAME_3" = "VALUE_3" } }
 
@@ -58,7 +61,7 @@ custom_identifier = "app2.example.com"
 [plugin.metadata.hostinfo]
 command = "hostinfo.sh"
 user = "zzz"
-execution_interval = 60
+execution_interval = "1h"
 timeout_seconds = 60
 
 [plugin.metadata.hostinfo2]
@@ -457,6 +460,9 @@ func TestLoadConfigFile(t *testing.T) {
 	if *checks.NotificationInterval != 60 {
 		t.Error("notification_interval should be 60")
 	}
+	if *checks.CheckInterval != 30 {
+		t.Error("check_interval should be 30")
+	}
 	if *checks.MaxCheckAttempts != 3 {
 		t.Error("max_check_attempts should be 3")
 	}
@@ -480,6 +486,12 @@ func TestLoadConfigFile(t *testing.T) {
 	if !expectContainsString(checks2.Command.Env, "ES_HOSTS=10.45.3.2:9220,10.45.3.1:9230") {
 		t.Errorf("Command.Env should contain 'ES_HOSTS=10.45.3.2:9220,10.45.3.1:9230'")
 	}
+	if *checks2.NotificationInterval != 90 {
+		t.Error("notification_interval should be 90")
+	}
+	if *checks2.CheckInterval != 60 {
+		t.Error("check_interval should be 60")
+	}
 	if checks2.Action.Env == nil {
 		t.Error("config should have action.env of check plugin")
 	}
@@ -499,6 +511,12 @@ func TestLoadConfigFile(t *testing.T) {
 	}
 	if checks3.CustomIdentifier != nil {
 		t.Error("config should not have customIdentifier")
+	}
+	if checks3.NotificationInterval != nil {
+		t.Error("config should not have notification_interval")
+	}
+	if checks3.CheckInterval != nil {
+		t.Error("config should not have check_interval")
 	}
 
 	checks4 := config.CheckPlugins["heartbeat4"]
@@ -533,6 +551,9 @@ func TestLoadConfigFile(t *testing.T) {
 	}
 	if !expectContainsString(metadataPlugin2.Command.Env, "NAME_1=VALUE_1") {
 		t.Errorf("Command.Env should contain 'NAME_1=VALUE_1'")
+	}
+	if metadataPlugin2.ExecutionInterval != nil {
+		t.Errorf("config should not have execution_interva but got %v", *metadataPlugin2.ExecutionInterval)
 	}
 
 	if config.Plugin != nil {

--- a/config/duration.go
+++ b/config/duration.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+)
+
+// duration represents a non-negative time duration.
+type duration int32 // in minutes
+
+func (m *duration) UnmarshalText(text []byte) error {
+	i, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
+		if i < 0 {
+			return fmt.Errorf("duration out of range: %d", i)
+		}
+		*m = duration(i)
+		return nil
+	}
+	if dur, err2 := time.ParseDuration(string(text)); err2 == nil {
+		minutes := dur.Minutes()
+		if minutes < 0 || float64(math.MaxInt32) < minutes {
+			return fmt.Errorf("duration out of range: %v", dur)
+		}
+		if dur != dur.Round(time.Minute) {
+			return fmt.Errorf("duration not multiple of 1m: %v", dur)
+		}
+		*m = duration(minutes)
+		return nil
+	}
+	return err
+}
+
+func (m *duration) Minutes() *int32 {
+	if m == nil {
+		return nil
+	}
+	i := int32(*m)
+	return &i
+}

--- a/config/duration_test.go
+++ b/config/duration_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestParseDuration(t *testing.T) {
+	testCases := []struct {
+		src      string
+		expected int32
+		err      string
+	}{
+		{
+			src:      "0",
+			expected: 0,
+		},
+		{
+			src:      "10",
+			expected: 10,
+		},
+		{
+			src: "-10",
+			err: "duration out of range: -10",
+		},
+		{
+			src:      "10m",
+			expected: 10,
+		},
+		{
+			src:      "1h10m",
+			expected: 70,
+		},
+		{
+			src:      "2.5h",
+			expected: 150,
+		},
+		{
+			src: "-10m",
+			err: "duration out of range: -10m0s",
+		},
+		{
+			src: "1s",
+			err: "duration not multiple of 1m: 1s",
+		},
+		{
+			src: "1ms",
+			err: "duration not multiple of 1m: 1ms",
+		},
+		{
+			src: "1.1m",
+			err: "duration not multiple of 1m: 1m6s",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.src, func(t *testing.T) {
+			var m struct{ Duration *duration }
+			if _, err := toml.Decode(fmt.Sprintf(`duration = %q`, tc.src), &m); err != nil {
+				if tc.err == "" {
+					t.Fatalf("duration %q, got error: %v", tc.src, err)
+				} else if err.Error() != tc.err {
+					t.Fatalf("duration %q, expected error: %v, got error: %v", tc.src, tc.err, err)
+				}
+			}
+			got := m.Duration.Minutes()
+			if *got != tc.expected {
+				t.Errorf("duration %q, expected: %v, got: %v", tc.src, tc.expected, *got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The unit of `notification_interval` is in minutes but it is hard to tell from the config (and we actually made mistake). How about allowing time.Duration here? For example,
```toml
[plugin.checks.sample]
command = "sample.sh"
notification_interval = "1h30m"
```
this is much readable :).

Here's a few notes.

- The formatted duration requires quotes. This is due to the TOML spec.
  - NG: `notification_interval: 1h`, OK: `notification_interval: "1h"`
- Units for day (`1d` or whatever) is not allowed. This is due to the Go language spec.