### PR TITLE
introduce monitorDelaySeconds to wait for user's specific services that take a long time to start up

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -212,7 +212,7 @@ func loop(app *App, termCh chan struct{}) error {
 	go enqueueLoop(ctx, app, postQueue)
 
 	postDelaySeconds := delayByHost(app.Host)
-	initialDelay := postDelaySeconds / 2
+	initialDelay := postDelaySeconds/2 + int(app.Config.MonitorDelaySeconds)
 	logger.Debugf("wait %d seconds before initial posting.", initialDelay)
 	select {
 	case <-termCh:

--- a/config/config.go
+++ b/config/config.go
@@ -93,23 +93,24 @@ func (c *CloudPlatform) UnmarshalText(text []byte) error {
 
 // Config represents mackerel-agent's configuration file.
 type Config struct {
-	Apibase       string
-	Apikey        string
-	Root          string
-	Pidfile       string
-	Conffile      string
-	Roles         []string
-	Verbose       bool
-	Silent        bool
-	Diagnostic    bool          `toml:"diagnostic"`
-	DisplayName   string        `toml:"display_name"`
-	HostStatus    HostStatus    `toml:"host_status" conf:"parent"`
-	Disks         Disks         `toml:"disks" conf:"parent"`
-	Filesystems   Filesystems   `toml:"filesystems" conf:"parent"`
-	Interfaces    Interfaces    `toml:"interfaces"  conf:"parent"`
-	HTTPProxy     string        `toml:"http_proxy"`
-	HTTPSProxy    string        `toml:"https_proxy"`
-	CloudPlatform CloudPlatform `toml:"cloud_platform"`
+	Apibase             string
+	Apikey              string
+	Root                string
+	Pidfile             string
+	Conffile            string
+	Roles               []string
+	Verbose             bool
+	Silent              bool
+	Diagnostic          bool          `toml:"diagnostic"`
+	DisplayName         string        `toml:"display_name"`
+	HostStatus          HostStatus    `toml:"host_status" conf:"parent"`
+	Disks               Disks         `toml:"disks" conf:"parent"`
+	Filesystems         Filesystems   `toml:"filesystems" conf:"parent"`
+	Interfaces          Interfaces    `toml:"interfaces"  conf:"parent"`
+	HTTPProxy           string        `toml:"http_proxy"`
+	HTTPSProxy          string        `toml:"https_proxy"`
+	CloudPlatform       CloudPlatform `toml:"cloud_platform"`
+	MonitorDelaySeconds uint16        `toml:"monitorDelaySeconds"`
 
 	// This Plugin field is used to decode the toml file. After reading the
 	// configuration from file, this field is set to nil.


### PR DESCRIPTION
The mackerel-agent may raise an alert for monitored services that take a long time to start up.
Here is proposed to introduce an option called `monitorDelaySeconds` for the wait seconds to start monitoring.

- An upper limit of around 3600 seconds would be appropriate, but since other settings of the agent did not seem to have a detailed limit, I just have set it to the uint16 range.
- The waiting time addition using host IDs is left as it is.
- The go routine for updating host meta information is executed without waiting.
- There will also be a wait time when restarting, but this is acceptable, I believe.
