### PR TITLE
fix http_proxy option in v0.71.2

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,7 @@ type Config struct {
 	Filesystems   Filesystems   `toml:"filesystems"`
 	Interfaces    Interfaces    `toml:"interfaces"`
 	HTTPProxy     string        `toml:"http_proxy"`
+	HTTPSProxy    string        `toml:"https_proxy"`
 	CloudPlatform CloudPlatform `toml:"cloud_platform"`
 
 	// This Plugin field is used to decode the toml file. After reading the

--- a/main.go
+++ b/main.go
@@ -157,6 +157,14 @@ func resolveConfig(fs *flag.FlagSet, argv []string) (*config.Config, error) {
 	if conf.HTTPProxy != "" {
 		os.Setenv("HTTP_PROXY", conf.HTTPProxy)
 	}
+	if conf.HTTPSProxy != "" {
+		os.Setenv("HTTPS_PROXY", conf.HTTPSProxy)
+	}
+	// fallback
+	if conf.HTTPProxy != "" && conf.HTTPSProxy == "" {
+		os.Setenv("HTTPS_PROXY", conf.HTTPProxy)
+	}
+
 	return conf, nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -251,14 +251,14 @@ func TestConfigProxy(t *testing.T) {
 				HTTPSProxy: tt.httpsProxy,
 			})
 
-			http_proxy := os.Getenv("HTTP_PROXY")
-			if http_proxy != tt.wantHTTPProxy {
-				t.Errorf("HTTP_PROXY=%s; but want %s", http_proxy, tt.wantHTTPProxy)
+			httpProxy := os.Getenv("HTTP_PROXY")
+			if httpProxy != tt.wantHTTPProxy {
+				t.Errorf("HTTP_PROXY=%s; but want %s", httpProxy, tt.wantHTTPProxy)
 			}
 
-			https_proxy := os.Getenv("HTTPS_PROXY")
-			if https_proxy != tt.wantHTTPSProxy {
-				t.Errorf("HTTPS_PROXY=%s; but want %s", https_proxy, tt.wantHTTPSProxy)
+			httpsProxy := os.Getenv("HTTPS_PROXY")
+			if httpsProxy != tt.wantHTTPSProxy {
+				t.Errorf("HTTPS_PROXY=%s; but want %s", httpsProxy, tt.wantHTTPSProxy)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/mackerelio/mackerel-agent/command"
+	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/pidfile"
 )
 
@@ -220,6 +221,46 @@ func TestNotifyUpdateFileDelete(t *testing.T) {
 	case <-termCh:
 	case <-time.After(time.Second):
 		t.Errorf("Interrupt signal is not received in a second")
+	}
+}
+
+func TestConfigProxy(t *testing.T) {
+	tests := []struct {
+		name           string
+		httpProxy      string
+		httpsProxy     string
+		wantHTTPProxy  string
+		wantHTTPSProxy string
+	}{
+		{"empty", "", "", "", ""},
+		{"http is direct", "direct", "", "", ""},
+		{"http only", "http", "", "http", "http"},
+		{"https only", "", "https", "", "https"},
+		{"http only, https is direct", "http", "direct", "http", ""},
+		{"http and https", "http", "https", "http", "https"},
+		{"http and https is direct", "direct", "direct", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Unsetenv("HTTP_PROXY")
+			os.Unsetenv("HTTPS_PROXY")
+
+			setProxy(&config.Config{
+				HTTPProxy:  tt.httpProxy,
+				HTTPSProxy: tt.httpsProxy,
+			})
+
+			http_proxy := os.Getenv("HTTP_PROXY")
+			if http_proxy != tt.wantHTTPProxy {
+				t.Errorf("HTTP_PROXY=%s; but want %s", http_proxy, tt.wantHTTPProxy)
+			}
+
+			https_proxy := os.Getenv("HTTPS_PROXY")
+			if https_proxy != tt.wantHTTPSProxy {
+				t.Errorf("HTTPS_PROXY=%s; but want %s", https_proxy, tt.wantHTTPSProxy)
+			}
+		})
 	}
 }
 

--- a/packaging/deb/debian/mackerel-agent.init
+++ b/packaging/deb/debian/mackerel-agent.init
@@ -24,6 +24,9 @@ MACKEREL_PLUGIN_WORKDIR=${MACKEREL_PLUGIN_WORKDIR:="/var/tmp/$NAME"}
 if [ "$HTTP_PROXY" != "" ]; then
     export HTTP_PROXY=$HTTP_PROXY
 fi
+if [ "$HTTPS_PROXY" != "" ]; then
+    export HTTPS_PROXY=$HTTPS_PROXY
+fi
 
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0

--- a/packaging/rpm/src/mackerel-agent.initd
+++ b/packaging/rpm/src/mackerel-agent.initd
@@ -29,6 +29,9 @@ MACKEREL_PLUGIN_WORKDIR=${MACKEREL_PLUGIN_WORKDIR:="/var/tmp/$prog"}
 if [ "$HTTP_PROXY" != "" ]; then
     export HTTP_PROXY=$HTTP_PROXY
 fi
+if [ "$HTTPS_PROXY" != "" ]; then
+    export HTTPS_PROXY=$HTTPS_PROXY
+fi
 
 lockfile=/var/lock/subsys/$prog
 


### PR DESCRIPTION
- Explicitly separate HTTP_PROXY and HTTPS_PROXY since Go 1.16
- Now accepts individual proxy settings.
- Also, the behavior is fallback to match the behavior of past mackerel-agent (v0.71.1)