### PR TITLE
[Windows]support x64 installation v2

### DIFF
--- a/wix/build.bat
+++ b/wix/build.bat
@@ -17,7 +17,7 @@ FOR /F %%w in (.\wix\pluginlist.txt) DO (
 CD %~dp0
 
 go build -o ..\build\wrapper.exe wrapper\wrapper_windows.go wrapper\install.go
-go build -o ..\build\replace.exe replace\replace_windows.go
+go build -o ..\build\replace.exe replace\replace_windows.go replace\shell_windows.go
 go build -o ..\build\generate_wxs.exe generate_wxs\generate_wxs.go
 
 REM retrieve numeric version from git tag

--- a/wix/replace/replace_windows.go
+++ b/wix/replace/replace_windows.go
@@ -1,9 +1,30 @@
 package main
 
+/*
+ * 1. Fresh installation
+ * => replace.exe <sample.conf> <conf> ___YOUR_API_KEY___ <apikey>
+ *	Substitute ___YOUR_API_KEY___ by <apikey> in <sample.conf> then it write to <conf>.
+ *
+ * 2. Upgrade to x64 from x86
+ * => replace.exe <sample.conf> <conf> ___YOUR_API_KEY___ '' (empty string)
+ *	Just copy <conf> from under ProgramFiles(x86)\Mackerel folder to <conf> if it exists.
+ *	Otherwise completely same as the case of fresh installation.
+ *
+ * 3. Upgrade from same architecture
+ * => replace.exe <sample.conf> <conf> ___YOUR_API_KEY___ '' (empty string)
+ *	Do nothing.
+ *
+ * Currently it is impossible to distinguish between the case 2 and 3 from the arguments.
+ * Therefore replace.exe looks <conf> on the location of mackerel-agent.exe,
+ * if exists, it will judge the state is in the case of 3.
+ */
+
 import (
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -16,6 +37,34 @@ func main() {
 	oldStr := os.Args[3]
 	newStr := os.Args[4]
 
+	if newStr == "" { // upgrade
+		if !filepath.IsAbs(outFile) {
+			// This program is usually called by the installer; safe.
+			log.Fatalf("%q: it must be an absolute path", outFile)
+		}
+		dir := filepath.Dir(outFile)
+		name := filepath.Base(outFile)
+		if oldDir := FallbackConfigDir(dir); oldDir != "" {
+			oldFile := filepath.Join(oldDir, name)
+			if err := migrateConfig(outFile, oldFile); err != nil {
+				if !os.IsNotExist(err) {
+					log.Fatalf("migrate %q to %q: %v", oldFile, outFile, err)
+				}
+				// Don't fallback; continue to the case 1.
+				goto out
+			}
+			idFile := filepath.Join(dir, "id")
+			oldIDFile := filepath.Join(oldDir, "id")
+			if err := migrateConfig(idFile, oldIDFile); err != nil {
+				if !os.IsNotExist(err) {
+					log.Fatalf("migrate %q to %q: %v", oldIDFile, idFile, err)
+				}
+			}
+			os.Exit(0)
+		}
+	}
+
+out:
 	content, err := ioutil.ReadFile(inFile)
 	if err != nil {
 		log.Fatal(err)
@@ -29,4 +78,34 @@ func main() {
 			log.Fatal(err)
 		}
 	}
+}
+
+// migrateConfig copies inFile to outFile if needed.
+// If inFile is not exist, this will return os.ErrNotExist or its variants.
+func migrateConfig(outFile, inFile string) error {
+	w, err := os.OpenFile(outFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+		return err
+	}
+	r, err := os.Open(inFile)
+	if os.IsNotExist(err) {
+		return err
+	}
+	_, err = io.Copy(w, r)
+	return err
+}
+
+func isExist(file string) (bool, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	f.Close()
+	return true, nil
 }

--- a/wix/replace/replace_windows.go
+++ b/wix/replace/replace_windows.go
@@ -46,7 +46,7 @@ func main() {
 		name := filepath.Base(outFile)
 		if oldDir := FallbackConfigDir(dir); oldDir != "" {
 			oldFile := filepath.Join(oldDir, name)
-			if err := migrateConfig(outFile, oldFile); err != nil {
+			if err := migrateFile(outFile, oldFile); err != nil {
 				if !os.IsNotExist(err) {
 					log.Fatalf("migrate %q to %q: %v", oldFile, outFile, err)
 				}
@@ -55,7 +55,7 @@ func main() {
 			}
 			idFile := filepath.Join(dir, "id")
 			oldIDFile := filepath.Join(oldDir, "id")
-			if err := migrateConfig(idFile, oldIDFile); err != nil {
+			if err := migrateFile(idFile, oldIDFile); err != nil {
 				if !os.IsNotExist(err) {
 					log.Fatalf("migrate %q to %q: %v", oldIDFile, idFile, err)
 				}
@@ -80,9 +80,9 @@ out:
 	}
 }
 
-// migrateConfig copies inFile to outFile if needed.
+// migrateFile copies inFile to outFile if needed.
 // If inFile is not exist, this will return os.ErrNotExist or its variants.
-func migrateConfig(outFile, inFile string) error {
+func migrateFile(outFile, inFile string) error {
 	w, err := os.OpenFile(outFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
 		if os.IsExist(err) {

--- a/wix/replace/shell_windows.go
+++ b/wix/replace/shell_windows.go
@@ -11,6 +11,9 @@ const (
 	// https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
 	maxPathLen = 260
 
+	// This value is defined in shlobj.h, but it's published only name.
+	// But its value is used, such as JNI, so probably it isn't changed.
+	// https://docs.microsoft.com/en-us/windows/win32/shell/csidl
 	csidlProgramFilesX86 = 0x2a
 )
 

--- a/wix/replace/shell_windows.go
+++ b/wix/replace/shell_windows.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	// (snip) the maximum length for a path is MAX_PATH, which is defined as 260 characters.
+	// https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
+	maxPathLen = 260
+
+	csidlProgramFilesX86 = 0x2a
+)
+
+var (
+	shell32                     = syscall.NewLazyDLL("shell32")
+	procSHGetSpecialFolderPathW = shell32.NewProc("SHGetSpecialFolderPathW")
+)
+
+// FallbackConfigDir returns an other ProgramFiles location if there.
+// wdir is current installed folder of the mackerel-agent.exe.
+func FallbackConfigDir(wdir string) string {
+	// The host that has installed mackerel-agent x86 edition is having id, pid and mackerel-agent.conf files
+	// in C:\Program Files (x86)\Mackerel.
+	// Though mackerel-agent refers to a directory containing mackerel-agent.exe,
+	// it should still refer these old files in x86 folder even if mackerel-agent is upgraded to x64 edition.
+
+	dir := getProgramFilesX86()
+	if dir == "" {
+		return ""
+	}
+	dir = filepath.Join(dir, "Mackerel", "mackerel-agent")
+	if dir == wdir {
+		return ""
+	}
+	return dir
+}
+
+func getProgramFilesX86() string {
+	var buf [maxPathLen]uint16
+	p := unsafe.Pointer(&buf[0])
+	rv, _, _ := procSHGetSpecialFolderPathW.Call(0, uintptr(p), csidlProgramFilesX86, 0)
+	if rv == 0 {
+		return ""
+	}
+	return syscall.UTF16ToString(buf[:])
+}

--- a/wix/replace/shell_windows_test.go
+++ b/wix/replace/shell_windows_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMakeFallbackEnv_386(t *testing.T) {
+	if runtime.GOARCH != "386" {
+		t.Skip()
+	}
+	wdir := filepath.Join(os.Getenv("PROGRAMFILES"), "Mackerel", "mackerel-agent")
+	dir := FallbackConfigDir(wdir)
+	if dir != "" {
+		t.Errorf("FallbackConfigDir(%q) = %q; want %q", wdir, dir, "")
+	}
+}
+
+func TestMakeFallbackEnv_amd64(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip()
+	}
+	wdir := filepath.Join(os.Getenv("PROGRAMFILES"), "Mackerel", "mackerel-agent")
+	dir := FallbackConfigDir(wdir)
+	want := filepath.Join(os.Getenv("PROGRAMFILES(X86)"), "Mackerel", "mackerel-agent")
+	if dir != want {
+		t.Errorf("makeFallbackEnv(%q) = %q; want %q", wdir, dir, want)
+	}
+}


### PR DESCRIPTION
previous version #613 

### motivation
The host that has installed mackerel-agent x86 edition is having id, pid and mackerel-agent.conf files in `C:\Program Files (x86)\Mackerel`. Though mackerel-agent refers to a directory containing mackerel-agent.exe, it should still keep these old configurations even if mackerel-agent is upgraded to x64 edition.

### Protocol
#### Fresh installation
**replace.exe** is called by installer:
```
replace.exe <sample.conf> <conf> ___YOUR_API_KEY___ <apikey>
```
Substitute *___YOUR_API_KEY___* by `<apikey>` in `<sample.conf>` then it write to `<conf>`. 

#### Upgrade to x64 from x86
**replace.exe** is called by installer:
```
replace.exe <sample.conf> <conf> ___YOUR_API_KEY___ ''
```
Just copy `<conf>` from under **ProgramFiles(x86)\Mackerel** folder to `<conf>` if it exists. Otherwise completely same as the case of fresh installation.

#### Upgrade from same architecture
**replace.exe** is called by installer:
```
replace.exe <sample.conf> <conf> ___YOUR_API_KEY___ ''
```
Do nothing.

### difference to #613 
613 changes mackerel-agent's behavior to refer old configurations if *MACKEREL_CONFIG_FALLBACK* environment variable is set. It is impossible because installer always copies mackerel-agent.sample.conf to the installing folder.

This p-r's approach copies the "mackerel-agent.conf" and "id" files from under ProgramFiles(x86) folder if needed.