### PR TITLE
Improve FreeBSD rc script

### DIFF
--- a/packaging/freebsd/README.md
+++ b/packaging/freebsd/README.md
@@ -1,22 +1,67 @@
 mackerel-agent for FreeBSD
 ==========================
 
-1. Get binary for FreeBSD at release page. https://github.com/mackerelio/mackerel-agent/releases
-    - `amd64`: `mackerel-agent_freebsd_amd64.tar.gz`
-    - `i386` : `mackerel-agent_freebsd_386.tar.gz`
-    - (`arm` : `mackerel-agent_freebsd_arm.tar.gz`)
-2. Extract file, and `cd`.
-    - `tar -xzvf mackerel-agent_freebsd_*.tar.gz`
-3. Copy `mackerel-agent` to `/usr/local/bin/`.
-    - `(sudo) cp mackerel-agent /usr/local/bin/`
-4. Edit `mackerel-agent.conf`, then copy it to `/usr/local/etc/`.
-    - `${EDITOR} mackerel-agent.conf`
-    - `(sudo) cp mackerel-agent.conf /usr/local/etc/`
-5. Copy `mackerel_agent` (this directory file; rc script) to `/usr/local/etc/rc.d/`.
-    - `(sudo) cp mackerel_agent /usr/local/etc/rc.d/`
-6. Add `mackerel_agent_enable="YES"` at `/etc/rc.conf` (or use `sysrc`).
-    - `(sudo) sysrc mackerel_agent_enable="YES"`
-    - (or `sudoedit /etc/rc.conf`)
-7. Start `mackerel_agent`.
-    - `(sudo) service mackerel_agent start`
+## Install from ports (recommended)
 
+mackerel-agent is now available  FreeBSD Ports Collection.
+
+### Install
+```
+$ sudo make -C /usr/ports/sysutils/mackerel-agent
+or
+$ sudo portmaster sysutils/mackerel-agent
+or
+$ sudo pkg install mackerel-agent
+```
+
+### Configure
+```
+$ sudoedit /usr/local/etc/mackerel-agent/mackerel-agent.conf
+```
+
+### Register as startup and start agent
+
+```
+$ sudo sysrc mackerel_agent_enable=YES
+$ sudo service mackerel_agent start
+```
+
+## Install from tarball
+
+### Fetch and extract
+
+Fetch the release tarball matches your architecture.
+
+```
+$ fetch https://github.com/mackerelio/mackerel-agent/releases/download/v0.67.1/mackerel-agent_freebsd_amd64.tar.gz
+$ tar zxfv mackerel-agent_freebsd_amd64.tar.gz
+$ cd mackerel-agent_freebsd_amd64
+```
+
+The release tarball doesn't include rc script so far. Fetch it from the git repository.
+
+```
+$ fetch https://raw.githubusercontent.com/mackerelio/mackerel-agent/master/packaging/freebsd/mackerel_agent
+```
+
+### Install
+
+```
+$ sudo install -d /usr/local/etc/mackerel-agent
+$ sudo install -m 0600 mackerel-agent.conf /usr/local/etc/mackerel-agent
+$ sudo install -m 555 mackerel-agent /usr/local/bin
+$ sudo install -m mackerel_agent /usr/local/etc/rc.d
+```
+
+### Configure
+
+```
+$ sudoedit /usr/local/etc/mackerel-agent/mackerel-agent.conf
+```
+
+### Register as startup and start agent
+
+```
+$ sudo sysrc mackerel_agent_enable=YES
+$ sudo service mackerel_agent start
+```

--- a/packaging/freebsd/mackerel_agent
+++ b/packaging/freebsd/mackerel_agent
@@ -4,11 +4,15 @@
 # REQUIRE: NETWORKING SERVERS DAEMON
 # KEYWORD: shutdown
 
-# 
+#
 # Add the following lines to /etc/rc.conf to enable mackerel_agent:
 # mackerel_agent_enable (bool) : Set to "NO" by default.
 #                                Set it to "YES" to enable
-# 
+# mackerel_agent_config (str)  : Path to mackerel-agent.conf.
+#                                Default: ${PREFIX}/etc/mackerel-agent/mackerel-agent.conf
+# mackerel_agent_flags (str)   : Extra flags to pass to mackerel-agent.
+#                                Default: empty
+#
 
 . /etc/rc.subr
 
@@ -17,9 +21,17 @@ rcvar=mackerel_agent_enable
 load_rc_config ${name}
 
 : ${mackerel_agent_enable:=NO}
-: ${mackerel_agent_config:=/usr/local/etc/mackerel-agent.conf}
+: ${mackerel_agent_config:=/usr/local/etc/mackerel-agent/mackerel-agent.conf}
 
 command="/usr/local/bin/mackerel-agent"
-command_args="--conf=${mackerel_agent_config} &"
+required_files="${mackerel_agent_config}"
+command_args="supervise -conf ${mackerel_agent_config} ${mackerel_agent_flags}"
+
+start_cmd=mackerel_agent_start
+
+mackerel_agent_start()
+{
+	/usr/sbin/daemon -cf -S -T mackerel-agent ${command} ${command_args}
+}
 
 run_rc_command "$1"


### PR DESCRIPTION
mackerel-agent is now available as [FreeBSD ports](https://www.freshports.org/sysutils/mackerel-agent/).  Here's a feedback on rc script from a FreeBSD developer.
- Add some comment
- Do not spit out logs on stdout but use syslog when run as daemon
- Use the same config file path as well as other distro (mackerel-agent subdir)
- Run as supervisor mode
