### PR TITLE
Add disable_http_keep_alive option

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -693,8 +693,8 @@ func buildUA(ver, rev string) string {
 }
 
 // NewMackerelClient returns Mackerel API client for mackerel-agent
-func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool, disableKeepAlive bool) (*mackerel.API, error) {
-	api, err := mackerel.NewAPI(apibase, apikey, verbose, disableKeepAlive)
+func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool, disableHttpKeepAlive bool) (*mackerel.API, error) {
+	api, err := mackerel.NewAPI(apibase, apikey, verbose, disableHttpKeepAlive)
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +708,7 @@ func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool, disableKe
 // Prepare sets up API and registers the host data to the Mackerel server.
 // Use returned values to call Run().
 func Prepare(conf *config.Config, ameta *AgentMeta) (*App, error) {
-	api, err := NewMackerelClient(conf.Apibase, conf.Apikey, ameta.Version, ameta.Revision, conf.Verbose, conf.DisableKeepAlive)
+	api, err := NewMackerelClient(conf.Apibase, conf.Apikey, ameta.Version, ameta.Revision, conf.Verbose, conf.DisableHttpKeepAlive)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare an api: %s", err.Error())
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -693,8 +693,8 @@ func buildUA(ver, rev string) string {
 }
 
 // NewMackerelClient returns Mackerel API client for mackerel-agent
-func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool, keepAlive bool) (*mackerel.API, error) {
-	api, err := mackerel.NewAPI(apibase, apikey, verbose, keepAlive)
+func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool, disableKeepAlive bool) (*mackerel.API, error) {
+	api, err := mackerel.NewAPI(apibase, apikey, verbose, disableKeepAlive)
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +708,7 @@ func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool, keepAlive
 // Prepare sets up API and registers the host data to the Mackerel server.
 // Use returned values to call Run().
 func Prepare(conf *config.Config, ameta *AgentMeta) (*App, error) {
-	api, err := NewMackerelClient(conf.Apibase, conf.Apikey, ameta.Version, ameta.Revision, conf.Verbose, conf.KeepAlive)
+	api, err := NewMackerelClient(conf.Apibase, conf.Apikey, ameta.Version, ameta.Revision, conf.Verbose, conf.DisableKeepAlive)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare an api: %s", err.Error())
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -693,8 +693,8 @@ func buildUA(ver, rev string) string {
 }
 
 // NewMackerelClient returns Mackerel API client for mackerel-agent
-func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool) (*mackerel.API, error) {
-	api, err := mackerel.NewAPI(apibase, apikey, verbose)
+func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool, keepAlive bool) (*mackerel.API, error) {
+	api, err := mackerel.NewAPI(apibase, apikey, verbose, keepAlive)
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +708,7 @@ func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool) (*mackere
 // Prepare sets up API and registers the host data to the Mackerel server.
 // Use returned values to call Run().
 func Prepare(conf *config.Config, ameta *AgentMeta) (*App, error) {
-	api, err := NewMackerelClient(conf.Apibase, conf.Apikey, ameta.Version, ameta.Revision, conf.Verbose)
+	api, err := NewMackerelClient(conf.Apibase, conf.Apikey, ameta.Version, ameta.Revision, conf.Verbose, conf.KeepAlive)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare an api: %s", err.Error())
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -693,8 +693,8 @@ func buildUA(ver, rev string) string {
 }
 
 // NewMackerelClient returns Mackerel API client for mackerel-agent
-func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool, disableHttpKeepAlive bool) (*mackerel.API, error) {
-	api, err := mackerel.NewAPI(apibase, apikey, verbose, disableHttpKeepAlive)
+func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool, disableHTTPKeepAlive bool) (*mackerel.API, error) {
+	api, err := mackerel.NewAPI(apibase, apikey, verbose, disableHTTPKeepAlive)
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +708,7 @@ func NewMackerelClient(apibase, apikey, ver, rev string, verbose bool, disableHt
 // Prepare sets up API and registers the host data to the Mackerel server.
 // Use returned values to call Run().
 func Prepare(conf *config.Config, ameta *AgentMeta) (*App, error) {
-	api, err := NewMackerelClient(conf.Apibase, conf.Apikey, ameta.Version, ameta.Revision, conf.Verbose, conf.DisableHttpKeepAlive)
+	api, err := NewMackerelClient(conf.Apibase, conf.Apikey, ameta.Version, ameta.Revision, conf.Verbose, conf.DisableHTTPKeepAlive)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare an api: %s", err.Error())
 	}

--- a/command/command_api_test.go
+++ b/command/command_api_test.go
@@ -33,7 +33,7 @@ func TestAPIRequestHeader(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	api, err := NewMackerelClient(ts.URL, apiKey, ver, rev, false)
+	api, err := NewMackerelClient(ts.URL, apiKey, ver, rev, false, true)
 	if err != nil {
 		t.Errorf("something went wrong while creating new mackerel client: %+v", err)
 	}

--- a/command/command_api_test.go
+++ b/command/command_api_test.go
@@ -33,7 +33,7 @@ func TestAPIRequestHeader(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	api, err := NewMackerelClient(ts.URL, apiKey, ver, rev, false, true)
+	api, err := NewMackerelClient(ts.URL, apiKey, ver, rev, false, false)
 	if err != nil {
 		t.Errorf("something went wrong while creating new mackerel client: %+v", err)
 	}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -346,7 +346,7 @@ func TestLoop(t *testing.T) {
 		},
 	}
 
-	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
+	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -442,7 +442,7 @@ func TestLoop_NetworkError(t *testing.T) {
 		},
 	}
 
-	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
+	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -524,7 +524,7 @@ func TestLoop_NetworkErrorWithRecovery(t *testing.T) {
 		},
 	}
 
-	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
+	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -585,7 +585,7 @@ func TestReportCheckMonitors(t *testing.T) {
 			return tc.Status, jsonObject{}
 		}
 
-		api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
+		api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -643,7 +643,7 @@ func TestReportCheckMonitors_NetworkError(t *testing.T) {
 		return http.StatusSeeOther, jsonObject{}
 	}
 
-	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
+	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -708,7 +708,7 @@ func TestReportCheckMonitors_NetworkErrorWithRecovery(t *testing.T) {
 		return http.StatusOK, jsonObject{}
 	}
 
-	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
+	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -346,7 +346,7 @@ func TestLoop(t *testing.T) {
 		},
 	}
 
-	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true)
+	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -442,7 +442,7 @@ func TestLoop_NetworkError(t *testing.T) {
 		},
 	}
 
-	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true)
+	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -524,7 +524,7 @@ func TestLoop_NetworkErrorWithRecovery(t *testing.T) {
 		},
 	}
 
