### PR TITLE
revert changing filename unexpectedly

### DIFF
--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/mackerelio/mackerel-agent.git
 Homepage: https://mackerel.io
 
 Package: mackerel-agent
-Architecture: any
+Architecture: all
 Depends: ${misc:Depends}
 Description: mackerel.io agent
  Server monitoring agent for https://mackerel.io (Monitoring SaaS)


### PR DESCRIPTION
I've introduced Architecture: any at #653 but its side-effects was changing package filename unexpectedly.
So I revert that changes.