### PR TITLE
Improve `mackerel-agent configtest`: detect unexpected key

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -111,7 +111,7 @@ func doConfigtest(fs *flag.FlagSet, argv []string) error {
 	if len(validResult) > 0 {
 		var messages string
 		for _, key := range validResult {
-			messages += fmt.Sprintf("\x1b[33m[WARNING] %s is not used key \x1b[0m \n", key)
+			messages += fmt.Sprintf("\x1b[33m[WARNING] %s is unexpected key \x1b[0m \n", key)
 		}
 		return fmt.Errorf(messages)
 	}

--- a/commands.go
+++ b/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/pidfile"
 	"github.com/mackerelio/mackerel-agent/supervisor"
+	"github.com/fatih/color"
 )
 
 /*
@@ -106,17 +107,19 @@ do configtest
 */
 func doConfigtest(fs *flag.FlagSet, argv []string) error {
 	conf, err := resolveConfig(fs, argv)
+	red := color.New(color.FgRed)
+	yellow := color.New(color.FgYellow)
 	if err != nil {
-		return fmt.Errorf("\x1b[31m[CRITICAL] failed to test config: %s \x1b[0m", err)
+		return fmt.Errorf(red.Sprintf("[CRITICAL] failed to test config: %s", err))
 	}
 	validResult, err := config.ValidateConfigFile(conf.Conffile)
 	if err != nil {
-		return fmt.Errorf("\x1b[31m[CRITICAL] failed to test config: %s \x1b[0m", err)
+		return fmt.Errorf(red.Sprintf("[CRITICAL] failed to test config: %s", err))
 	}
 	if len(validResult) > 0 {
 		var messages string
 		for _, key := range validResult {
-			messages += fmt.Sprintf("\x1b[33m[WARNING] %s is unexpected key \x1b[0m \n", key)
+			messages += fmt.Sprintf(yellow.Sprintf("[WARNING] %s is unexpected key\n", key))
 		}
 		return fmt.Errorf(messages)
 	}

--- a/commands.go
+++ b/commands.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/Songmu/prompter"
 	"github.com/Songmu/retry"
+	"github.com/fatih/color"
 	"github.com/mackerelio/mackerel-agent/command"
 	"github.com/mackerelio/mackerel-agent/config"
 	"github.com/mackerelio/mackerel-agent/pidfile"
 	"github.com/mackerelio/mackerel-agent/supervisor"
-	"github.com/fatih/color"
 )
 
 /*

--- a/commands.go
+++ b/commands.go
@@ -102,9 +102,21 @@ do configtest
 func doConfigtest(fs *flag.FlagSet, argv []string) error {
 	conf, err := resolveConfig(fs, argv)
 	if err != nil {
-		return fmt.Errorf("failed to test config: %s", err)
+		return fmt.Errorf("\x1b[31m[CRITICAL] failed to test config: %s \x1b[0m", err)
 	}
-	fmt.Fprintf(os.Stderr, "%s Syntax OK\n", conf.Conffile)
+	validResult, err := config.ValidateConfigFile(conf.Conffile)
+	if err != nil {
+		return fmt.Errorf("\x1b[31m[CRITICAL] failed to test config: %s \x1b[0m", err)
+	}
+	if len(validResult) > 0 {
+		var messages string
+		for _, key := range validResult {
+			messages += fmt.Sprintf("\x1b[33m[WARNING] %s is not used key \x1b[0m \n", key)
+		}
+		return fmt.Errorf(messages)
+	}
+	
+	fmt.Fprintf(os.Stderr, "SUCCESS (%s)\n", conf.Conffile)
 	return nil
 }
 

--- a/commands.go
+++ b/commands.go
@@ -17,9 +17,10 @@ import (
 	"github.com/mackerelio/mackerel-agent/supervisor"
 )
 
-/* +main - mackerel-agent
+/*
+	 +main - mackerel-agent
 
-	mackerel-agent [options]
+		mackerel-agent [options]
 
 main process of mackerel-agent
 */
