### PR TITLE
Updated runner to use latest Windows 2025 image

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       # Please do not specify `windows-latest`
       # Build process is complex then need to check operation.
-      os-versions: '["ubuntu-latest", "windows-2022", "windows-2025"]' # When windows-2025 become stable, remove windows-2022
+      os-versions: '["ubuntu-latest", "windows-2025"]'
 
   build-linux:
     name: Build (Linux)
@@ -60,7 +60,7 @@ jobs:
   # Therefore we installs msys2 on each 32bit and 64bit platforms.
   build-windows:
     name: Build (Windows)
-    runs-on: windows-2022
+    runs-on: windows-2025
     needs: test
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     strategy:
@@ -137,7 +137,7 @@ jobs:
 
   windows-installer:
     name: Make Installer (Windows)
-    runs-on: windows-2022
+    runs-on: windows-2025
     needs: build-windows
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     strategy:


### PR DESCRIPTION
I'll check if the installer built on Windows Server 2025 works after merging into main.