### PR TITLE
remove comment that differ from current plugin implementation

### DIFF
--- a/mackerel-agent.sample.conf
+++ b/mackerel-agent.sample.conf
@@ -87,7 +87,6 @@
 
 # Plugin for Redis
 #   By default, the plugin accesses Redis on localhost.
-#   Currently AUTH password has not been supported yet.
 # [plugin.metrics.redis]
 # command = "mackerel-plugin-redis"
 


### PR DESCRIPTION
Currently, mackerel-plugin-redis supports password authentication. refs. https://github.com/mackerelio/mackerel-agent-plugins/pull/232