@@ -31,19 +32,20 @@ func doMain(fs *flag.FlagSet, argv []string) error {
 	return start(conf, make(chan struct{}))
 }
 
-/* +command init - initialize mackerel-agent.conf with apikey
+/*
+	 +command init - initialize mackerel-agent.conf with apikey
 
-	init -apikey=xxxxxxxxxxx [-conf=mackerel-agent.conf]
+		init -apikey=xxxxxxxxxxx [-conf=mackerel-agent.conf]
 
 Initialize mackerel-agent.conf with api key.
 
-- The conf file doesn't exist:
+  - The conf file doesn't exist:
     create new file and set the apikey.
-- The conf file exists and apikey is unset:
+  - The conf file exists and apikey is unset:
     set the apikey.
-- The conf file exists and apikey already set:
+  - The conf file exists and apikey already set:
     skip initializing. Don't overwrite apikey and exit normally.
-- The conf file exists, but the contents of it is invalid toml:
+  - The conf file exists, but the contents of it is invalid toml:
     exit with error.
 */
 func doInit(fs *flag.FlagSet, argv []string) error {
@@ -55,9 +57,10 @@ func doInit(fs *flag.FlagSet, argv []string) error {
 	return err
 }
 
-/* +command supervise - supervisor mode
+/*
+	 +command supervise - supervisor mode
 
-	supervise -conf mackerel-agent.conf ...
+		supervise -conf mackerel-agent.conf ...
 
 run as supervisor mode enabling configuration reloading and crash recovery
 */
@@ -81,9 +84,10 @@ func doSupervise(fs *flag.FlagSet, argv []string) error {
 	return supervisor.Supervise(os.Args[0], copiedArgv, nil)
 }
 
-/* +command version - display version of mackerel-agent
+/*
+	 +command version - display version of mackerel-agent
 
-	version
+		version
 
 display the version of mackerel-agent
 */
@@ -93,9 +97,10 @@ func doVersion(_ *flag.FlagSet, _ []string) error {
 	return nil
 }
 
-/* +command configtest - configtest
+/*
+	 +command configtest - configtest
 
-	configtest
+		configtest
 
 do configtest
 */
@@ -115,14 +120,15 @@ func doConfigtest(fs *flag.FlagSet, argv []string) error {
 		}
 		return fmt.Errorf(messages)
 	}
-	
+
 	fmt.Fprintf(os.Stderr, "SUCCESS (%s)\n", conf.Conffile)
 	return nil
 }
 
-/* +command retire - retire the host
+/*
+	 +command retire - retire the host
 
-	retire [-force]
+		retire [-force]
 
 retire the host
 */
@@ -161,9 +167,10 @@ func doRetire(fs *flag.FlagSet, argv []string) error {
 	return nil
 }
 
