### PR TITLE
Support IMDSv2 for AWS EC2

### DIFF
--- a/spec/cloud.go
+++ b/spec/cloud.go
@@ -121,7 +121,7 @@ func (s *cloudGeneratorSuggester) Suggest(conf *config.Config) *CloudGenerator {
 var CloudGeneratorSuggester *cloudGeneratorSuggester
 
 func init() {
-	ec2BaseURL, _ = url.Parse("http://169.254.169.254/latest/")
+	ec2BaseURL, _ = url.Parse("http://169.254.169.254/latest")
 	gceMetaURL, _ = url.Parse("http://metadata.google.internal./computeMetadata/v1")
 	azureVMBaseURL, _ = url.Parse("http://169.254.169.254/metadata/instance")
 

--- a/spec/isec2.go
+++ b/spec/isec2.go
@@ -4,30 +4,21 @@ package spec
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/Songmu/retry"
 )
 
 // For instances other than Linux, retry only 1 times to shorten whole process
-func isEC2(ctx context.Context) bool {
-	isEC2 := false
+func (g *EC2Generator) isEC2(ctx context.Context) bool {
+	var res bool
 	err := retry.WithContext(ctx, 2, 2*time.Second, func() error {
-		cl := httpCli()
-		// '/ami-id` is probably an AWS specific URL
-		req, err := http.NewRequest("GET", ec2BaseURL.String()+"/ami-id", nil)
+		res0, err := g.hasMetadataService(ctx)
 		if err != nil {
 			return err
 		}
-		resp, err := cl.Do(req.WithContext(ctx))
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-
-		isEC2 = resp.StatusCode == 200
+		res = res0
 		return nil
 	})
-	return err == nil && isEC2
+	return err == nil && res
 }

--- a/spec/isec2_linux_test.go
+++ b/spec/isec2_linux_test.go
@@ -85,6 +85,8 @@ func TestIsEC2(t *testing.T) {
 				if !tc.existsAMIId {
 					res.WriteHeader(http.StatusNotFound)
 				}
+				res.WriteHeader(http.StatusOK)
+				res.Write([]byte("aws"))
 			}
 			ts := httptest.NewServer(http.HandlerFunc(handler))
 			defer ts.Close()

--- a/spec/isec2_linux_test.go
+++ b/spec/isec2_linux_test.go
@@ -10,14 +10,6 @@ import (
 	"testing"
 )
 
-func setEc2BaseURL(url *url.URL) func() {
-	oldEC2BaseURL := ec2BaseURL
-	ec2BaseURL = url
-	return func() {
-		ec2BaseURL = oldEC2BaseURL // restore value
-	}
-}
-
 func TestIsEC2UUID(t *testing.T) {
 	tests := []struct {
 		uuid   string
@@ -25,8 +17,8 @@ func TestIsEC2UUID(t *testing.T) {
 	}{
 		{"ec2e1916-9099-7caf-fd21-01234abcdef", true},
 		{"EC2E1916-9099-7CAF-FD21-01234ABCDEF", true},
-		{"45e12aec-dcd1-b213-94ed-01234abcdef", true}, // litte endian
-		{"45E12AEC-DCD1-B213-94ED-01234ABCDEF", true}, // litte endian
+		{"45e12aec-dcd1-b213-94ed-01234abcdef", true}, // little endian
+		{"45E12AEC-DCD1-B213-94ED-01234ABCDEF", true}, // little endian
 		{"abcd1916-9099-7caf-fd21-01234abcdef", false},
 		{"ABCD1916-9099-7CAF-FD21-01234ABCDEF", false},
 		{"", false},
@@ -95,10 +87,11 @@ func TestIsEC2(t *testing.T) {
 				}
 			}
 			ts := httptest.NewServer(http.HandlerFunc(handler))
-			defer func() { ts.Close() }()
-
+			defer ts.Close()
 			u, _ := url.Parse(ts.URL)
-			defer setEc2BaseURL(u)()
+			g := &EC2Generator{
+				baseURL: u,
+			}
 
 			uuidFiles := make([]string, 0, 2)
 			for _, exist := range tc.existsUUIDFiles {
@@ -121,7 +114,7 @@ func TestIsEC2(t *testing.T) {
 				tf.Close()
 			}
 
-			if isEC2WithSpecifiedUUIDFiles(context.Background(), uuidFiles) != tc.expect {
+			if g.isEC2WithSpecifiedUUIDFiles(context.Background(), uuidFiles) != tc.expect {
 				t.Errorf("isEC2() should be %v: %#v", tc.expect, tc)
 			}
 		}()

--- a/spec/isec2_windows.go
+++ b/spec/isec2_windows.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -38,7 +37,7 @@ func (g *EC2Generator) isEC2(ctx context.Context) bool {
 	if len(records) == 0 {
 		return false
 	}
-	return isEC2WithSpecifiedWmiRecords(ctx, records)
+	return g.isEC2WithSpecifiedWmiRecords(ctx, records)
 }
 
 func (g *EC2Generator) isEC2WithSpecifiedWmiRecords(ctx context.Context, records []Win32ComputerSystemProduct) bool {

--- a/spec/isec2_windows.go
+++ b/spec/isec2_windows.go
@@ -29,7 +29,7 @@ type Win32ComputerSystemProduct struct {
 
 // If the OS is Windows, check UUID in WMI class Win32_ComputerSystemProduct first. If UUID seems to be EC2-ish, call the metadata API (up to 3 times).
 // ref. https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/identify_ec2_instances.html
-func isEC2(ctx context.Context) bool {
+func (g *EC2Generator) isEC2(ctx context.Context) bool {
 	var records []Win32ComputerSystemProduct
 	err := wmi.Query("SELECT UUID FROM Win32_ComputerSystemProduct", &records)
 	if err != nil {
@@ -41,7 +41,7 @@ func isEC2(ctx context.Context) bool {
 	return isEC2WithSpecifiedWmiRecords(ctx, records)
 }
 
-func isEC2WithSpecifiedWmiRecords(ctx context.Context, records []Win32ComputerSystemProduct) bool {
+func (g *EC2Generator) isEC2WithSpecifiedWmiRecords(ctx context.Context, records []Win32ComputerSystemProduct) bool {
 	looksLikeEC2 := false
 	for _, r := range records {
 		if isEC2UUID(r.UUID) {
@@ -60,29 +60,16 @@ func isEC2WithSpecifiedWmiRecords(ctx context.Context, records []Win32ComputerSy
 	default:
 	}
 
-	res := false
-	cl := httpCli()
+	var res bool
 	err := retry.WithContext(ctx, 3, 2*time.Second, func() error {
-		// '/ami-id` is probably an AWS specific URL
-		req, err := http.NewRequest("GET", ec2BaseURL.String()+"/ami-id", nil)
-		if err != nil {
-			return nil // something wrong. give up
-		}
-		resp, err := cl.Do(req.WithContext(ctx))
+		res0, err := g.hasMetadataService(ctx)
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
-
-		res = resp.StatusCode == 200
+		res = res0
 		return nil
 	})
-
-	if err == nil {
-		return res
-	}
-
-	return false
+	return err == nil && res
 }
 
 func isEC2UUID(uuid string) bool {

--- a/spec/isec2_windows_test.go
+++ b/spec/isec2_windows_test.go
@@ -8,14 +8,6 @@ import (
 	"testing"
 )
 
-func setEc2BaseURL(url *url.URL) func() {
-	oldEC2BaseURL := ec2BaseURL
-	ec2BaseURL = url
-	return func() {
-		ec2BaseURL = oldEC2BaseURL // restore value
-	}
-}
-
 func TestIsEC2UUID(t *testing.T) {
 	tests := []struct {
 		uuid   string
@@ -23,8 +15,8 @@ func TestIsEC2UUID(t *testing.T) {
 	}{
 		{"ec2e1916-9099-7caf-fd21-01234abcdef", true},
 		{"EC2E1916-9099-7CAF-FD21-01234ABCDEF", true},
-		{"45e12aec-dcd1-b213-94ed-01234abcdef", true}, // litte endian
-		{"45E12AEC-DCD1-B213-94ED-01234ABCDEF", true}, // litte endian
+		{"45e12aec-dcd1-b213-94ed-01234abcdef", true}, // little endian
+		{"45E12AEC-DCD1-B213-94ED-01234ABCDEF", true}, // little endian
 		{"abcd1916-9099-7caf-fd21-01234abcdef", false},
 		{"ABCD1916-9099-7CAF-FD21-01234ABCDEF", false},
 		{"", false},
@@ -93,10 +85,11 @@ func TestIsEC2(t *testing.T) {
 				}
 			}
 			ts := httptest.NewServer(http.HandlerFunc(handler))
-			defer func() { ts.Close() }()
-
+			defer ts.Close()
 			u, _ := url.Parse(ts.URL)
-			defer setEc2BaseURL(u)()
+			g := &EC2Generator{
+				baseURL: u,
+			}
 
 			wmiRecords := make([]Win32ComputerSystemProduct, 2)
 			for i, exist := range tc.existsWmicRecords {
@@ -107,7 +100,7 @@ func TestIsEC2(t *testing.T) {
 				}
 			}
 
-			if isEC2WithSpecifiedWmiRecords(context.Background(), wmiRecords) != tc.expect {
+			if g.isEC2WithSpecifiedWmiRecords(context.Background(), wmiRecords) != tc.expect {
 				t.Errorf("isEC2() should be %v: %#v", tc.expect, tc)
 			}
 		}()

--- a/spec/isec2_windows_test.go
+++ b/spec/isec2_windows_test.go
@@ -83,6 +83,8 @@ func TestIsEC2(t *testing.T) {
 				if !tc.existsAMIId {
 					res.WriteHeader(http.StatusNotFound)
 				}
+				res.WriteHeader(http.StatusOK)
+				res.Write([]byte("aws"))
 			}
 			ts := httptest.NewServer(http.HandlerFunc(handler))
 			defer ts.Close()


### PR DESCRIPTION
new version of EC2 instance metadata service is released in last year.

https://aws.amazon.com/jp/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/