### PR TITLE
Add `omitted_success_message` option for check plugins

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -462,6 +462,10 @@ func runChecker(ctx context.Context, checker *checks.Checker, checkReportCh chan
 				}()
 			}
 
+			if checker.Config.OmittedSuccessMessage && report.Status == checks.StatusOK {
+				report.Message = "(Omitted by mackerel-agent.)"
+			}
+
 			if report.Status == checks.StatusOK && report.Status == lastStatus && report.Message == lastMessage {
 				// Do not report if nothing has changed
 				continue

--- a/config/config.go
+++ b/config/config.go
@@ -139,6 +139,7 @@ type PluginConfig struct {
 	ExcludePattern        *string       `toml:"exclude_pattern"`
 	Action                CommandConfig `toml:"action"`
 	Memo                  string        `toml:"memo"`
+	OmittedSuccessMessage bool          `toml:"omitted_success_message"`
 }
 
 // CommandConfig represents an executable command configuration.
@@ -258,6 +259,7 @@ type CheckPlugin struct {
 	PreventAlertAutoClose bool
 	Action                *Command
 	Memo                  string
+	OmittedSuccessMessage bool
 }
 
 func (pconf *PluginConfig) buildCheckPlugin(name string) (*CheckPlugin, error) {
@@ -297,6 +299,7 @@ func (pconf *PluginConfig) buildCheckPlugin(name string) (*CheckPlugin, error) {
 		PreventAlertAutoClose: pconf.PreventAlertAutoClose,
 		Action:                action,
 		Memo:                  pconf.Memo,
+		OmittedSuccessMessage: pconf.OmittedSuccessMessage,
 	}
 	if plugin.MaxCheckAttempts != nil && *plugin.MaxCheckAttempts > 1 && plugin.PreventAlertAutoClose {
 		*plugin.MaxCheckAttempts = 1


### PR DESCRIPTION
- If `omitted_success_message` option is true, overwrite the success message with a fixed message and omit it.
- This option make mackerel-agent not report the OK status of the plugin to the server unless it is changed from OK status.