### PR TITLE
Add arm64/darwin build to GitHub release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,11 @@ crossbuild: deps credits
 		-include=mackerel-agent.conf \
 		-n $(MACKEREL_AGENT_NAME) -o $(MACKEREL_AGENT_NAME)
 	goxz -build-ldflags=$(BUILD_LDFLAGS) \
-		-os=linux -arch=arm64,mips -d ./snapshot \
+		-os=linux,darwin -arch=arm64 -d ./snapshot \
+		-include=mackerel-agent.conf \
+		-n $(MACKEREL_AGENT_NAME) -o $(MACKEREL_AGENT_NAME)
+	goxz -build-ldflags=$(BUILD_LDFLAGS) \
+		-os=linux -arch=mips -d ./snapshot \
 		-include=mackerel-agent.conf \
 		-n $(MACKEREL_AGENT_NAME) -o $(MACKEREL_AGENT_NAME)
 


### PR DESCRIPTION
Hi.

I'd like to request add arm64/darwin build (= build for Apple Silicon Macs) to GitHub releases artifact (, and finally homebrew formula).

In this p-r I simply added arm64/darwin as `make crossbuild` target.  Once approved, I'm also willing to open p-r to https://github.com/mackerelio/homebrew-mackerel-agent so that brew taps will work on Apple Silicon Macs.