### PR TITLE
Fix artifact filename pattern again to include mackerel-agent_{os}_{arch}.tar.gz to GitHub Release artifacts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,6 +33,7 @@ jobs:
     name: Build (Linux)
     runs-on: ubuntu-latest
     needs: test-linux
+    if: github.ref == 'refs/heads/master'
     env:
       DEBIAN_FRONTEND: noninteractive
       GO111MODULE: on

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,6 @@ jobs:
     name: Build (Linux)
     runs-on: ubuntu-latest
     needs: test-linux
-    if: github.ref == 'refs/heads/master'
     env:
       DEBIAN_FRONTEND: noninteractive
       GO111MODULE: on

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,7 +55,8 @@ jobs:
         path: |
           rpmbuild/RPMS/*/*.rpm
           packaging/*.deb
-          snapshot/*.{zip, tar.gz}
+          snapshot/*.zip
+          snapshot/*.tar.gz
           build/*.tar.gz
   # TODO add build-windows
 


### PR DESCRIPTION
#674 did not solve the problem.  It seems we cannot use `{}` here