### PR TITLE
Build with Go 1.14 in CI (was 1.15 by mistake)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: 1.14
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: 1.14
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: 1.14
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2


### PR DESCRIPTION
`^1.14` matched any Go 1.x !!