### PR TITLE
command: drop `go test -short` mode

### DIFF
--- a/command/command_unix_test.go
+++ b/command/command_unix_test.go
@@ -6,7 +6,6 @@ package command
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/mackerelio/mackerel-agent/config"
 	mkr "github.com/mackerelio/mackerel-client-go"
@@ -15,14 +14,6 @@ import (
 var diceCommand = "go run ../_example/metrics-plugins/dice-with-meta.go"
 
 func TestRunOnce(t *testing.T) {
-	if testing.Short() {
-		origMetricsInterval := metricsInterval
-		metricsInterval = 1 * time.Second
-		defer func() {
-			metricsInterval = origMetricsInterval
-		}()
-	}
-
 	conf := &config.Config{
 		MetricPlugins: map[string]*config.MetricPlugin{
 			"metric1": {
@@ -42,14 +33,6 @@ func TestRunOnce(t *testing.T) {
 }
 
 func TestRunOncePayload(t *testing.T) {
-	if testing.Short() {
-		origMetricsInterval := metricsInterval
-		metricsInterval = 1 * time.Second
-		defer func() {
-			metricsInterval = origMetricsInterval
-		}()
-	}
-
 	conf := &config.Config{
 		MetricPlugins: map[string]*config.MetricPlugin{
 			"metric1": {


### PR DESCRIPTION
For now, this flag did not reduce testing times :relaxed: 

### before

```console
$ go test -v -run=Once -short
=== RUN   TestRunOnce
--- PASS: TestRunOnce (9.08s)
=== RUN   TestRunOncePayload
--- PASS: TestRunOncePayload (9.08s)
PASS
ok  	github.com/mackerelio/mackerel-agent/command	18.166s

$ go test -v -run=Once
=== RUN   TestRunOnce
--- PASS: TestRunOnce (9.07s)
=== RUN   TestRunOncePayload
--- PASS: TestRunOncePayload (9.07s)
PASS
ok  	github.com/mackerelio/mackerel-agent/command	18.147s
```

### after

```console
$ go test -v -run=Once
=== RUN   TestRunOnce
--- PASS: TestRunOnce (9.08s)
=== RUN   TestRunOncePayload
--- PASS: TestRunOncePayload (9.08s)
PASS
ok  	github.com/mackerelio/mackerel-agent/command	18.161s
```