### PR TITLE
fixed to log the key when metric parsing fails

### DIFF
--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -246,7 +246,7 @@ func (g *pluginGenerator) collectValues() (Values, error) {
 
 		value, err := strconv.ParseFloat(items[1], 64)
 		if err != nil {
-			pluginLogger.Warningf("Failed to parse values: %s", err)
+			pluginLogger.Warningf("Failed to parse values (key=%s): %s", key, err)
 			continue
 		}
 


### PR DESCRIPTION
When a custom plugin outputs an invalid metric, it is difficult to identify the corresponding location from the error message. 
I would like to improve this by outputting the metric name to the log so that the cause can be identified more easily.