### PR TITLE
Fix config test

### DIFF
--- a/config/validate.go
+++ b/config/validate.go
@@ -2,12 +2,13 @@ package config
 
 import (
 	"fmt"
-	"github.com/BurntSushi/toml"
-	"github.com/agext/levenshtein"
 	"reflect"
 	"sort"
 	"strings"
 	"unicode"
+
+	"github.com/BurntSushi/toml"
+	"github.com/agext/levenshtein"
 )
 
 // UnexpectedKey represents result of validation
@@ -55,7 +56,9 @@ func nameSuggestion(given string, candidates []string) string {
 	for _, candidate := range candidates {
 		dist := levenshtein.Distance(given, candidate, nil)
 		if dist < 3 {
-			return candidate
+			if candidate != given {
+				return candidate
+			}
 		}
 	}
 	return ""

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -50,6 +51,12 @@ action = { command = "test command", xxx = "yyy" }
 [plugin.checks.1]
 command = "test command"
 action = { command = "test command", user = "test user", en = { TEST_KEY = "VALUE_1" } }
+
+[plugin.metrics.aaa]
+command = ["exit 1"]
+[plugin.metrics.aaa.action]
+command = ["exit 2"]
+max_check_attempts = 3
 `
 
 func TestValidateConfig(t *testing.T) {
@@ -75,6 +82,7 @@ func TestValidateConfig(t *testing.T) {
 		{"plugin.metric.1", "plugin.metrics.1"},
 		{"plugin.metrics.1.action.use", "plugin.metrics.1.action.user"},
 		{"plugin.metrics.2.action.xxx", ""},
+		{"plugin.metrics.aaa.action.max_check_attempts", ""},
 		{"plugins", "plugin"},
 		{"podfile", "pidfile"},
 	}
@@ -84,6 +92,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 
 	for i, v := range validResult {
+		fmt.Println(i, v)
 		if wantUnexpectedKey[i].Name != v.Name {
 			t.Errorf("expect Name: %v, actual Name: %v", wantUnexpectedKey[i].Name, v.Name)
 		}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"testing"
 )
@@ -92,7 +91,6 @@ func TestValidateConfig(t *testing.T) {
 	}
 
 	for i, v := range validResult {
-		fmt.Println(i, v)
 		if wantUnexpectedKey[i].Name != v.Name {
 			t.Errorf("expect Name: %v, actual Name: %v", wantUnexpectedKey[i].Name, v.Name)
 		}


### PR DESCRIPTION
refs: https://github.com/mackerelio/mackerel-agent/issues/829

```
# befor
[WARNING] plugin.metrics.aaa.action.max_check_attempts is unexpected key. did you mean plugin.metrics.aaa.action.max_check_attempts ?

# after
[WARNING] plugin.metrics.aaa.action.max_check_attempts is unexpected key.
```