-/* +command once - output onetime
+/*
+	 +command once - output onetime
 
-	once
+		once
 
 output metrics and meta data of the host one time.
 These data are only displayed and not posted to Mackerel.

--- a/commands_gen.go
+++ b/commands_gen.go
@@ -19,7 +19,7 @@ func init() {
 			Name:   "init",
 			Action: doInit,
 			Short:  "initialize mackerel-agent.conf with apikey",
-			Long:   "init -apikey=xxxxxxxxxxx [-conf=mackerel-agent.conf]\n\nInitialize mackerel-agent.conf with api key.\n\n- The conf file doesn't exist:\n    create new file and set the apikey.\n- The conf file exists and apikey is unset:\n    set the apikey.\n- The conf file exists and apikey already set:\n    skip initializing. Don't overwrite apikey and exit normally.\n- The conf file exists, but the contents of it is invalid toml:\n    exit with error.",
+			Long:   "init -apikey=xxxxxxxxxxx [-conf=mackerel-agent.conf]\n\nInitialize mackerel-agent.conf with api key.\n\n  - The conf file doesn't exist:\n    create new file and set the apikey.\n  - The conf file exists and apikey is unset:\n    set the apikey.\n  - The conf file exists and apikey already set:\n    skip initializing. Don't overwrite apikey and exit normally.\n  - The conf file exists, but the contents of it is invalid toml:\n    exit with error.",
 		},
 	)
 

--- a/config/validate.go
+++ b/config/validate.go
@@ -13,9 +13,9 @@ func ValidateConfigFile(file string) ([]string, error) {
 		return nil, fmt.Errorf("failed to test config: %s", err)
 	}
 
-	var unexpectedKey []string = make([]string, 0)
+	var unexpectedKeys []string
 	for _, v := range md.Undecoded() {
-		unexpectedKey = append(unexpectedKey, v.String())
+		unexpectedKeys = append(unexpectedKeys, v.String())
 	}
 
 	for k1, v := range config.Plugin {
@@ -34,10 +34,10 @@ func ValidateConfigFile(file string) ([]string, error) {
 		*/
 		if k1 != "metrics" && k1 != "checks" && k1 != "metadata" {
 			for k2 := range v {
-				unexpectedKey = append(unexpectedKey, fmt.Sprintf("plugin.%s.%s", k1, k2))
+				unexpectedKeys = append(unexpectedKeys, fmt.Sprintf("plugin.%s.%s", k1, k2))
 			}
 		}
 	}
 
-	return unexpectedKey, nil
+	return unexpectedKeys, nil
 }

--- a/config/validate.go
+++ b/config/validate.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"fmt"
+	"github.com/BurntSushi/toml"
+)
+
+func ValidateConfigFile(file string) ([]toml.Key, error) {
+	config := &Config{}
+	md, err := toml.DecodeFile(file, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to test config: %s", err)
+	}
+	return md.Undecoded(), nil
+}

