### PR TITLE
`%q` verb of fmt is invalid for map[string]float64 types

### DIFF
--- a/mackerel/check.go
+++ b/mackerel/check.go
@@ -36,7 +36,7 @@ func (api *API) ReportCheckMonitors(hostID string, reports []*checks.Report) err
 	return api.Client.PostCheckReports(payload)
 }
 
-// normalize returns rounded valid number for Mackerel's Cehck API.
+// normalize returns rounded valid number for Mackerel's Check API.
 //
 // In Mackerel, notification_interval regards nil as none,
 // but regards zero as default (10 minutes).

--- a/metrics/windows/cpuusage.go
+++ b/metrics/windows/cpuusage.go
@@ -73,7 +73,7 @@ func (g *CPUUsageGenerator) Generate() (metrics.Values, error) {
 		}
 	}
 
-	cpuUsageLogger.Debugf("cpuusage: %q", results)
+	cpuUsageLogger.Debugf("cpuusage: %#v", results)
 
 	return results, nil
 }

--- a/metrics/windows/cpuusage.go
+++ b/metrics/windows/cpuusage.go
@@ -25,28 +25,28 @@ func NewCPUUsageGenerator() (*CPUUsageGenerator, error) {
 	var err error
 	g.query, err = windows.CreateQuery()
 	if err != nil {
-		cpuUsageLogger.Criticalf(err.Error())
+		cpuUsageLogger.Critical(err.Error())
 		return nil, err
 	}
 	var counter *windows.CounterInfo
 
 	counter, err = windows.CreateCounter(g.query, "cpu.user.percentage", `\Processor(_Total)\% User Time`)
 	if err != nil {
-		cpuUsageLogger.Criticalf(err.Error())
+		cpuUsageLogger.Critical(err.Error())
 		return nil, err
 	}
 	g.counters = append(g.counters, counter)
 
 	counter, err = windows.CreateCounter(g.query, "cpu.system.percentage", `\Processor(_Total)\% Privileged Time`)
 	if err != nil {
-		cpuUsageLogger.Criticalf(err.Error())
+		cpuUsageLogger.Critical(err.Error())
 		return nil, err
 	}
 	g.counters = append(g.counters, counter)
 
 	counter, err = windows.CreateCounter(g.query, "cpu.idle.percentage", `\Processor(_Total)\% Idle Time`)
 	if err != nil {
-		cpuUsageLogger.Criticalf(err.Error())
+		cpuUsageLogger.Critical(err.Error())
 		return nil, err
 	}
 	g.counters = append(g.counters, counter)

--- a/metrics/windows/cpuusage.go
+++ b/metrics/windows/cpuusage.go
@@ -25,28 +25,28 @@ func NewCPUUsageGenerator() (*CPUUsageGenerator, error) {
 	var err error
 	g.query, err = windows.CreateQuery()
 	if err != nil {
-		cpuUsageLogger.Critical(err.Error())
+		cpuUsageLogger.Criticalf("%s", err.Error())
 		return nil, err
 	}
 	var counter *windows.CounterInfo
 
 	counter, err = windows.CreateCounter(g.query, "cpu.user.percentage", `\Processor(_Total)\% User Time`)
 	if err != nil {
-		cpuUsageLogger.Critical(err.Error())
+		cpuUsageLogger.Criticalf("%s", err.Error())
 		return nil, err
 	}
 	g.counters = append(g.counters, counter)
 
 	counter, err = windows.CreateCounter(g.query, "cpu.system.percentage", `\Processor(_Total)\% Privileged Time`)
 	if err != nil {
-		cpuUsageLogger.Critical(err.Error())
+		cpuUsageLogger.Criticalf("%s", err.Error())
 		return nil, err
 	}
 	g.counters = append(g.counters, counter)
 
 	counter, err = windows.CreateCounter(g.query, "cpu.idle.percentage", `\Processor(_Total)\% Idle Time`)
 	if err != nil {
-		cpuUsageLogger.Critical(err.Error())
+		cpuUsageLogger.Criticalf("%s", err.Error())
 		return nil, err
 	}
 	g.counters = append(g.counters, counter)

--- a/metrics/windows/disk.go
+++ b/metrics/windows/disk.go
@@ -50,7 +50,7 @@ func (g *DiskGenerator) Generate() (metrics.Values, error) {
 		results[fmt.Sprintf(`disk.%s.reads.delta`, name)] = float64(record.DiskReadsPerSec)
 		results[fmt.Sprintf(`disk.%s.writes.delta`, name)] = float64(record.DiskWritesPerSec)
 	}
-	diskLogger.Debugf("%q", results)
+	diskLogger.Debugf("disk %#v", results)
 	return results, nil
 }
 

--- a/metrics/windows/filesystem.go
+++ b/metrics/windows/filesystem.go
@@ -42,6 +42,6 @@ func (g *FilesystemGenerator) Generate() (metrics.Values, error) {
 			ret["filesystem."+device+".used"] = values.KbUsed * 1024
 		}
 	}
-	logger.Debugf("%q", ret)
+	logger.Debugf("filesystem %#v", ret)
 	return ret, nil
 }

--- a/metrics/windows/interface.go
+++ b/metrics/windows/interface.go
@@ -158,7 +158,7 @@ func (g *InterfaceGenerator) Generate() (metrics.Values, error) {
 		}
 	}
 
-	interfaceLogger.Debugf("%q", results)
+	interfaceLogger.Debugf("interface: %#v", results)
 
 	return results, nil
 }

