### PR TITLE
add feature to ignore disk labels by regexp in 'disk' of system metrics

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -94,7 +94,7 @@ jobs:
     name: Build (Windows)
     runs-on: windows-2019
     needs: test-windows
-    # if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         GOARCH: ["amd64", "386"]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -94,7 +94,7 @@ jobs:
     name: Build (Windows)
     runs-on: windows-2019
     needs: test-windows
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    # if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         GOARCH: ["amd64", "386"]

--- a/command/command_linux.go
+++ b/command/command_linux.go
@@ -28,7 +28,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 		&metricsLinux.CPUUsageGenerator{Interval: metricsInterval},
 		&metricsLinux.MemoryGenerator{},
 		&metrics.InterfaceGenerator{IgnoreRegexp: conf.Interfaces.Ignore.Regexp, Interval: metricsInterval},
-		&metricsLinux.DiskGenerator{Interval: metricsInterval, UseMountpoint: conf.Filesystems.UseMountpoint},
+		&metricsLinux.DiskGenerator{IgnoreRegexp: conf.Disks.Ignore.Regexp, Interval: metricsInterval, UseMountpoint: conf.Filesystems.UseMountpoint},
 		&metrics.FilesystemGenerator{IgnoreRegexp: conf.Filesystems.Ignore.Regexp, UseMountpoint: conf.Filesystems.UseMountpoint},
 	}
 

--- a/command/command_windows.go
+++ b/command/command_windows.go
@@ -42,7 +42,7 @@ func metricsGenerators(conf *config.Config) []metrics.Generator {
 	if g, err = metricsWindows.NewInterfaceGenerator(conf.Interfaces.Ignore.Regexp, metricsInterval); err == nil {
 		generators = append(generators, g)
 	}
-	if g, err = metricsWindows.NewDiskGenerator(metricsInterval); err == nil {
+	if g, err = metricsWindows.NewDiskGenerator(conf.Disks.Ignore.Regexp, metricsInterval); err == nil {
 		generators = append(generators, g)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,7 @@ type Config struct {
 	Diagnostic    bool          `toml:"diagnostic"`
 	DisplayName   string        `toml:"display_name"`
 	HostStatus    HostStatus    `toml:"host_status" conf:"parent"`
+	Disks         Disks         `toml:"disks" conf:"parent"`
 	Filesystems   Filesystems   `toml:"filesystems" conf:"parent"`
 	Interfaces    Interfaces    `toml:"interfaces"  conf:"parent"`
 	HTTPProxy     string        `toml:"http_proxy"`
@@ -368,6 +369,11 @@ var PostMetricsInterval = 1 * time.Minute
 type HostStatus struct {
 	OnStart string `toml:"on_start"`
 	OnStop  string `toml:"on_stop"`
+}
+
+// Disks configure disks related settings
+type Disks struct {
+	Ignore Regexpwrapper `toml:"ignore"`
 }
 
 // Filesystems configure filesystem related settings

--- a/metrics/linux/disk_test.go
+++ b/metrics/linux/disk_test.go
@@ -80,7 +80,7 @@ func TestParseDiskStats(t *testing.T) {
 		"xvda1": "_some_mount",
 		"xvda3": "_nonused_mount",
 	}
-	resultWithMapping, err := parseDiskStats(out, mapping)
+	resultWithMapping, err := g.parseDiskStats(out, mapping)
 	if err != nil {
 		t.Errorf("error should be nil but: %s", err)
 	}
@@ -115,12 +115,13 @@ func TestParseDiskStats(t *testing.T) {
 }
 
 func TestParseDiskStats_MoreFields(t *testing.T) {
+	g := &DiskGenerator{Interval: 1 * time.Second}
 	// There are 18 columns since Linux 4.18+.
 	out := []byte(`202       1 xvda1 750193 3037 28116978 368712 16600606 7233846 424712632 23987908 0 2355636 24345740 0 0 0 0
   7       0 loop0 15 0 0 0 0 0 0 0 0 0 0 0 0 0 0`)
 
 	var emptyMapping map[string]string
-	result, err := parseDiskStats(out, emptyMapping)
+	result, err := g.parseDiskStats(out, emptyMapping)
 	if err != nil {
 		t.Errorf("error should be nil but: %s", err)
 	}
@@ -155,12 +156,13 @@ func TestParseDiskStats_MoreFields(t *testing.T) {
 }
 
 func TestParseDiskStats_ShouldIgnoreIfAllFieldsAreZeroOrSpecificDeviceName(t *testing.T) {
+	g := &DiskGenerator{Interval: 1 * time.Second}
 	out := []byte(`253       0 dm-0 2 0 40 0 314 0 2512 2136 0 236 2136
 253       1 dm-1 964 0 57886 944 74855 0 644512 5421192 0 1580 5422136
   7       0 loop0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0`)
 
 	var emptyMapping map[string]string
-	result, err := parseDiskStats(out, emptyMapping)
+	result, err := g.parseDiskStats(out, emptyMapping)
 	if err != nil {
 		t.Errorf("error should be nil but: %s", err)
 	}

--- a/metrics/linux/disk_test.go
+++ b/metrics/linux/disk_test.go
@@ -36,13 +36,14 @@ func TestDiskGenerator(t *testing.T) {
 }
 
 func TestParseDiskStats(t *testing.T) {
+	g := &DiskGenerator{Interval: 1 * time.Second}
 	// insert empty line intentionally
 	out := []byte(`202       1 xvda1 750193 3037 28116978 368712 16600606 7233846 424712632 23987908 0 2355636 24345740
 
 202       2 xvda2 1641 9310 87552 1252 6365 3717 80664 24192 0 15040 25428`)
 
 	var emptyMapping map[string]string
-	result, err := parseDiskStats(out, emptyMapping)
+	result, err := g.parseDiskStats(out, emptyMapping)
 	if err != nil {
 		t.Errorf("error should be nil but: %s", err)
 	}

--- a/metrics/windows/disk_test.go
+++ b/metrics/windows/disk_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDiskGenerator(t *testing.T) {
-	g, err := NewDiskGenerator(1 * time.Second)
+	g, err := NewDiskGenerator(nil, 1 * time.Second)
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}

--- a/metrics/windows/disk_test.go
+++ b/metrics/windows/disk_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDiskGenerator(t *testing.T) {
-	g, err := NewDiskGenerator(nil, 1 * time.Second)
+	g, err := NewDiskGenerator(nil, 1*time.Second)
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}


### PR DESCRIPTION
This patch aims to allow the disk label to be ignored using Go regular expressions, as well as filesystems and interfaces.

example of mackerel-agent.conf:
```
[disks]
ignore = "loop.*"
```

(Unfortunately, the system metric graphs cannot be rebuilt, so users have to write above settings before running mackerel-agent to avoid extra disk labels appearing in the graph.)