--- a/config/validate.go
+++ b/config/validate.go
@@ -5,7 +5,7 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// detect unexpected key in configfile
+// ValidateConfigFile detect unexpected key in configfile
 func ValidateConfigFile(file string) ([]string, error) {
 	config := &Config{}
 	md, err := toml.DecodeFile(file, config)

--- a/config/validate.go
+++ b/config/validate.go
@@ -5,6 +5,7 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+// detect unexpected key in configfile
 func ValidateConfigFile(file string) ([]string, error) {
 	config := &Config{}
 	md, err := toml.DecodeFile(file, config)

--- a/config/validate.go
+++ b/config/validate.go
@@ -5,11 +5,38 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-func ValidateConfigFile(file string) ([]toml.Key, error) {
+func ValidateConfigFile(file string) ([]string, error) {
 	config := &Config{}
 	md, err := toml.DecodeFile(file, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to test config: %s", err)
 	}
-	return md.Undecoded(), nil
+
+	var unexpectedKey []string = make([]string, 0)
+	for _, v := range md.Undecoded() {
+		unexpectedKey = append(unexpectedKey, v.String())
+	}
+
+	for k1, v := range config.Plugin {
+		/*
+			detect [plugin.<unexpected>.<unexpected>]
+			don't have to detect critical syntax error about plugin here because error should have occured while loading config
+			```
+			[plugin.metrics.correct]
+			```
+			-> A configuration value of `command` should be string or string slice, but <nil>
+			```
+			[plugin.metrics]
+			command = "test command"
+			```
+			-> type mismatch for config.PluginConfig: expected table but found string
+		*/
+		if k1 != "metrics" && k1 != "checks" && k1 != "metadata" {
+			for k2 := range v {
+				unexpectedKey = append(unexpectedKey, fmt.Sprintf("plugin.%s.%s", k1, k2))
+			}
+		}
+	}
+
+	return unexpectedKey, nil
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+var configFile = `
+apikey = "hoge"
+podfile = "/path/to/pidfile"
+
+[foobar]
+command = "test command"
+
+# TODO: detect warning
+[plugin.check.hoge]
+command = "test command"
+
+[plugins.check.hoge]
+command = "test command"
+
+# this is correct
+[plugin.checks.hoge]
+command = "test command"
+`
+
+func TestValidateConfig(t *testing.T) {
+	tmpFile, err := newTempFileWithContent(configFile)
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+
+	validResult, err := ValidateConfigFile(tmpFile.Name())
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+
+	want := []string{
+		"podfile",
+		"foobar",
+		"foobar.command",
+		"plugins.check.hoge",
+		"plugins.check.hoge.command",
+	}
+
+	if len(want) != len(validResult) {
+		t.Errorf("should be more undecoded keys: want %v, validResult: %v", len(want), len(validResult))
+	}
+
+	for _, v := range validResult {
+		if !contains(want, v.String()) {
+			t.Errorf("should be Undecoded: %v", v.String())
+		}
+	}
+}
+
+func contains(target []string, want string) bool {
+	for _, v := range target {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -11,16 +11,28 @@ podfile = "/path/to/pidfile"
 
 [foobar]
 command = "test command"
+env = { FOO = "BAR" }
 
-# TODO: detect warning
-[plugin.check.hoge]
+[plugin.foo.bar]
+command = "test command"
+env = { FOO = "BAR" }
+
+[plugin.metric.first]
 command = "test command"
 
-[plugins.check.hoge]
+[plugin.check.first]
 command = "test command"
 
-# this is correct
-[plugin.checks.hoge]
+[plugin.check.second]
+command = "test command"
+
+[plugins.check.first]
+command = "test command"
+
+[plugin.metrics.correct]
+command = "test command"
+
+[plugin.checks.correct]
 command = "test command"
 `
 
@@ -36,21 +48,31 @@ func TestValidateConfig(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	want := []string{
+	wantUnexpectedKey := []string{
 		"podfile",
 		"foobar",
 		"foobar.command",
-		"plugins.check.hoge",
-		"plugins.check.hoge.command",
+		"foobar.env",
+		"foobar.env.FOO",
+		"plugin.foo.bar",
+		// don't detect child of plugin.<unexpected>.<unexpected>
+		// "plugin.foo.bar.command",
+		// "plugin.foo.bar.env",
+		// "plugin.foo.bar.env.FOO",
+		"plugin.metric.first",
+		"plugin.check.first",
+		"plugin.check.second",
+		"plugins.check.first",
+		"plugins.check.first.command",
 	}
 
-	if len(want) != len(validResult) {
-		t.Errorf("should be more undecoded keys: want %v, validResult: %v", len(want), len(validResult))
+	if len(wantUnexpectedKey) != len(validResult) {
+		t.Errorf("should be more undecoded keys: want %v, validResult: %v", len(wantUnexpectedKey), len(validResult))
 	}
 
 	for _, v := range validResult {
-		if !contains(want, v.String()) {
-			t.Errorf("should be Undecoded: %v", v.String())
+		if !contains(wantUnexpectedKey, v) {
+			t.Errorf("should be Undecoded: %v", v)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -27,10 +27,12 @@ require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
+	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/klauspost/compress v1.14.2 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
+	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mholt/archiver/v3 v3.5.1 // indirect
 	github.com/nwaples/rardecode v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/mackerelio/golib v1.2.1 h1:SDcDn6Jw3p9bi1N0bg1Z/ilG5qcBB23qL8xNwrU0gg
 github.com/mackerelio/golib v1.2.1/go.mod h1:b8ZaapsHGH1FlEJlCqfD98CqafLeyMevyATDlID2BsM=
 github.com/mackerelio/mackerel-client-go v0.21.1 h1:VeWwvXEvFSABD68HxCZYKE3f+yOVpXWp6imUe5IjNBo=
 github.com/mackerelio/mackerel-client-go v0.21.1/go.mod h1:/GNOj+y1eFsd3CK8c6IQ/uS38/GT0+NWImk5YGJs5Lk=
+github.com/mackerelio/mackerel-client-go v0.21.2 h1:m/Pe2onBkry7qKCimutEJ/TRSWpSOQ1rrO5iSwgUNFc=
+github.com/mackerelio/mackerel-client-go v0.21.2/go.mod h1:VM9KAjzs7wkROQ9WdZRvkY8K/bIUllN82dxyK36ZU3s=
 github.com/mattn/go-colorable v0.1.9 h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69YV3U=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 h1:iFaUwBSo5Svw6L7HYpRu/0lE3e0BaElwnNO1qkNQxBY=
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
@@ -46,6 +48,9 @@ github.com/mackerelio/golib v1.2.1 h1:SDcDn6Jw3p9bi1N0bg1Z/ilG5qcBB23qL8xNwrU0gg
 github.com/mackerelio/golib v1.2.1/go.mod h1:b8ZaapsHGH1FlEJlCqfD98CqafLeyMevyATDlID2BsM=
 github.com/mackerelio/mackerel-client-go v0.21.1 h1:VeWwvXEvFSABD68HxCZYKE3f+yOVpXWp6imUe5IjNBo=
 github.com/mackerelio/mackerel-client-go v0.21.1/go.mod h1:/GNOj+y1eFsd3CK8c6IQ/uS38/GT0+NWImk5YGJs5Lk=
+github.com/mattn/go-colorable v0.1.9 h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69YV3U=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/goveralls v0.0.11 h1:eJXea6R6IFlL1QMKNMzDvvHv/hwGrnvyig4N+0+XiMM=
@@ -113,6 +118,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main_test.go
+++ b/main_test.go
@@ -324,6 +324,28 @@ invalid!!!
 	}
 }
 
+func TestConfigTestUnexpectedKey(t *testing.T) {
+	// prepare dummy config
+	confFile, err := os.CreateTemp("", "mackerel-config-test")
+	if err != nil {
+		t.Fatalf("Could not create temporary config file for test")
+	}
+	confFile.WriteString(`
+	apikey="DUMMYAPIKEY"
+	unexpected="value"
+`)
+	confFile.Sync()
+	confFile.Close()
+	defer os.Remove(confFile.Name())
+
+	argv := []string{"-conf=" + confFile.Name()}
+	err = doConfigtest(&flag.FlagSet{}, argv)
+
+	if err == nil {
+		t.Errorf("configtest(failed) must be return error")
+	}
+}
+
 func TestDoOnce(t *testing.T) {
 	err := doOnce(&flag.FlagSet{}, []string{})
 	if err != nil {

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -77,23 +77,23 @@ var pluginMetaHeadlineReg = regexp.MustCompile(`^#\s*mackerel-agent-plugin\b(.*)
 // mackerel-agent runs the command with MACKEREL_AGENT_PLUGIN_META
 // environment variable set.  The command is supposed to output like below:
 //
-// 	# mackerel-agent-plugin
-// 	{
-// 	  "graphs": {
-// 	    GRAPH_NAME: {
-// 	      "label": GRAPH_LABEL,
-// 	      "unit": UNIT_TYPE
-// 	      "metrics": [
-// 	        {
-// 	          "name": METRIC_NAME,
-// 	          "label": METRIC_LABEL
-// 	        },
-// 	        ...
-// 	      ]
-// 	    },
-// 	    GRAPH_NAME: ...
-// 	  }
-// 	}
+//	# mackerel-agent-plugin
+//	{
+//	  "graphs": {
+//	    GRAPH_NAME: {
+//	      "label": GRAPH_LABEL,
+//	      "unit": UNIT_TYPE
+//	      "metrics": [
+//	        {
+//	          "name": METRIC_NAME,
+//	          "label": METRIC_LABEL
+//	        },
+//	        ...
+//	      ]
+//	    },
+//	    GRAPH_NAME: ...
+//	  }
+//	}
 //
 // Valid UNIT_TYPEs are: "float", "integer", "percentage", "seconds", "milliseconds", "bytes", "bytes/sec", "bits/sec", "iops"
 //
@@ -102,24 +102,24 @@ var pluginMetaHeadlineReg = regexp.MustCompile(`^#\s*mackerel-agent-plugin\b(.*)
 //
 // Below is a working example where the plugin emits metrics named "dice.d6" and "dice.d20":
 //
-// 	{
-// 	  "graphs": {
-// 	    "dice": {
-// 	      "metrics": [
-// 	        {
-// 	          "name": "d6",
-// 	          "label": "Die (d6)"
-// 	        },
-// 	        {
-// 	          "name": "d20",
-// 	          "label": "Die (d20)"
-// 	        }
-// 	      ],
-// 	      "unit": "integer",
-// 	      "label": "My Dice"
-// 	    }
-// 	  }
-// 	}
+//	{
+//	  "graphs": {
+//	    "dice": {
+//	      "metrics": [
+//	        {
+//	          "name": "d6",
+//	          "label": "Die (d6)"
+//	        },
+//	        {
+//	          "name": "d20",
+//	          "label": "Die (d20)"
+//	        }
+//	      ],
+//	      "unit": "integer",
+//	      "label": "My Dice"
+//	    }
+//	  }
+//	}
 func (g *pluginGenerator) loadPluginMeta() error {
 	// Set environment variable to make the plugin command generate its configuration
 	pluginMetaEnv := pluginConfigurationEnvName + "=1"


### PR DESCRIPTION
part of: https://github.com/mackerelio/mackerel-agent/issues/810

#### example of WARNING

```
$ cat /usr/local/etc/mackerel-agent-sample.conf
apikey = "foo"
podfile = "/path/to/pidfile"

[foobar]
command = "test command"
env = { FOO = "BAR" }

[plugin.foo.bar]
command = "test command"
env = { FOO = "BAR" }

[plugin.metric.first]
command = "test command"

[plugin.check.first]
command = "test command"

[plugin.check.second]
command = "test command"

[plugins.check.first]
command = "test command"

[plugin.metrics.correct]
command = "test command"

[plugin.checks.correct]
command = "test command"
```

```zsh
~/desktop/mackerel-agent
$ ./build/mackerel-agent configtest -conf=/usr/local/etc/mackerel-agent-sample.conf
[WARNING] podfile is unexpected key  
[WARNING] foobar is unexpected key  
[WARNING] foobar.command is unexpected key  
[WARNING] foobar.env.FOO is unexpected key  
[WARNING] foobar.env is unexpected key  
[WARNING] plugins.check.first is unexpected key  
[WARNING] plugins.check.first.command is unexpected key  
[WARNING] plugin.metric.first is unexpected key  
[WARNING] plugin.check.first is unexpected key  
[WARNING] plugin.check.second is unexpected key  
[WARNING] plugin.foo.bar is unexpected key  
```

![スクリーンショット 2022-09-12 16 47 52](https://user-images.githubusercontent.com/50798936/189600261-96114ac7-188f-4f18-84d8-3cbb5503e6cb.png)

#### example of CRITICAL

```
$ cat /usr/local/etc/mackerel-agent-sample-2.conf
uncorrectapikey = "foo"
```

```
~/desktop/mackerel-agent
$ ./build/mackerel-agent configtest -conf=/usr/local/etc/mackerel-agent-sample-2.conf
[CRITICAL] failed to test config: apikey must be specified in the config file (or by the DEPRECATED command-line flag) 
```

![スクリーンショット 2022-09-12 16 45 55](https://user-images.githubusercontent.com/50798936/189600057-60d9d13a-7254-4ebf-a27f-23b638ed2f78.png)