--- a/metrics/windows/interface.go
+++ b/metrics/windows/interface.go
@@ -40,19 +40,19 @@ func NewInterfaceGenerator(interval time.Duration) (*InterfaceGenerator, error) 
 	var err error
 	g.query, err = windows.CreateQuery()
 	if err != nil {
-		interfaceLogger.Criticalf(err.Error())
+		interfaceLogger.Critical(err.Error())
 		return nil, err
 	}
 
 	ifs, err := net.Interfaces()
 	if err != nil {
-		interfaceLogger.Criticalf(err.Error())
+		interfaceLogger.Critical(err.Error())
 		return nil, err
 	}
 
 	ai, err := windows.GetAdapterList()
 	if err != nil {
-		interfaceLogger.Criticalf(err.Error())
+		interfaceLogger.Critical(err.Error())
 		return nil, err
 	}
 

--- a/metrics/windows/interface.go
+++ b/metrics/windows/interface.go
@@ -40,19 +40,19 @@ func NewInterfaceGenerator(interval time.Duration) (*InterfaceGenerator, error) 
 	var err error
 	g.query, err = windows.CreateQuery()
 	if err != nil {
-		interfaceLogger.Critical(err.Error())
+		interfaceLogger.Criticalf("%s", err.Error())
 		return nil, err
 	}
 
 	ifs, err := net.Interfaces()
 	if err != nil {
-		interfaceLogger.Critical(err.Error())
+		interfaceLogger.Criticalf("%s", err.Error())
 		return nil, err
 	}
 
 	ai, err := windows.GetAdapterList()
 	if err != nil {
-		interfaceLogger.Critical(err.Error())
+		interfaceLogger.Criticalf("%s", err.Error())
 		return nil, err
 	}
 

--- a/metrics/windows/memory.go
+++ b/metrics/windows/memory.go
@@ -40,6 +40,6 @@ func (g *MemoryGenerator) Generate() (metrics.Values, error) {
 	ret["memory.pagefile_total"] = float64(memoryStatusEx.TotalPageFile)
 	ret["memory.pagefile_free"] = float64(memoryStatusEx.AvailPageFile)
 
-	memoryLogger.Debugf("memory : %s", ret)
+	memoryLogger.Debugf("memory : %#v", ret)
 	return metrics.Values(ret), nil
 }

--- a/metrics/windows/processor_queue_length.go
+++ b/metrics/windows/processor_queue_length.go
@@ -58,7 +58,7 @@ func (g *ProcessorQueueLengthGenerator) Generate() (metrics.Values, error) {
 		}
 	}
 
-	processorQueueLengthLogger.Debugf("processor_queue_length: %q", results)
+	processorQueueLengthLogger.Debugf("processor_queue_length: %#v", results)
 
 	return results, nil
 }


### PR DESCRIPTION
I added `verbose = true` into `mackerel-agent.conf`, and ran it on windows.
I got strange debug messages `%!q`.

Before:

```
2020/01/25 01:13:00 processor_queue_length.go:61: DEBUG <metrics.processor_queue_length> processor_queue_length: map["processor_queue_length":%!q(float64=0)]
2020/01/25 01:13:00 cpuusage.go:76: DEBUG <cpu.user.percentage> cpuusage: map["cpu.idle.percentage":%!q(float64=94.90321463376188) "cpu.system.percentage":%!q(float64=0.2994878553084956) "cpu.user.percentage":%!q(float64=2.3828816313675953)]
2020/01/25 01:13:00 memory.go:43: DEBUG <metrics.memory> memory : map[memory.free:5.395554304e+09 memory.pagefile_free:6.951104512e+09 memory.pagefile_total:9.931702272e+09 memory.total:8.589524992e+09 memory.used:3.193970688e+09]
2020/01/25 01:13:00 filesystem.go:45: DEBUG <metrics.filesystem> map["filesystem.C.size":%!q(float64=1.07372081152e+11) "filesystem.C.used":%!q(float64=2.6775281664e+10)]
2020/01/25 01:13:00 interface.go:161: DEBUG <metrics.interface> map["interface.AWS_PV_Network_Device__0.rxBytes.delta":%!q(float64=1271.6533062985964) "interface.AWS_PV_Network_Device__0.txBytes.delta":%!q(float64=1059.2694207671607)]
2020/01/25 01:13:00 disk.go:53: DEBUG <metrics.disk> map["disk.C.reads.delta":%!q(float64=0) "disk.C.writes.delta":%!q(float64=0)]
```

After:

```
2020/01/25 01:20:00 processor_queue_length.go:61: DEBUG <metrics.processor_queue_length> processor_queue_length: map[string]float64{"processor_queue_length":0}
2020/01/25 01:20:00 cpuusage.go:76: DEBUG <cpu.user.percentage> cpuusage: map[string]float64{"cpu.idle.percentage":95.23952779227113, "cpu.system.percentage":0.3906852280347538, "cpu.user.percentage":0.8725303426109502}
2020/01/25 01:20:00 memory.go:43: DEBUG <metrics.memory> memory : map[string]float64{"memory.free":5.327568896e+09, "memory.pagefile_free":6.883442688e+09, "memory.pagefile_total":9.931702272e+09, "memory.total":8.589524992e+09, "memory.used":3.261956096e+09}
2020/01/25 01:20:00 filesystem.go:45: DEBUG <metrics.filesystem> filesystem metrics.Values{"filesystem.C.size":1.07372081152e+11, "filesystem.C.used":2.6775973888e+10}
2020/01/25 01:20:00 interface.go:161: DEBUG <metrics.interface> interface: map[string]float64{"interface.AWS_PV_Network_Device__0.rxBytes.delta":187.43822700496182, "interface.AWS_PV_Network_Device__0.txBytes.delta":656.4254365849947}
2020/01/25 01:20:01 disk.go:53: DEBUG <metrics.disk> disk map[string]float64{"disk.C.reads.delta":0, "disk.C.writes.delta":0}
```