### PR TITLE
Release version 0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.66.0 (2020-01-22)
+
+* Bump github.com/pkg/errors from 0.8.1 to 0.9.1 #623 (dependabot-preview[bot])
+* Bump github.com/shirou/gopsutil from 2.19.11+incompatible to 2.19.12+incompatible #620 (dependabot-preview[bot])
+* Bump github.com/Songmu/prompter from 0.2.0 to 0.3.0 #617 (dependabot-preview[bot])
+* Implement GCEGenerator.SuggestCustomIdentifier #618 (tanatana)
+* fix how to get self executable path for autoshutdown option #616 (lufia)
+
+
 ## 0.65.0 (2019-12-05)
 
 * add -private-autoshutdown option #612 (lufia)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION := 0.65.0
+VERSION := 0.66.0
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 ARGS := "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS := "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent (0.66.0-1.systemd) stable; urgency=low
+
+  * Bump github.com/pkg/errors from 0.8.1 to 0.9.1 (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/623>
+  * Bump github.com/shirou/gopsutil from 2.19.11+incompatible to 2.19.12+incompatible (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/620>
+  * Bump github.com/Songmu/prompter from 0.2.0 to 0.3.0 (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/617>
+  * Implement GCEGenerator.SuggestCustomIdentifier (by tanatana)
+    <https://github.com/mackerelio/mackerel-agent/pull/618>
+  * fix how to get self executable path for autoshutdown option (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/616>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 22 Jan 2020 07:14:51 +0000
+
 mackerel-agent (0.65.0-1.systemd) stable; urgency=low
 
   * add -private-autoshutdown option (by lufia)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent (0.66.0-1) stable; urgency=low
+
+  * Bump github.com/pkg/errors from 0.8.1 to 0.9.1 (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/623>
+  * Bump github.com/shirou/gopsutil from 2.19.11+incompatible to 2.19.12+incompatible (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/620>
+  * Bump github.com/Songmu/prompter from 0.2.0 to 0.3.0 (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/617>
+  * Implement GCEGenerator.SuggestCustomIdentifier (by tanatana)
+    <https://github.com/mackerelio/mackerel-agent/pull/618>
+  * fix how to get self executable path for autoshutdown option (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/616>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 22 Jan 2020 07:14:51 +0000
+
 mackerel-agent (0.65.0-1) stable; urgency=low
 
   * add -private-autoshutdown option (by lufia)

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,13 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Wed Jan 22 2020 <mackerel-developers@hatena.ne.jp> - 0.66.0
+- Bump github.com/pkg/errors from 0.8.1 to 0.9.1 (by dependabot-preview[bot])
+- Bump github.com/shirou/gopsutil from 2.19.11+incompatible to 2.19.12+incompatible (by dependabot-preview[bot])
+- Bump github.com/Songmu/prompter from 0.2.0 to 0.3.0 (by dependabot-preview[bot])
+- Implement GCEGenerator.SuggestCustomIdentifier (by tanatana)
+- fix how to get self executable path for autoshutdown option (by lufia)
+
 * Thu Dec 05 2019 <mackerel-developers@hatena.ne.jp> - 0.65.0
 - add -private-autoshutdown option (by lufia)
 - Fix Windows Edition name (by mattn)

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,13 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Jan 22 2020 <mackerel-developers@hatena.ne.jp> - 0.66.0
+- Bump github.com/pkg/errors from 0.8.1 to 0.9.1 (by dependabot-preview[bot])
+- Bump github.com/shirou/gopsutil from 2.19.11+incompatible to 2.19.12+incompatible (by dependabot-preview[bot])
+- Bump github.com/Songmu/prompter from 0.2.0 to 0.3.0 (by dependabot-preview[bot])
+- Implement GCEGenerator.SuggestCustomIdentifier (by tanatana)
+- fix how to get self executable path for autoshutdown option (by lufia)
+
 * Thu Dec 05 2019 <mackerel-developers@hatena.ne.jp> - 0.65.0
 - add -private-autoshutdown option (by lufia)
 - Fix Windows Edition name (by mattn)

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.65.0"
+const version = "0.66.0"
 
 var gitcommit string


### PR DESCRIPTION
- Bump github.com/pkg/errors from 0.8.1 to 0.9.1 #623
- Bump github.com/shirou/gopsutil from 2.19.11+incompatible to 2.19.12+incompatible #620
- Bump github.com/Songmu/prompter from 0.2.0 to 0.3.0 #617
- Implement GCEGenerator.SuggestCustomIdentifier #618
- fix how to get self executable path for autoshutdown option #616