### PR TITLE
Write out error message when plugin seems have a bug

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/mackerelio/mackerel-agent/checks"
@@ -98,7 +99,11 @@ func (agent *Agent) CollectGraphDefsOfPlugins() []*mkr.GraphDefsParam {
 
 	for _, g := range agent.PluginGenerators {
 		p, err := g.PrepareGraphDefs()
-		if err != nil {
+
+		var faultError *metrics.PluginFaultError
+		if errors.As(err, &faultError) {
+			logger.Errorf("Failed to fetch meta information from plugin %v; seems that the plugin has a bug: %v", g, err)
+		} else if err != nil {
 			logger.Debugf("Failed to fetch meta information from plugin %v (non critical); seems that this plugin does not have meta information: %v", g, err)
 		}
 		if p != nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -42,3 +42,18 @@ type PluginGenerator interface {
 	PrepareGraphDefs() ([]*mkr.GraphDefsParam, error)
 	CustomIdentifier() *string
 }
+
+// PluginFaultError may be returned by [PluginGenerator.PrepareGraphDefs].
+// This error indicates a bug in a plugin and should be logged for a user.
+// Note that [PluginGenerator.PrepareGraphDefs] can also return other error types.
+type PluginFaultError struct {
+	Err error
+}
+
+func (e *PluginFaultError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *PluginFaultError) Unwrap() error {
+	return e.Err
+}

--- a/metrics/plugin.go
+++ b/metrics/plugin.go
@@ -125,7 +125,7 @@ func (g *pluginGenerator) loadPluginMeta() error {
 	pluginMetaEnv := pluginConfigurationEnvName + "=1"
 	stdout, stderr, exitCode, err := g.Config.Command.RunWithEnv([]string{pluginMetaEnv})
 	if err != nil {
-		return fmt.Errorf("running %s failed: %s, exit=%d stderr=%q", g.Config.Command.CommandString(), err, exitCode, stderr)
+		return &PluginFaultError{fmt.Errorf("running %s failed: %s, exit=%d stderr=%q", g.Config.Command.CommandString(), err, exitCode, stderr)}
 	}
 
 	outBuffer := bufio.NewReader(strings.NewReader(stdout))
@@ -170,7 +170,7 @@ func (g *pluginGenerator) loadPluginMeta() error {
 	err = json.NewDecoder(outBuffer).Decode(conf)
 
 	if err != nil {
-		return fmt.Errorf("while reading plugin configuration: %s", err)
+		return &PluginFaultError{fmt.Errorf("while reading plugin configuration: %s", err)}
 	}
 
 	g.Meta = conf


### PR DESCRIPTION
Mackerel-agent does not write out any error log when fails to parse a broken JSON as a plugin's graph definition.
It makes hard to find out a bug of the plugin.

This PR makes mackerel-agent write out error log when plugin seems have a bug.

## Implements
I defined PluginFaultError.
```
// PluginFaultError may be returned by [PluginGenerator.PrepareGraphDefs].
// This error indicates a bug in a plugin and should be logged for a user.
// Note that [PluginGenerator.PrepareGraphDefs] can also return other error types.
type PluginFaultError struct {
	Err error
}
```

A method PrepareGraphDefs fetches a graph definition from a plugin. By this PR, PrepareGraphDefs will return PluginFaultError, when it faces following two situation,

- Fails to exec plugin
- Fails to parse JSON as a graph definition.

Mackerel-agent will write out an error log when it catches PluginFaultError.

## Behaviour

When plugin provides broken JSON as a graph definition, mackerel-agent write out ERROR log.
```
2024/11/18 20:58:40 agent.go:105: ERROR <agent> Failed to fetch meta information from plugin &{0x14000140b60 <nil>}; seems that the plugin may have a bug: while reading plugin configuration: invalid character '}' looking for beginning of object key string
```

When plugin has no graph definition (It should not be a bug), no ERROR log. 

DEBUG log is written out if verbose option is on. This behavior is the same as before.
```
2024/11/18 20:56:38 agent.go:102: DEBUG <agent> Failed to fetch meta information from plugin &{0x140001c9b90 <nil>} (non critical); seems that this plugin does not have meta information: bad format of first line: "x-custom-sh.testmetric2\t16452\t1731930998\n"
```