### PR TITLE
Loosen the conditions of delaying report of check monitering.

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -536,7 +536,7 @@ func runCheckersLoop(ctx context.Context, app *App, termCheckerCh <-chan struct{
 		// Extend the delay when there are lots of reports
 		if len(reports) > len(app.Agent.Checkers) {
 			reportCheckDelay = reportCheckDelaySecondsMax
-			logger.Debugf("RunCheckerLoop: Extend the delay to %d seconds. There are %d reports.", reportCheckDelay, len(reports))
+			logger.Warningf("RunCheckerLoop: Extend the delay to %d seconds for every %d reports. There are %d reports.", reportCheckDelay, checkReportMaxSize, len(reports))
 		}
 
 		// "" means no CustomIdentifier, which means the host running this agent itself.

--- a/command/command.go
+++ b/command/command.go
@@ -532,17 +532,19 @@ func runCheckersLoop(ctx context.Context, app *App, termCheckerCh <-chan struct{
 		// Do not report too many reports at once.
 		const checkReportMaxSize = 10
 
-		// Do not report many times in a short time.
-		// Extend the delay when there are lots of reports
-		if len(reports) > len(app.Agent.Checkers)*2 {
-			// e.g. reportCheckDelay: 1 -> 2 -> 4 -> 8 -> 16 -> 30
-			reportCheckDelay = reportCheckDelay * 2
-			if reportCheckDelay > reportCheckDelaySecondsMax {
-				reportCheckDelay = reportCheckDelaySecondsMax
+		if len(reports) > checkReportMaxSize {
+			// Do not report many times in a short time.
+			// Extend the delay when there are lots of reports
+			if len(reports) > len(app.Agent.Checkers)*2 {
+				// e.g. reportCheckDelay: 1 -> 2 -> 4 -> 8 -> 16 -> 30
+				reportCheckDelay = reportCheckDelay * 2
+				if reportCheckDelay > reportCheckDelaySecondsMax {
+					reportCheckDelay = reportCheckDelaySecondsMax
+				}
+				logger.Warningf("RunCheckerLoop: Extend the delay to %d seconds for every %d reports. There are %d reports.", reportCheckDelay, checkReportMaxSize, len(reports))
+			} else {
+				reportCheckDelay = reportCheckDelaySecondsMin
 			}
-			logger.Warningf("RunCheckerLoop: Extend the delay to %d seconds for every %d reports. There are %d reports.", reportCheckDelay, checkReportMaxSize, len(reports))
-		} else {
-			reportCheckDelay = reportCheckDelaySecondsMin
 		}
 
 		// "" means no CustomIdentifier, which means the host running this agent itself.

--- a/command/command.go
+++ b/command/command.go
@@ -536,7 +536,9 @@ func runCheckersLoop(ctx context.Context, app *App, termCheckerCh <-chan struct{
 		// Extend the delay when there are lots of reports
 		if len(reports) > len(app.Agent.Checkers)*2 {
 			reportCheckDelay = reportCheckDelaySecondsMax
-			logger.Warningf("RunCheckerLoop: Extend the delay to %d seconds for every %d reports. There are %d reports.", reportCheckDelay, checkReportMaxSize, len(reports))
+			if len(reports) > checkReportMaxSize {
+				logger.Warningf("RunCheckerLoop: Extend the delay to %d seconds for every %d reports. There are %d reports.", reportCheckDelay, checkReportMaxSize, len(reports))
+			}
 		}
 
 		// "" means no CustomIdentifier, which means the host running this agent itself.

--- a/command/command.go
+++ b/command/command.go
@@ -34,7 +34,7 @@ var (
 	postMetricsBufferSize          = 6 * 60 // Keep metric values of 6 hours in the queue
 
 	reportCheckDelaySeconds      = 1      // Wait for a second before reporting the next check
-	reportCheckDelaySecondsMax   = 30     // Wait 30 seconds before reporting the next check when many reports in queue
+	reportCheckDelaySecondsMax   = 15     // Wait 15 seconds before reporting the next check when many reports in queue
 	reportCheckRetryDelaySeconds = 30     // Wait 30 seconds before retrying report the next check
 	reportCheckBufferSize        = 6 * 60 // Keep check reports of 6 hours in the queue
 )
@@ -529,12 +529,12 @@ func runCheckersLoop(ctx context.Context, app *App, termCheckerCh <-chan struct{
 		}
 
 		// Do not report too many reports at once.
-		const checkReportMaxSize = 10
+		const checkReportMaxSize = 20
 
 		// Do not report many times in a short time.
 		reportCheckDelay := reportCheckDelaySeconds
 		// Extend the delay when there are lots of reports
-		if len(reports) > len(app.Agent.Checkers) {
+		if len(reports) > len(app.Agent.Checkers)*2 {
 			reportCheckDelay = reportCheckDelaySecondsMax
 			logger.Warningf("RunCheckerLoop: Extend the delay to %d seconds for every %d reports. There are %d reports.", reportCheckDelay, checkReportMaxSize, len(reports))
 		}


### PR DESCRIPTION
- Change the log level when delaying report of check monitering.
  - I want to know if the report is delayed, even if it's not DEBUG level.
- Loosen the conditions of delaying report of check monitering.
  - In my environment, the timing when the number of reports is greater than the number of check monitors occurs once or twice an hour.
  - If the number of check monitoring is high and the number of reports is high, waiting in 30 seconds is fatal, and the number of reports will not decrease. The number of reports will continue to increase.