### PR TITLE
add s, ms, bps to metric units

### DIFF
--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -95,7 +95,7 @@ var pluginMetaHeadlineReg = regexp.MustCompile(`^#\s*mackerel-agent-plugin\b(.*)
 // 	  }
 // 	}
 //
-// Valid UNIT_TYPEs are: "float", "integer", "percentage", "bytes", "bytes/sec", "iops"
+// Valid UNIT_TYPEs are: "float", "integer", "percentage", "seconds", "milliseconds", "bytes", "bytes/sec", "bits/sec", "iops"
 //
 // The output should start with a line beginning with '#', which contains
 // meta-info of the configuration. (eg. plugin schema version)


### PR DESCRIPTION
The following metric units are now available:

- seconds [s]
- milliseconds [ms]
- bits/sec [bps]

Then we added to the comment about metric units.
