### PR TITLE
Set the default path by "mkr plugin install" to the PATH environment.

### DIFF
--- a/init_unix.go
+++ b/init_unix.go
@@ -5,11 +5,13 @@ package main
 
 import "os"
 
+const MkrPluginInstallPath = "/opt/mackerel-agent/plugins/bin"
+
 func init() {
 	if path := os.Getenv("PATH"); path != "" {
-		os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin:"+path)
+		os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin:"+path+":"+MkrPluginInstallPath)
 	} else {
-		os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin")
+		os.Setenv("PATH", "/sbin:/usr/sbin:/bin:/usr/bin:"+MkrPluginInstallPath)
 	}
 	// prevent changing outputs of some command, e.g. ifconfig.
 	os.Setenv("LANG", "C")


### PR DESCRIPTION
Hi!

`mkr plugin install` installs plugins into `/opt/mackerel-agent/plugins/bin` by default. However, the mackerel agent cannot find the plugins from this path.

This PR added the path into the `PATH` environment variable on init.

On Windows, mkr installs plugins into mkr's executable dir + "plugins". https://github.com/mackerelio/mkr/blob/57f3f0c589f69f1466a25aafea079efab0fde1d9/plugin/install.go#L27 So, the mackerel agent cannot know it.