-	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true)
+	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -585,7 +585,7 @@ func TestReportCheckMonitors(t *testing.T) {
 			return tc.Status, jsonObject{}
 		}
 
-		api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true)
+		api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -643,7 +643,7 @@ func TestReportCheckMonitors_NetworkError(t *testing.T) {
 		return http.StatusSeeOther, jsonObject{}
 	}
 
-	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true)
+	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -708,7 +708,7 @@ func TestReportCheckMonitors_NetworkErrorWithRecovery(t *testing.T) {
 		return http.StatusOK, jsonObject{}
 	}
 
-	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true)
+	api, err := mackerel.NewAPI(conf.Apibase, conf.Apikey, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/commands.go
+++ b/commands.go
@@ -156,7 +156,7 @@ func doRetire(fs *flag.FlagSet, argv []string) error {
 		return fmt.Errorf("hostID file is not found or empty")
 	}
 
-	api, err := command.NewMackerelClient(conf.Apibase, conf.Apikey, version, gitcommit, conf.Verbose, conf.DisableHttpKeepAlive)
+	api, err := command.NewMackerelClient(conf.Apibase, conf.Apikey, version, gitcommit, conf.Verbose, conf.DisableHTTPKeepAlive)
 	if err != nil {
 		return fmt.Errorf("faild to create api client: %s", err)
 	}

--- a/commands.go
+++ b/commands.go
@@ -156,7 +156,7 @@ func doRetire(fs *flag.FlagSet, argv []string) error {
 		return fmt.Errorf("hostID file is not found or empty")
 	}
 
-	api, err := command.NewMackerelClient(conf.Apibase, conf.Apikey, version, gitcommit, conf.Verbose, conf.KeepAlive)
+	api, err := command.NewMackerelClient(conf.Apibase, conf.Apikey, version, gitcommit, conf.Verbose, conf.DisableKeepAlive)
 	if err != nil {
 		return fmt.Errorf("faild to create api client: %s", err)
 	}

--- a/commands.go
+++ b/commands.go
@@ -156,7 +156,7 @@ func doRetire(fs *flag.FlagSet, argv []string) error {
 		return fmt.Errorf("hostID file is not found or empty")
 	}
 
-	api, err := command.NewMackerelClient(conf.Apibase, conf.Apikey, version, gitcommit, conf.Verbose, conf.DisableKeepAlive)
+	api, err := command.NewMackerelClient(conf.Apibase, conf.Apikey, version, gitcommit, conf.Verbose, conf.DisableHttpKeepAlive)
 	if err != nil {
 		return fmt.Errorf("faild to create api client: %s", err)
 	}

--- a/commands.go
+++ b/commands.go
@@ -156,7 +156,7 @@ func doRetire(fs *flag.FlagSet, argv []string) error {
 		return fmt.Errorf("hostID file is not found or empty")
 	}
 
-	api, err := command.NewMackerelClient(conf.Apibase, conf.Apikey, version, gitcommit, conf.Verbose)
+	api, err := command.NewMackerelClient(conf.Apibase, conf.Apikey, version, gitcommit, conf.Verbose, conf.KeepAlive)
 	if err != nil {
 		return fmt.Errorf("faild to create api client: %s", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,7 @@ type Config struct {
 	Verbose       bool
 	Silent        bool
 	Diagnostic    bool          `toml:"diagnostic"`
+	KeepAlive     bool          `toml:"keep_alive"`
 	DisplayName   string        `toml:"display_name"`
 	HostStatus    HostStatus    `toml:"host_status" conf:"parent"`
 	Disks         Disks         `toml:"disks" conf:"parent"`
@@ -446,6 +447,9 @@ func LoadConfig(conffile string) (*Config, error) {
 	}
 	if !config.Diagnostic {
 		config.Diagnostic = DefaultConfig.Diagnostic
+	}
+	if !config.KeepAlive {
+		config.KeepAlive = true
 	}
 
 	return config, err

--- a/config/config.go
+++ b/config/config.go
@@ -93,24 +93,24 @@ func (c *CloudPlatform) UnmarshalText(text []byte) error {
 
 // Config represents mackerel-agent's configuration file.
 type Config struct {
-	Apibase       string
-	Apikey        string
-	Root          string
-	Pidfile       string
-	Conffile      string
-	Roles         []string
-	Verbose       bool
-	Silent        bool
-	Diagnostic    bool          `toml:"diagnostic"`
-	KeepAlive     bool          `toml:"keep_alive"`
-	DisplayName   string        `toml:"display_name"`
-	HostStatus    HostStatus    `toml:"host_status" conf:"parent"`
-	Disks         Disks         `toml:"disks" conf:"parent"`
-	Filesystems   Filesystems   `toml:"filesystems" conf:"parent"`
-	Interfaces    Interfaces    `toml:"interfaces"  conf:"parent"`
-	HTTPProxy     string        `toml:"http_proxy"`
-	HTTPSProxy    string        `toml:"https_proxy"`
-	CloudPlatform CloudPlatform `toml:"cloud_platform"`
+	Apibase          string
+	Apikey           string
+	Root             string
+	Pidfile          string
+	Conffile         string
+	Roles            []string
+	Verbose          bool
+	Silent           bool
+	Diagnostic       bool          `toml:"diagnostic"`
+	DisableKeepAlive bool          `toml:"disable_keep_alive"`
+	DisplayName      string        `toml:"display_name"`
+	HostStatus       HostStatus    `toml:"host_status" conf:"parent"`
+	Disks            Disks         `toml:"disks" conf:"parent"`
+	Filesystems      Filesystems   `toml:"filesystems" conf:"parent"`
+	Interfaces       Interfaces    `toml:"interfaces"  conf:"parent"`
+	HTTPProxy        string        `toml:"http_proxy"`
+	HTTPSProxy       string        `toml:"https_proxy"`
+	CloudPlatform    CloudPlatform `toml:"cloud_platform"`
 
 	// This Plugin field is used to decode the toml file. After reading the
 	// configuration from file, this field is set to nil.
@@ -448,8 +448,8 @@ func LoadConfig(conffile string) (*Config, error) {
 	if !config.Diagnostic {
 		config.Diagnostic = DefaultConfig.Diagnostic
 	}
-	if !config.KeepAlive {
-		config.KeepAlive = true
+	if !config.DisableKeepAlive {
+		config.DisableKeepAlive = DefaultConfig.DisableKeepAlive
 	}
 
 	return config, err

--- a/config/config.go
+++ b/config/config.go
@@ -102,7 +102,7 @@ type Config struct {
 	Verbose              bool
 	Silent               bool
 	Diagnostic           bool          `toml:"diagnostic"`
-	DisableHttpKeepAlive bool          `toml:"disable_http_keep_alive"`
+	DisableHTTPKeepAlive bool          `toml:"disable_http_keep_alive"`
 	DisplayName          string        `toml:"display_name"`
 	HostStatus           HostStatus    `toml:"host_status" conf:"parent"`
 	Disks                Disks         `toml:"disks" conf:"parent"`
@@ -448,8 +448,8 @@ func LoadConfig(conffile string) (*Config, error) {
 	if !config.Diagnostic {
 		config.Diagnostic = DefaultConfig.Diagnostic
 	}
-	if !config.DisableHttpKeepAlive {
-		config.DisableHttpKeepAlive = DefaultConfig.DisableHttpKeepAlive
+	if !config.DisableHTTPKeepAlive {
+		config.DisableHTTPKeepAlive = DefaultConfig.DisableHTTPKeepAlive
 	}
 
 	return config, err

--- a/config/config.go
+++ b/config/config.go
@@ -448,10 +448,6 @@ func LoadConfig(conffile string) (*Config, error) {
 	if !config.Diagnostic {
 		config.Diagnostic = DefaultConfig.Diagnostic
 	}
-	if !config.DisableHTTPKeepAlive {
-		config.DisableHTTPKeepAlive = DefaultConfig.DisableHTTPKeepAlive
-	}
-
 	return config, err
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -93,24 +93,24 @@ func (c *CloudPlatform) UnmarshalText(text []byte) error {
 
 // Config represents mackerel-agent's configuration file.
 type Config struct {
-	Apibase          string
-	Apikey           string
-	Root             string
-	Pidfile          string
-	Conffile         string
-	Roles            []string
-	Verbose          bool
-	Silent           bool
-	Diagnostic       bool          `toml:"diagnostic"`
-	DisableKeepAlive bool          `toml:"disable_keep_alive"`
-	DisplayName      string        `toml:"display_name"`
-	HostStatus       HostStatus    `toml:"host_status" conf:"parent"`
-	Disks            Disks         `toml:"disks" conf:"parent"`
-	Filesystems      Filesystems   `toml:"filesystems" conf:"parent"`
-	Interfaces       Interfaces    `toml:"interfaces"  conf:"parent"`
-	HTTPProxy        string        `toml:"http_proxy"`
-	HTTPSProxy       string        `toml:"https_proxy"`
-	CloudPlatform    CloudPlatform `toml:"cloud_platform"`
+	Apibase              string
+	Apikey               string
+	Root                 string
+	Pidfile              string
+	Conffile             string
+	Roles                []string
+	Verbose              bool
+	Silent               bool
+	Diagnostic           bool          `toml:"diagnostic"`
+	DisableHttpKeepAlive bool          `toml:"disable_http_keep_alive"`
+	DisplayName          string        `toml:"display_name"`
+	HostStatus           HostStatus    `toml:"host_status" conf:"parent"`
+	Disks                Disks         `toml:"disks" conf:"parent"`
+	Filesystems          Filesystems   `toml:"filesystems" conf:"parent"`
+	Interfaces           Interfaces    `toml:"interfaces"  conf:"parent"`
+	HTTPProxy            string        `toml:"http_proxy"`
+	HTTPSProxy           string        `toml:"https_proxy"`
+	CloudPlatform        CloudPlatform `toml:"cloud_platform"`
 
 	// This Plugin field is used to decode the toml file. After reading the
 	// configuration from file, this field is set to nil.
@@ -448,8 +448,8 @@ func LoadConfig(conffile string) (*Config, error) {
 	if !config.Diagnostic {
 		config.Diagnostic = DefaultConfig.Diagnostic
 	}
-	if !config.DisableKeepAlive {
-		config.DisableKeepAlive = DefaultConfig.DisableKeepAlive
+	if !config.DisableHttpKeepAlive {
+		config.DisableHttpKeepAlive = DefaultConfig.DisableHttpKeepAlive
 	}
 
 	return config, err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,8 +100,8 @@ func TestLoadConfig(t *testing.T) {
 		t.Error("should be false (default value should be used)")
 	}
 
-	if config.KeepAlive != true {
-		t.Error("should be true (default value should be used)")
+	if config.DisableKeepAlive != false {
+		t.Error("should be false (default value should be used)")
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,7 +100,7 @@ func TestLoadConfig(t *testing.T) {
 		t.Error("should be false (default value should be used)")
 	}
 
-	if config.DisableHttpKeepAlive != false {
+	if config.DisableHTTPKeepAlive != false {
 		t.Error("should be false (default value should be used)")
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -99,6 +99,10 @@ func TestLoadConfig(t *testing.T) {
 	if config.Filesystems.UseMountpoint != false {
 		t.Error("should be false (default value should be used)")
 	}
+
+	if config.KeepAlive != true {
+		t.Error("should be true (default value should be used)")
+	}
 }
 
 var sampleConfigWithHostStatus = `

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,7 +100,7 @@ func TestLoadConfig(t *testing.T) {
 		t.Error("should be false (default value should be used)")
 	}
 
-	if config.DisableKeepAlive != false {
+	if config.DisableHttpKeepAlive != false {
 		t.Error("should be false (default value should be used)")
 	}
 }

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -57,14 +57,14 @@ func infoError(msg string) *InfoError {
 }
 
 // NewAPI creates a new instance of API.
-func NewAPI(rawurl string, apiKey string, verbose bool, disableHttpKeepAlive bool) (*API, error) {
+func NewAPI(rawurl string, apiKey string, verbose bool, disableHTTPKeepAlive bool) (*API, error) {
 	c, err := mkr.NewClientWithOptions(apiKey, rawurl, verbose)
 	if err != nil {
 		return nil, err
 	}
 	c.PrioritizedLogger = logger
 	t := http.DefaultTransport.(*http.Transport).Clone()
-	t.DisableKeepAlives = disableHttpKeepAlive
+	t.DisableKeepAlives = disableHTTPKeepAlive
 	c.HTTPClient.Transport = t
 
 	return &API{Client: c}, nil

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -64,7 +64,6 @@ func NewAPI(rawurl string, apiKey string, verbose bool, disableKeepAlive bool) (
 	}
 	c.PrioritizedLogger = logger
 	t := http.DefaultTransport.(*http.Transport).Clone()
-	print(disableKeepAlive)
 	t.DisableKeepAlives = disableKeepAlive
 	c.HTTPClient.Transport = t
 

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -57,14 +57,14 @@ func infoError(msg string) *InfoError {
 }
 
 // NewAPI creates a new instance of API.
-func NewAPI(rawurl string, apiKey string, verbose bool, disableKeepAlive bool) (*API, error) {
+func NewAPI(rawurl string, apiKey string, verbose bool, disableHttpKeepAlive bool) (*API, error) {
 	c, err := mkr.NewClientWithOptions(apiKey, rawurl, verbose)
 	if err != nil {
 		return nil, err
 	}
 	c.PrioritizedLogger = logger
 	t := http.DefaultTransport.(*http.Transport).Clone()
-	t.DisableKeepAlives = disableKeepAlive
+	t.DisableKeepAlives = disableHttpKeepAlive
 	c.HTTPClient.Transport = t
 
 	return &API{Client: c}, nil

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -57,15 +57,17 @@ func infoError(msg string) *InfoError {
 }
 
 // NewAPI creates a new instance of API.
-func NewAPI(rawurl string, apiKey string, verbose bool, keepAlive bool) (*API, error) {
+func NewAPI(rawurl string, apiKey string, verbose bool, disableKeepAlive bool) (*API, error) {
 	c, err := mkr.NewClientWithOptions(apiKey, rawurl, verbose)
 	if err != nil {
 		return nil, err
 	}
 	c.PrioritizedLogger = logger
-	c.HTTPClient.Transport = &http.Transport{
-		DisableKeepAlives: true,
-	}
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	print(disableKeepAlive)
+	t.DisableKeepAlives = disableKeepAlive
+	c.HTTPClient.Transport = t
+
 	return &API{Client: c}, nil
 }
 

--- a/mackerel/api.go
+++ b/mackerel/api.go
@@ -3,6 +3,7 @@ package mackerel
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/mackerelio/golib/logging"
@@ -56,12 +57,15 @@ func infoError(msg string) *InfoError {
 }
 
 // NewAPI creates a new instance of API.
-func NewAPI(rawurl string, apiKey string, verbose bool) (*API, error) {
+func NewAPI(rawurl string, apiKey string, verbose bool, keepAlive bool) (*API, error) {
 	c, err := mkr.NewClientWithOptions(apiKey, rawurl, verbose)
 	if err != nil {
 		return nil, err
 	}
 	c.PrioritizedLogger = logger
+	c.HTTPClient.Transport = &http.Transport{
+		DisableKeepAlives: true,
+	}
 	return &API{Client: c}, nil
 }
 

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -18,7 +18,7 @@ func TestNewAPI(t *testing.T) {
 		"http://example.com",
 		"dummy-key",
 		true,
-		true,
+		false,
 	)
 
 	if err != nil {
@@ -73,7 +73,7 @@ func TestFindHostByCustomIdentifier(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	api, _ := NewAPI(ts.URL, "dummy-key", false, true)
+	api, _ := NewAPI(ts.URL, "dummy-key", false, false)
 
 	var tests = []struct {
 		customIdentifier string

--- a/mackerel/api_test.go
+++ b/mackerel/api_test.go
@@ -18,6 +18,7 @@ func TestNewAPI(t *testing.T) {
 		"http://example.com",
 		"dummy-key",
 		true,
+		true,
 	)
 
 	if err != nil {
@@ -72,7 +73,7 @@ func TestFindHostByCustomIdentifier(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	api, _ := NewAPI(ts.URL, "dummy-key", false)
+	api, _ := NewAPI(ts.URL, "dummy-key", false, true)
 
 	var tests = []struct {
 		customIdentifier string

--- a/mackerel/check_test.go
+++ b/mackerel/check_test.go
@@ -61,7 +61,7 @@ func TestReportCheckMonitors(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	api, _ := NewAPI(ts.URL, "dummy-key", false, true)
+	api, _ := NewAPI(ts.URL, "dummy-key", false, false)
 
 	err := api.ReportCheckMonitors("9rxGOHfVF8F", []*checks.Report{
 		{
@@ -153,7 +153,7 @@ func TestReportCheckMonitorsCompat(t *testing.T) {
 			maxAttemts: 0,
 		},
 	}
-	api, _ := NewAPI(ts.URL, "dummy-key", false, true)
+	api, _ := NewAPI(ts.URL, "dummy-key", false, false)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			api.ReportCheckMonitors("xxx", []*checks.Report{

--- a/mackerel/check_test.go
+++ b/mackerel/check_test.go
@@ -61,7 +61,7 @@ func TestReportCheckMonitors(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	api, _ := NewAPI(ts.URL, "dummy-key", false)
+	api, _ := NewAPI(ts.URL, "dummy-key", false, true)
 
 	err := api.ReportCheckMonitors("9rxGOHfVF8F", []*checks.Report{
 		{
@@ -153,7 +153,7 @@ func TestReportCheckMonitorsCompat(t *testing.T) {
 			maxAttemts: 0,
 		},
 	}
-	api, _ := NewAPI(ts.URL, "dummy-key", false)
+	api, _ := NewAPI(ts.URL, "dummy-key", false, true)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			api.ReportCheckMonitors("xxx", []*checks.Report{


### PR DESCRIPTION
- Added `disable_http_keep_alive` option
- The default value for `disable_http_keep_alive` is false
- When `disable_http_keep_alive` is true, mkr requests mackerel without KeepAlive