### PR TITLE
Improve `mackerel-agent configtest`: Add suggestion to unexpected keys

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -119,7 +119,7 @@ func doConfigtest(fs *flag.FlagSet, argv []string) error {
 	if len(validResult) > 0 {
 		var messages string
 		for _, key := range validResult {
-			messages += fmt.Sprintf(yellow.Sprintf("[WARNING] %s is unexpected key\n", key))
+			messages += fmt.Sprintf(yellow.Sprintf("[WARNING] %s is unexpected key\n", key.Name))
 		}
 		return fmt.Errorf(messages)
 	}

--- a/commands.go
+++ b/commands.go
@@ -119,7 +119,11 @@ func doConfigtest(fs *flag.FlagSet, argv []string) error {
 	if len(validResult) > 0 {
 		var messages string
 		for _, key := range validResult {
-			messages += fmt.Sprintf(yellow.Sprintf("[WARNING] %s is unexpected key\n", key.Name))
+			if key.SuggestName == "" {
+				messages += fmt.Sprintf(yellow.Sprintf("[WARNING] %s is unexpected key.\n", key.Name))
+			} else {
+				messages += fmt.Sprintf(yellow.Sprintf("[WARNING] %s is unexpected key. did you mean %s ?\n", key.Name, key.SuggestName))
+			}
 		}
 		return fmt.Errorf(messages)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -103,9 +103,9 @@ type Config struct {
 	Silent        bool
 	Diagnostic    bool          `toml:"diagnostic"`
 	DisplayName   string        `toml:"display_name"`
-	HostStatus    HostStatus    `toml:"host_status"`
-	Filesystems   Filesystems   `toml:"filesystems"`
-	Interfaces    Interfaces    `toml:"interfaces"`
+	HostStatus    HostStatus    `toml:"host_status" conf:"parent"`
+	Filesystems   Filesystems   `toml:"filesystems" conf:"parent"`
+	Interfaces    Interfaces    `toml:"interfaces"  conf:"parent"`
 	HTTPProxy     string        `toml:"http_proxy"`
 	HTTPSProxy    string        `toml:"https_proxy"`
 	CloudPlatform CloudPlatform `toml:"cloud_platform"`
@@ -113,16 +113,16 @@ type Config struct {
 	// This Plugin field is used to decode the toml file. After reading the
 	// configuration from file, this field is set to nil.
 	// Please consider using MetricPlugins and CheckPlugins.
-	Plugin map[string]map[string]*PluginConfig
+	Plugin map[string]map[string]*PluginConfig `conf:"parent"`
 
 	Include string
 
 	// Cannot exist in configuration files
-	HostIDStorage   HostIDStorage
-	MetricPlugins   map[string]*MetricPlugin
-	CheckPlugins    map[string]*CheckPlugin
-	MetadataPlugins map[string]*MetadataPlugin
-	AutoShutdown    bool
+	HostIDStorage   HostIDStorage              `conf:"ignore"`
+	MetricPlugins   map[string]*MetricPlugin   `conf:"ignore"`
+	CheckPlugins    map[string]*CheckPlugin    `conf:"ignore"`
+	MetadataPlugins map[string]*MetadataPlugin `conf:"ignore"`
+	AutoShutdown    bool                       `conf:"ignore"`
 }
 
 // PluginConfig represents a plugin configuration.
@@ -136,7 +136,7 @@ type PluginConfig struct {
 	PreventAlertAutoClose bool          `toml:"prevent_alert_auto_close"`
 	IncludePattern        *string       `toml:"include_pattern"`
 	ExcludePattern        *string       `toml:"exclude_pattern"`
-	Action                CommandConfig `toml:"action"`
+	Action                CommandConfig `toml:"action" conf:"parent"`
 	Memo                  string        `toml:"memo"`
 }
 

--- a/config/validate.go
+++ b/config/validate.go
@@ -24,10 +24,9 @@ func normalizeKeyname(f reflect.StructField) string {
 	return name
 }
 
-func addKeynameToCandidates(f reflect.StructField, candidates *[]string) *[]string {
+func addKeynameToCandidates(f reflect.StructField, candidates []string) []string {
 	name := normalizeKeyname(f)
-	*candidates = append(*candidates, name)
-	return candidates
+	return append(candidates, name)
 }
 
 func makeCandidates(t reflect.Type) []string {
@@ -41,12 +40,12 @@ func makeCandidates(t reflect.Type) []string {
 			continue
 		}
 		if s := f.Tag.Get("conf"); s == "parent" {
-			addKeynameToCandidates(f, &candidates)
+			candidates = addKeynameToCandidates(f, candidates)
 			childCandidates := makeCandidates(f.Type)
 			candidates = append(candidates, childCandidates...)
 			continue
 		}
-		addKeynameToCandidates(f, &candidates)
+		candidates = addKeynameToCandidates(f, candidates)
 	}
 
 	return candidates

--- a/config/validate.go
+++ b/config/validate.go
@@ -24,7 +24,7 @@ func normalizeKeyname(f reflect.StructField) string {
 	return name
 }
 
-func addKeynametoCandidates(f reflect.StructField, candidates *[]string) *[]string {
+func addKeynameToCandidates(f reflect.StructField, candidates *[]string) *[]string {
 	name := normalizeKeyname(f)
 	*candidates = append(*candidates, name)
 	return candidates
@@ -41,12 +41,12 @@ func makeCandidates(t reflect.Type) []string {
 			continue
 		}
 		if s := f.Tag.Get("conf"); s == "parent" {
-			addKeynametoCandidates(f, &candidates)
+			addKeynameToCandidates(f, &candidates)
 			childCandidates := makeCandidates(f.Type)
 			candidates = append(candidates, childCandidates...)
 			continue
 		}
-		addKeynametoCandidates(f, &candidates)
+		addKeynameToCandidates(f, &candidates)
 	}
 
 	return candidates

--- a/config/validate.go
+++ b/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"github.com/BurntSushi/toml"
+	"strings"
 )
 
 // ValidateConfigFile detect unexpected key in configfile
@@ -15,7 +16,10 @@ func ValidateConfigFile(file string) ([]string, error) {
 
 	var unexpectedKeys []string
 	for _, v := range md.Undecoded() {
-		unexpectedKeys = append(unexpectedKeys, v.String())
+		key := strings.Split(v.String(), ".")[0]
+		if !contains(unexpectedKeys, key) {
+			unexpectedKeys = append(unexpectedKeys, key)
+		}
 	}
 
 	for k1, v := range config.Plugin {
@@ -40,4 +44,13 @@ func ValidateConfigFile(file string) ([]string, error) {
 	}
 
 	return unexpectedKeys, nil
+}
+
+func contains(target []string, want string) bool {
+	for _, v := range target {
+		if v == want {
+			return true
+		}
+	}
+	return false
 }

--- a/config/validate.go
+++ b/config/validate.go
@@ -3,11 +3,25 @@ package config
 import (
 	"fmt"
 	"github.com/BurntSushi/toml"
+	"github.com/agext/levenshtein"
+	"sort"
 	"strings"
 )
 
+// UnexpectedKey represents result of validation
 type UnexpectedKey struct {
-	Name string
+	Name        string
+	SuggestName string
+}
+
+func nameSuggestion(given string, suggestions []string) string {
+	for _, suggestion := range suggestions {
+		dist := levenshtein.Distance(given, suggestion, nil)
+		if dist < 3 {
+			return suggestion
+		}
+	}
+	return ""
 }
 
 // ValidateConfigFile detect unexpected key in configfile
@@ -18,17 +32,87 @@ func ValidateConfigFile(file string) ([]UnexpectedKey, error) {
 		return nil, fmt.Errorf("failed to test config: %s", err)
 	}
 
+	var suggestions = []string{
+		// from type Config
+		"apikey",
+		"pidfile",
+		"root",
+		"pidfile",
+		"conffile",
+		"roles",
+		"verbose",
+		"silent",
+		"diagnostic",
+		"display_name",
+		"host_status",
+		"on_start",
+		"on_stop",
+		"filesystems",
+		"ignore",
+		"use_mountpoint",
+		"interfaces",
+		"http_proxy",
+		"https_proxy",
+		"cloud_platform",
+		"plugin",
+		"include",
+		// from type PluginConfig
+		"notification_interval",
+		"check_interval",
+		"execution_interval",
+		"max_check_attempts",
+		"custom_identifier",
+		"prevent_alert_auto_close",
+		"include_pattern",
+		"exclude_pattern",
+		"action",
+		"memo",
+		// from type CommandConfig
+		"command",
+		"user",
+		"env",
+		"timeout_seconds",
+	}
+
 	var unexpectedKeys []UnexpectedKey
 	for _, v := range md.Undecoded() {
-		key := strings.Split(v.String(), ".")[0]
-		if !containKey(unexpectedKeys, key) {
-			unexpectedKeys = append(unexpectedKeys, UnexpectedKey{Name: key})
+		splitedKey := strings.Split(v.String(), ".")
+		key := splitedKey[0]
+		if key == "host_status" || key == "filesystems" || key == "interfaces" || key == "plugin" {
+			/*
+					if conffile is following, UnexpectedKey.SuggestName should be `filesystems.use_mountpoint`, not `filesystems`
+					```
+					[filesystems]
+				  use_mntpoint = true
+					```
+			*/
+			suggestName := nameSuggestion(splitedKey[len(splitedKey)-1], suggestions)
+			if suggestName == "" {
+				unexpectedKeys = append(unexpectedKeys, UnexpectedKey{
+					v.String(),
+					"",
+				})
+			} else {
+				unexpectedKeys = append(unexpectedKeys, UnexpectedKey{
+					v.String(),
+					strings.Join(splitedKey[:len(splitedKey)-1], ".") + "." + suggestName,
+				})
+			}
+		} else {
+			// don't accept duplicate unexpectedKey
+			if !containKey(unexpectedKeys, key) {
+				unexpectedKeys = append(unexpectedKeys, UnexpectedKey{
+					key,
+					nameSuggestion(key, suggestions),
+				})
+			}
 		}
 	}
 
 	for k1, v := range config.Plugin {
 		/*
-			detect [plugin.<unexpected>.<unexpected>]
+			detect [plugin.<unexpected>.<???>]
+			default suggestion of [plugin.<unexpected>.<???>] is plugin.metrics.<???>
 			don't have to detect critical syntax error about plugin here because error should have occured while loading config
 			```
 			[plugin.metrics.correct]
@@ -41,11 +125,26 @@ func ValidateConfigFile(file string) ([]UnexpectedKey, error) {
 			-> type mismatch for config.PluginConfig: expected table but found string
 		*/
 		if k1 != "metrics" && k1 != "checks" && k1 != "metadata" {
+			suggestName := nameSuggestion(k1, []string{"metrics", "checks", "metadata"})
 			for k2 := range v {
-				unexpectedKeys = append(unexpectedKeys, UnexpectedKey{Name: fmt.Sprintf("plugin.%s.%s", k1, k2)})
+				if suggestName == "" {
+					unexpectedKeys = append(unexpectedKeys, UnexpectedKey{
+						fmt.Sprintf("plugin.%s.%s", k1, k2),
+						fmt.Sprintf("plugin.metrics.%s", k2),
+					})
+				} else {
+					unexpectedKeys = append(unexpectedKeys, UnexpectedKey{
+						fmt.Sprintf("plugin.%s.%s", k1, k2),
+						fmt.Sprintf("plugin.%s.%s", suggestName, k2),
+					})
+				}
 			}
 		}
 	}
+
+	sort.Slice(unexpectedKeys, func(i, j int) bool {
+		return unexpectedKeys[i].Name < unexpectedKeys[j].Name
+	})
 
 	return unexpectedKeys, nil
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -48,14 +48,14 @@ func TestValidateConfig(t *testing.T) {
 		t.Errorf("should not raise error: %v", err)
 	}
 
-	wantUnexpectedKey := []string{
-		"podfile",
-		"foobar",
-		"plugin.foo.bar",
-		"plugin.metric.first",
-		"plugin.check.first",
-		"plugin.check.second",
-		"plugins",
+	wantUnexpectedKey := []UnexpectedKey{
+		{Name: "podfile"},
+		{Name: "foobar"},
+		{Name: "plugin.foo.bar"},
+		{Name: "plugin.metric.first"},
+		{Name: "plugin.check.first"},
+		{Name: "plugin.check.second"},
+		{Name: "plugins"},
 	}
 
 	if len(wantUnexpectedKey) != len(validResult) {
@@ -63,7 +63,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 
 	for _, v := range validResult {
-		if !contains(wantUnexpectedKey, v) {
+		if !containKey(wantUnexpectedKey, v.Name) {
 			t.Errorf("should be Undecoded: %v", v)
 		}
 	}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -51,19 +51,11 @@ func TestValidateConfig(t *testing.T) {
 	wantUnexpectedKey := []string{
 		"podfile",
 		"foobar",
-		"foobar.command",
-		"foobar.env",
-		"foobar.env.FOO",
 		"plugin.foo.bar",
-		// don't detect child of plugin.<unexpected>.<unexpected>
-		// "plugin.foo.bar.command",
-		// "plugin.foo.bar.env",
-		// "plugin.foo.bar.env.FOO",
 		"plugin.metric.first",
 		"plugin.check.first",
 		"plugin.check.second",
-		"plugins.check.first",
-		"plugins.check.first.command",
+		"plugins",
 	}
 
 	if len(wantUnexpectedKey) != len(validResult) {
@@ -75,13 +67,4 @@ func TestValidateConfig(t *testing.T) {
 			t.Errorf("should be Undecoded: %v", v)
 		}
 	}
-}
-
-func contains(target []string, want string) bool {
-	for _, v := range target {
-		if v == want {
-			return true
-		}
-	}
-	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 
 require (
 	github.com/Songmu/wrapcommander v0.1.0 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/Songmu/wrapcommander v0.1.0 h1:y8/yk9/PHT983weH+ehZIOJ7JtwAlI1AkfUpUN
 github.com/Songmu/wrapcommander v0.1.0/go.mod h1:EC2y4OnN8PkdMnaCwcSzItewq+f0yqUvS30kcS4vmn0=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
+github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
+github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=


### PR DESCRIPTION
part of: https://github.com/mackerelio/mackerel-agent/issues/810

my conf
```my.conf
$ cat /usr/local/etc/mackerel-agent-sample.conf
apikey = "123456abcde"
podfile = "/path/to/pidfile"

[foobar]
command = "test command"
env = { FOO = "BAR" }

[filesystems]
ignore = "/path/to/ignore"
use_mntpoint = true

[plugin.foo.bar]
command = "test command"
env = { FOO = "BAR" }

[plugin.metric.1]
command = "test command"

[plugin.check.1]
command = "test command"

[plugin.check.2]
command = "test command"

[plugins.check.1]
command = "test command"

[plugin.metrics.correct]
command = "test command"

[plugin.checks.correct]
command = "test command"

[plugin.metrics.1]
command = "test command"
action = { command = "test command", use = "test user", env = { TEST_KEY = "VALUE_1" } }

[plugin.metrics.2]
command = "test command"
action = { command = "test command", xxx = "yyy" }

[plugin.checks.1]
command = "test command"
action = { command = "test command", user = "test user", en = { TEST_KEY = "VALUE_1" } }
```

result
![スクリーンショット 2022-09-28 16 00 00](https://user-images.githubusercontent.com/50798936/192710189-ec204a2d-440e-4109-9cb9-1f2a7b09cad6.png)
