### PR TITLE
Pined build actions runner version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
 
   build-linux:
     name: Build (Linux)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     env:


### PR DESCRIPTION
Since Ubuntu 24.04(ubuntu-latest) can't package for debian because of the missing build-essential, I've pined the workflow runner to Ubuntu 22.04.

Failed job: https://github.com/mackerelio/mackerel-agent/actions/runs/12498957543/job/34873888222