### PR TITLE
[nit] spec/darwin/cpu: remove unnecessary option of `sysctl`

### DIFF
--- a/spec/darwin/cpu.go
+++ b/spec/darwin/cpu.go
@@ -86,7 +86,7 @@ func (g *CPUGenerator) getCPUCount() (*int, error) {
 // - cache_size
 // - flags
 func (g *CPUGenerator) Generate() (interface{}, error) {
-	cpuInfoBytes, err := exec.Command("sysctl", "-a", "machdep.cpu").Output()
+	cpuInfoBytes, err := exec.Command("sysctl", "machdep.cpu").Output()
 	cpuInfo, err := g.parseSysCtlBytes(cpuInfoBytes)
 	if err != nil {
 		cpuLogger.Errorf("Failed: %s", err)


### PR DESCRIPTION
Currently mackerel-agent executes `sysctl -a machdep.cpu` to retrieve CPU information.
But, according to `man sysctl`, `-a` option is described as "This option is ignored if one or more variable names are specified on the command line."

## testing

retrieve CPU information via `mackerel-agent once` and check the response kept unchanged between this branch and master branch.
```
make build
./build/mackerel-agent once | jq .host.meta.cpu
```
