### PR TITLE
list wix packages

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,7 +62,7 @@ jobs:
     name: Build (Windows)
     runs-on: windows-2022
     needs: test
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         GOARCH: ["amd64", "386"]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,7 +62,7 @@ jobs:
     name: Build (Windows)
     runs-on: windows-2022
     needs: test
-    #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         GOARCH: ["amd64", "386"]

--- a/wix/pluginlist.sh
+++ b/wix/pluginlist.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 
+set -eu
+
 d=$(dirname "$0")
-go list -f '{{range .Imports}}{{println .}}{{end}}' "$d/plugins_windows.go"
+
+# `main` package can't import, but it only manages versions in go.mod, so I use the `-e` option to ignore errors and list them.
+go list -e -f '{{range .Imports}}{{println .}}{{end}}' "$d/plugins_windows.go"


### PR DESCRIPTION
https://github.com/mackerelio/mackerel-agent/actions/runs/8904749775/job/24454574171
>Error: plugins_windows.go:7:2: import "github.com/mackerelio/go-check-plugins/check-disk" is a program, not an importable package

I checked that the `build-windows` jobs are succeeded.
- https://github.com/mackerelio/mackerel-agent/actions/runs/8906052482/job/24457719885?pr=1000
- https://github.com/mackerelio/mackerel-agent/actions/runs/8906052482/job/24457720029?pr=1000

.

- cf. https://github.com/golang/go/issues/59186