### PR TITLE
check status code in go.yaml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Build mackerel-agent-plugins
         run: |
+          set -x
           cd wix
           plugins=( $(./pluginlist.sh) ) || exit 1
           for p in "${plugins[@]}"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -110,13 +110,13 @@ jobs:
 
       - name: Build mackerel-agent-plugins
         run: |
-          set -x
           cd wix
           plugins=( $(./pluginlist.sh) ) || exit 1
           for p in "${plugins[@]}"
           do
             name=$(basename "$p")
             go build -o "../build/$name.exe" "$p"
+            echo go build -o "../build/$name.exe" "$p"
           done
         shell: msys2 {0}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -111,7 +111,8 @@ jobs:
       - name: Build mackerel-agent-plugins
         run: |
           cd wix
-          for p in $(./pluginlist.sh)
+          plugins=( $(./pluginlist.sh) ) || exit 1
+          for p in "${plugins[@]}"
           do
             name=$(basename "$p")
             go build -o "../build/$name.exe" "$p"


### PR DESCRIPTION
The action https://github.com/mackerelio/mackerel-agent/actions/runs/12025920937/job/33524055923#step:7:15 has failed,  but GitHub Actions did not detect the failure and incorrectly marked it as passing.

The error occurred in the following code. `./pluginlist.sh` failed.
https://github.com/mackerelio/mackerel-agent/blob/2b84d849d0d7ac374284cdff6ca17fa663ebd4c1/.github/workflows/go.yml#L114-L118

In Bash, the exit status of a command substitution in the `for` statement is ignored even when `set -e` is enabled. Thus, I guess, Github Actions have ignored the error.

In this PR, I separate the execution of `./pluginlist.sh` from the `for` statement.