### PR TITLE
Release version 0.67.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.67.0 (2020-02-05)
+
+* Bump github.com/shirou/gopsutil from 2.19.12+incompatible to 2.20.1+incompatible #631 (dependabot-preview[bot])
+* Bump github.com/mackerelio/mackerel-client-go from 0.8.0 to 0.9.0 #629 (dependabot-preview[bot])
+* Allow formatted duration in config #624 (itchyny)
+* rename: github.com/motemen/gobump -> github.com/x-motemen/gobump #630 (lufia)
+* Support IMDSv2 for AWS EC2 #627 (shogo82148)
+* `%q` verb of fmt is invalid for map[string]float64 types #628 (shogo82148)
+
+
 ## 0.66.0 (2020-01-22)
 
 * Bump github.com/pkg/errors from 0.8.1 to 0.9.1 #623 (dependabot-preview[bot])

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION := 0.66.0
+VERSION := 0.67.0
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 ARGS := "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS := "linux darwin freebsd windows netbsd"

--- a/packaging/deb-systemd/debian/changelog
+++ b/packaging/deb-systemd/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.67.0-1.systemd) stable; urgency=low
+
+  * Bump github.com/shirou/gopsutil from 2.19.12+incompatible to 2.20.1+incompatible (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/631>
+  * Bump github.com/mackerelio/mackerel-client-go from 0.8.0 to 0.9.0 (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/629>
+  * Allow formatted duration in config (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/624>
+  * rename: github.com/motemen/gobump -> github.com/x-motemen/gobump (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/630>
+  * Support IMDSv2 for AWS EC2 (by shogo82148)
+    <https://github.com/mackerelio/mackerel-agent/pull/627>
+  * `%q` verb of fmt is invalid for map[string]float64 types (by shogo82148)
+    <https://github.com/mackerelio/mackerel-agent/pull/628>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 05 Feb 2020 07:57:06 +0000
+
 mackerel-agent (0.66.0-1.systemd) stable; urgency=low
 
   * Bump github.com/pkg/errors from 0.8.1 to 0.9.1 (by dependabot-preview[bot])

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-agent (0.67.0-1) stable; urgency=low
+
+  * Bump github.com/shirou/gopsutil from 2.19.12+incompatible to 2.20.1+incompatible (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/631>
+  * Bump github.com/mackerelio/mackerel-client-go from 0.8.0 to 0.9.0 (by dependabot-preview[bot])
+    <https://github.com/mackerelio/mackerel-agent/pull/629>
+  * Allow formatted duration in config (by itchyny)
+    <https://github.com/mackerelio/mackerel-agent/pull/624>
+  * rename: github.com/motemen/gobump -> github.com/x-motemen/gobump (by lufia)
+    <https://github.com/mackerelio/mackerel-agent/pull/630>
+  * Support IMDSv2 for AWS EC2 (by shogo82148)
+    <https://github.com/mackerelio/mackerel-agent/pull/627>
+  * `%q` verb of fmt is invalid for map[string]float64 types (by shogo82148)
+    <https://github.com/mackerelio/mackerel-agent/pull/628>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 05 Feb 2020 07:57:06 +0000
+
 mackerel-agent (0.66.0-1) stable; urgency=low
 
   * Bump github.com/pkg/errors from 0.8.1 to 0.9.1 (by dependabot-preview[bot])

--- a/packaging/rpm/mackerel-agent-systemd.spec
+++ b/packaging/rpm/mackerel-agent-systemd.spec
@@ -55,6 +55,14 @@ systemctl enable %{name}.service
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 
 %changelog
+* Wed Feb 05 2020 <mackerel-developers@hatena.ne.jp> - 0.67.0
+- Bump github.com/shirou/gopsutil from 2.19.12+incompatible to 2.20.1+incompatible (by dependabot-preview[bot])
+- Bump github.com/mackerelio/mackerel-client-go from 0.8.0 to 0.9.0 (by dependabot-preview[bot])
+- Allow formatted duration in config (by itchyny)
+- rename: github.com/motemen/gobump -> github.com/x-motemen/gobump (by lufia)
+- Support IMDSv2 for AWS EC2 (by shogo82148)
+- `%q` verb of fmt is invalid for map[string]float64 types (by shogo82148)
+
 * Wed Jan 22 2020 <mackerel-developers@hatena.ne.jp> - 0.66.0
 - Bump github.com/pkg/errors from 0.8.1 to 0.9.1 (by dependabot-preview[bot])
 - Bump github.com/shirou/gopsutil from 2.19.11+incompatible to 2.19.12+incompatible (by dependabot-preview[bot])

--- a/packaging/rpm/mackerel-agent.spec
+++ b/packaging/rpm/mackerel-agent.spec
@@ -62,6 +62,14 @@ fi
 /usr/local/bin/%{name}
 
 %changelog
+* Wed Feb 05 2020 <mackerel-developers@hatena.ne.jp> - 0.67.0
+- Bump github.com/shirou/gopsutil from 2.19.12+incompatible to 2.20.1+incompatible (by dependabot-preview[bot])
+- Bump github.com/mackerelio/mackerel-client-go from 0.8.0 to 0.9.0 (by dependabot-preview[bot])
+- Allow formatted duration in config (by itchyny)
+- rename: github.com/motemen/gobump -> github.com/x-motemen/gobump (by lufia)
+- Support IMDSv2 for AWS EC2 (by shogo82148)
+- `%q` verb of fmt is invalid for map[string]float64 types (by shogo82148)
+
 * Wed Jan 22 2020 <mackerel-developers@hatena.ne.jp> - 0.66.0
 - Bump github.com/pkg/errors from 0.8.1 to 0.9.1 (by dependabot-preview[bot])
 - Bump github.com/shirou/gopsutil from 2.19.11+incompatible to 2.19.12+incompatible (by dependabot-preview[bot])

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.66.0"
+const version = "0.67.0"
 
 var gitcommit string


### PR DESCRIPTION
- Bump github.com/shirou/gopsutil from 2.19.12+incompatible to 2.20.1+incompatible #631
- Bump github.com/mackerelio/mackerel-client-go from 0.8.0 to 0.9.0 #629
- Allow formatted duration in config #624
- rename: github.com/motemen/gobump -> github.com/x-motemen/gobump #630
- Support IMDSv2 for AWS EC2 #627
- `%q` verb of fmt is invalid for map[string]float64 types #628