### PR TITLE
improve purge stage of Debian package to remove id file and keep custom files

### DIFF
--- a/packaging/deb-systemd/debian/mackerel-agent.dirs
+++ b/packaging/deb-systemd/debian/mackerel-agent.dirs
@@ -1,2 +1,3 @@
 usr/bin
 etc/mackerel-agent
+var/lib/mackerel-agent

--- a/packaging/deb-systemd/debian/mackerel-agent.postrm
+++ b/packaging/deb-systemd/debian/mackerel-agent.postrm
@@ -2,7 +2,8 @@
 set -e
 
 if [ "$1" = "purge" ]; then
-  rm -rf /etc/mackerel-agent
+  rm -f /etc/mackerel-agent/mackerel-agent.conf
+  rm -f /var/lib/mackerel-agent/id
 fi
 rm -f /var/run/mackerel-agent.pid
 


### PR DESCRIPTION
For #836

Here are two fixes for Debian/Ubuntu package.

- remove `/var/lib/mackerel-agent/id` file at purge stage.
- remove `/etc/mackerel-agent/mackerel-agent.conf` explicitly instead of `rm -rf /etc/mackerel-agent`, and define `var/lib/mackerel-agent` as package own directory.

Second change is intended to keep user's file in `/etc/mackerel-agent` and `/var/lib/mackerel-agent`. The purge stage should remove the files what package created,  but should not remove user's own files.

[normal]
```
$ ls /etc/mackerel-agent /var/lib/mackerel-agent
/etc/mackerel-agent:
mackerel-agent.conf  mackerel-agent.conf.example

/var/lib/mackerel-agent:
id
$ sudo apt-get purge mackerel-agent
 ...
Removing mackerel-agent (0.73.3-1.systemd) ...
(Reading database ... 688477 files and directories currently installed.)
Purging configuration files for mackerel-agent (0.73.3-1.systemd) ...
$ ls /etc/mackerel-agent /var/lib/mackerel-agent
ls: cannot access '/etc/mackerel-agent': No such file or directory
ls: cannot access '/var/lib/mackerel-agent': No such file or directory
```

[with user's custom file]
```
$ ls /etc/mackerel-agent /var/lib/mackerel-agent
/etc/mackerel-agent:
mackerel-agent.conf  mackerel-agent.conf.example  my-note.txt

/var/lib/mackerel-agent:
id my-note.txt

$ sudo apt-get purge mackerel-agent
 ...
Purging configuration files for mackerel-agent (0.73.3-1.systemd) ...
dpkg: warning: while removing mackerel-agent, directory '/var/lib/mackerel-agent' not empty so not removed
dpkg: warning: while removing mackerel-agent, directory '/etc/mackerel-agent' not empty so not removed
$ ls /etc/mackerel-agent /var/lib/mackerel-agent
/etc/mackerel-agent:
my-note.txt

/var/lib/mackerel-agent:
my-note.txt
```